### PR TITLE
Sync license text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -571,10 +571,8 @@ License
 
 Copyright (c) 2017-2050 Curtis G. Northcutt
 
-cleanlab is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+cleanlab is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
 cleanlab is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
 
-See `GNU General Public LICENSE <https://github.com/cleanlab/cleanlab/blob/master/LICENSE>`__ for details.
-
-THIS LICENSE APPLIES TO THIS VERSION AND ALL PREVIOUS VERSIONS OF cleanlab.
+See `GNU Affero General Public LICENSE <https://github.com/cleanlab/cleanlab/blob/master/LICENSE>`__ for details.

--- a/cleanlab/baseline_methods.py
+++ b/cleanlab/baseline_methods.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 # Baseline methods
 # 

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 """
 cleanlab package for multiclass learning with noisy labels for any model.

--- a/cleanlab/coteaching.py
+++ b/cleanlab/coteaching.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 
 # coding: utf-8

--- a/cleanlab/latent_algebra.py
+++ b/cleanlab/latent_algebra.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 
 # ## Latent Algebra

--- a/cleanlab/latent_estimation.py
+++ b/cleanlab/latent_estimation.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 
 # ## Latent Estimation

--- a/cleanlab/models/cifar_cnn.py
+++ b/cleanlab/models/cifar_cnn.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 """
 A PyTorch CNN for training CIFAR-10 using Co-Teaching.

--- a/cleanlab/models/fasttext.py
+++ b/cleanlab/models/fasttext.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 # Python 2 and 3 compatibility
 from __future__ import (

--- a/cleanlab/models/mnist_pytorch.py
+++ b/cleanlab/models/mnist_pytorch.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 
 # ## A cleanlab compatible PyTorch CNN classifier.

--- a/cleanlab/noise_generation.py
+++ b/cleanlab/noise_generation.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 
 # ## Noise Generation

--- a/cleanlab/polyplex.py
+++ b/cleanlab/polyplex.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 
 # ## The Polyplex

--- a/cleanlab/pruning.py
+++ b/cleanlab/pruning.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 
 # ## Pruning

--- a/cleanlab/util.py
+++ b/cleanlab/util.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 
 # ## Confident Learning Utilties

--- a/cleanlab/version.py
+++ b/cleanlab/version.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 __version__ = '1.0'
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ exec(open('cleanlab/version.py').read())
 setup(
     name='cleanlab',
     version=__version__,
-    license='GPLv3+',
+    license='AGPLv3+',
     long_description=long_description,
     long_description_content_type='text/x-rst',
     description = 'The standard package for machine learning with noisy labels and finding mislabeled data in Python.',
@@ -58,7 +58,7 @@ setup(
       'Intended Audience :: Education',
       'Intended Audience :: Science/Research',
       'Intended Audience :: Information Technology',
-      'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+      'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
       'Natural Language :: English',
 
       # We believe this package works will these versions, but we do not guarantee it!

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,15 +9,13 @@ Copyright (c) 2017-2050 Curtis G. Northcutt
 All files listed above and contained in this folder (https://github.com/cgnorthcutt/cleanlab/tests) are part of cleanlab.
 
 cleanlab is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
+it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
 cleanlab is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+GNU Affero General Public License for more details.
 
-You should have received a copy of the GNU General Public License in cleanlab/LICENSE.
-
-This agreement applies to this version and all previous versions of cleanlab.
+You should have received a copy of the GNU Affero General Public License in cleanlab/LICENSE.

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 # Python 2 and 3 compatibility
 from __future__ import print_function, absolute_import, division, unicode_literals, with_statement

--- a/tests/test_latent.py
+++ b/tests/test_latent.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 from __future__ import print_function, absolute_import, division, unicode_literals, with_statement
 

--- a/tests/test_latent_estimation_and_pruning.py
+++ b/tests/test_latent_estimation_and_pruning.py
@@ -13,8 +13,6 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
-#
-# This agreement applies to this version and all previous versions of cleanlab.
 
 from __future__ import (
     print_function, absolute_import, division, unicode_literals,


### PR DESCRIPTION
See old PR #96.

This patch updates metadata in `setup.py` and comments in other files to clarify that the current license is AGPLv3, as is specified in the current `LICENSE` file.

This patch also removes the "this agreement applies to this version and all previous versions" text from the README and code comments, because it is redundant; the previous code was already released under a _more liberal_ license, so giving the option of AGPLv3 is not useful (and perhaps confusing).