### PR TITLE
Redirect RTD site to docs.cleanlab.ai

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
       - requirements: docs/requirements.txt
       - method: pip

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,7 @@
+.. raw:: html
+
+    <p>Redirecting you to <a href="https://docs.cleanlab.ai/">docs.cleanlab.ai</a>...</p>
+    
+    <script type="text/javascript">
+        window.location.replace('https://docs.cleanlab.ai/');
+    </script>


### PR DESCRIPTION
This PR is part of a series of PRs to redirect https://cleanlab.readthedocs.io to https://docs.cleanlab.ai. A mockup can be found here: https://cleanlab-test.readthedocs.io.

**Warning: this procedure "removes" the old docs in the RTD site**

- [x] 1. Add "Redirects" to the `cleanlab` project in RTD
- [ ] 2. Add the `index.rst` (redirecting HTML) and change Python to v3.8 in `.readthedocs.yaml` in the `cleanlab`'s `master` branch
- [ ] 3. Allow RTD to build this latest version (AKA `master` branch) of the docs and disable any other versions except `latest`
- [ ] 4. **Admin** to disable the RTD webhook from https://github.com/cleanlab/cleanlab/settings/hooks
- [ ] 5. Delete the `index.rst` and `.readthedocs.yaml` files in the `cleanlab`'s `master` branch