### PR TITLE
Dedupe deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Install dependencies
+      - name: Install test dependencies
         run: |
           pip install pytest pytest-cov 'coverage<6.3'
-          pip install -r requirements.txt
       - name: Install torch and torchvision
         if: "${{ !(contains(matrix.os, 'windows') && matrix.python == '2.7') }}"
         run: pip install torch torchvision

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE README.rst requirements.txt CONTRIBUTING.md
+include LICENSE README.rst CONTRIBUTING.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy>=1.11.3
-scipy>=0.13.3
-scikit-learn>=0.18
-tqdm>=4.53.0

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['img', 'examples']),
+    packages=find_packages(exclude=[]),
     
     # Include cleanlab license file.    
     include_package_data=True,


### PR DESCRIPTION
This was duplicating content in setup.py (and the two had gotten out of sync, listing different versions for scipy).

According to the Python Packaging User Guide (https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/), the `install_requires` specifies what a project minimally needs to run correctly, while the requirements.txt file contains an exhaustive list of pinned versions for the purpose of repeatable installations of a complete environment. Cleanlab is a Python package that users will `pip install`, so we don't need a requirements.txt.

Some related projects like scikit-learn don't have a requirements.txt, and others that do have such a file use it for a different purpose, e.g. PyTorch and Keras use the file to list dev dependencies.