### PR TITLE
Ban coverage==6.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov 'coverage<6.3'
           pip install -r requirements.txt
       - name: Install torch and torchvision
         if: "${{ !(contains(matrix.os, 'windows') && matrix.python == '2.7') }}"


### PR DESCRIPTION
See https://github.com/nedbat/coveragepy/issues/1312. We can remove this once a newer version of coverage is released that includes https://github.com/nedbat/coveragepy/commit/00da68ef1a0b4d43c003babae0cb8f91beaf06d2.

Competing PR: #108