### PR TITLE
Add label quality scoring functions and user API to choose the method

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -949,3 +949,32 @@ def converge_estimates(
         )
 
     return py, noise_matrix, inverse_noise_matrix
+
+
+def get_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.array:
+    """Returns expected (average) "self-confidence" for each class.
+
+    The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
+
+    Parameters
+    ----------
+    labels : np.array
+      A discrete vector of noisy labels, i.e. some labels may be erroneous.
+      *Format requirements*: for dataset with K classes, labels must be in {0,1,...,K-1}.
+
+    pred_probs : np.array (shape (N, K))
+      P(label=k|x) is a matrix with K model-predicted probabilities.
+      Each row of this matrix corresponds to an example x and contains the model-predicted
+      probabilities that x belongs to each possible class.
+      The columns must be ordered such that these probabilities correspond to class 0,1,2,...
+      `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
+
+    Returns
+    -------
+    confident_thresholds : np.array (shape (K,))
+
+    """
+    confident_thresholds = np.array(
+        [np.mean(pred_probs[:, k][labels == k]) for k in range(pred_probs.shape[1])]
+    )
+    return confident_thresholds

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -534,7 +534,7 @@ def find_label_issues(
             labels=labels,
             pred_probs=pred_probs,
             rank_by=return_indices_ranked_by,
-            **rank_by_kwargs,
+            rank_by_kwargs=rank_by_kwargs,
         )
         return er
     confident_joint

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -342,13 +342,9 @@ def find_label_issues(
       If 0, no print statements. If 1, prints when multiprocessing happens.
 
     rank_by_kwargs : dict
-      Optional keyword arguments to pass into scoring functions for ranking.
+      Optional keyword arguments to pass into `rank.score_label_quality()` method.
       Accepted args include:
         adj_pred_probs : bool, default = False
-          Adjust predicted probabilities by subtracting the class confident thresholds and renormalizing.
-          The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
-          See paper "Confident Learning: Estimating Uncertainty in Dataset Labels" by Northcutt et al.
-          https://arxiv.org/abs/1911.00068
 
     Returns
     -------

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -243,6 +243,7 @@ def find_label_issues(
     num_to_remove_per_class=None,
     n_jobs=None,
     verbose=0,
+    **rank_by_kwargs,
 ):
     """By default, this method returns a boolean mask for the entire dataset where True represents
     a label issue and False represents an example that is confidently/accurately labeled.
@@ -523,6 +524,7 @@ def find_label_issues(
             labels=labels,
             pred_probs=pred_probs,
             rank_by=return_indices_ranked_by,
+            **rank_by_kwargs,
         )
         return er
     confident_joint

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -308,7 +308,7 @@ def find_label_issues(
 
     rank_by_kwargs : dict
       Optional keyword arguments to pass into scoring functions for ranking by label quality score
-      (see: `score_label_quality()` in cleanlab/rank.py).
+      (see: `get_label_quality_scores()` in cleanlab/rank.py).
       Accepted args include:
         adj_pred_probs : bool, default = False
 

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -310,7 +310,7 @@ def find_label_issues(
       Optional keyword arguments to pass into scoring functions for ranking by label quality score
       (see: `get_label_quality_scores()` in cleanlab/rank.py).
       Accepted args include:
-        adj_pred_probs : bool, default = False
+      adj_pred_probs : bool, default = False
 
     multi_label : bool
       If true, labels should be an iterable (e.g. list) of iterables, containing a

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -243,7 +243,7 @@ def find_label_issues(
     num_to_remove_per_class=None,
     n_jobs=None,
     verbose=0,
-    **rank_by_kwargs,
+    rank_by_kwargs={},
 ):
     """By default, this method returns a boolean mask for the entire dataset where True represents
     a label issue and False represents an example that is confidently/accurately labeled.
@@ -339,6 +339,11 @@ def find_label_issues(
 
     verbose : int
       If 0, no print statements. If 1, prints when multiprocessing happens.
+
+    rank_by_kwargs : dict
+      Optional keyword arguments to pass into scoring functions for ranking.
+      Accepted args includes:
+        adj_pred_probs : bool, default = False
 
     Returns
     -------

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -238,12 +238,12 @@ def find_label_issues(
     confident_joint=None,
     filter_by="prune_by_noise_rate",
     return_indices_ranked_by=None,
+    rank_by_kwargs={},
     multi_label=False,
     frac_noise=1.0,
     num_to_remove_per_class=None,
     n_jobs=None,
     verbose=0,
-    rank_by_kwargs={},
 ):
     """By default, this method returns a boolean mask for the entire dataset where True represents
     a label issue and False represents an example that is confidently/accurately labeled.
@@ -306,6 +306,12 @@ def find_label_issues(
       ``'self_confidence' := [pred_probs[i][labels[i]] for i in label_issues_idx]``
       ``'confidence_weighted_entropy' := entropy(pred_probs) / self_confidence``
 
+    rank_by_kwargs : dict
+      Optional keyword arguments to pass into scoring functions for ranking by label quality score
+      (see: `score_label_quality()` in cleanlab/rank.py).
+      Accepted args include:
+        adj_pred_probs : bool, default = False
+
     multi_label : bool
       If true, labels should be an iterable (e.g. list) of iterables, containing a
       list of labels for each example, instead of just a single label.
@@ -340,11 +346,6 @@ def find_label_issues(
 
     verbose : int
       If 0, no print statements. If 1, prints when multiprocessing happens.
-
-    rank_by_kwargs : dict
-      Optional keyword arguments to pass into `rank.score_label_quality()` method.
-      Accepted args include:
-        adj_pred_probs : bool, default = False
 
     Returns
     -------

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -298,12 +298,13 @@ def find_label_issues(
       5. 'predicted_neq_given': Find examples where the predicted class
       (i.e. argmax of the predicted probabilities) does not match the given label.
 
-    return_indices_ranked_by : {:obj:`None`, :obj:`self_confidence`, :obj:`normalized_margin`}
+    return_indices_ranked_by : {:obj:`None`, :obj:`self_confidence`, :obj:`normalized_margin`, :obj:`confidence_weighted_entropy`}
       If None, returns a boolean mask (true if example at index is label error)
       If not None, returns an array of the label error indices
       (instead of a bool mask) where error indices are ordered by the either:
       ``'normalized_margin' := normalized margin (p(label = k) - max(p(label != k)))``
       ``'self_confidence' := [pred_probs[i][labels[i]] for i in label_issues_idx]``
+      ``'confidence_weighted_entropy' := entropy(pred_probs) / self_confidence``
 
     multi_label : bool
       If true, labels should be an iterable (e.g. list) of iterables, containing a
@@ -342,8 +343,12 @@ def find_label_issues(
 
     rank_by_kwargs : dict
       Optional keyword arguments to pass into scoring functions for ranking.
-      Accepted args includes:
+      Accepted args include:
         adj_pred_probs : bool, default = False
+          Adjust predicted probabilities by subtracting the class confident thresholds and renormalizing.
+          The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
+          See paper "Confident Learning: Estimating Uncertainty in Dataset Labels" by Northcutt et al.
+          https://arxiv.org/abs/1911.00068
 
     Returns
     -------

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -310,7 +310,7 @@ def find_label_issues(
       Optional keyword arguments to pass into scoring functions for ranking by label quality score
       (see: `get_label_quality_scores()` in cleanlab/rank.py).
       Accepted args include:
-      adj_pred_probs : bool, default = False
+      adjust_pred_probs : bool, default = False
 
     multi_label : bool
       If true, labels should be an iterable (e.g. list) of iterables, containing a

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -378,7 +378,15 @@ def score_label_quality(
     }
 
     # Select scoring function
-    scoring_func = scoring_funcs[method]
+    try:
+        scoring_func = scoring_funcs[method]
+    except:
+        raise ValueError(
+            f"""
+            Provided rank_by scoring method {method} is not a valid method!
+            Please choose a valid rank_by: self_confidence, normalized_margin, confidence_weighted_entropy
+            """
+        )
 
     # Adjust predicted probabilities
     if adj_pred_probs:

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -31,12 +31,12 @@ import numpy as np
 
 
 def order_label_issues(
-    label_issues_mask,
-    labels,
-    pred_probs,
-    *,
+    label_issues_mask: np.array,
+    labels: np.array,
+    pred_probs: np.array,
     rank_by="normalized_margin",
-):
+    **rank_by_kwargs,
+) -> np.array:
     """Sorts label issues by normalized margin.
     See https://arxiv.org/pdf/1810.05369.pdf (eqn 2.2)
     e.g. normalized_margin = prob_label - max_prob_not_label
@@ -62,31 +62,37 @@ def order_label_issues(
         'normalized_margin' := normalized margin (p(label = k) - max(p(label != k)))
         'self_confidence' := [pred_probs[i][labels[i]] for i in label_issues_idx]
 
+    rank_by_kwargs : dict
+      Optional keyword arguments to pass into scoring functions for ranking.
+      Accepted args includes:
+        adj_pred_probs : bool, default = True
+
     Returns
     -------
-      label_issues_idx : np.array (int)
-        Return the index integers of the label issues, ordered by
-        the normalized margin."""
+    label_issues_idx : np.array (int)
+      Return the index integers of the label issues, ordered by
+      the normalized margin."""
 
     assert len(pred_probs) == len(labels)
+
     # Convert bool mask to index mask
     label_issues_idx = np.arange(len(labels))[label_issues_mask]
+
+    # Get pred_probs and labels for label issues
     pred_probs_er, labels_er = pred_probs[label_issues_mask], labels[label_issues_mask]
-    if rank_by == "self_confidence":
-        label_quality_scores = get_self_confidence_for_each_label(labels_er, pred_probs_er)
-    elif rank_by == "normalized_margin":
-        label_quality_scores = get_normalized_margin_for_each_label(labels_er, pred_probs_er)
-    else:
-        raise ValueError(
-            'rank_by must be "self_confidence" or "normalized_margin", ' 'but is "' + rank_by + '".'
-        )
+
+    # Calculate label quality scores
+    label_quality_scores = score_label_quality(
+        labels_er, pred_probs_er, method=rank_by, **rank_by_kwargs
+    )
+
     return label_issues_idx[np.argsort(label_quality_scores)]
 
 
 def get_self_confidence_for_each_label(
-    labels,
-    pred_probs,
-):
+    labels: np.array,
+    pred_probs: np.array,
+) -> np.array:
     """Returns the "self-confidence" for every example in the dataset associated pred_probs
     and labels. The self-confidence is the holdout probability that an example belongs to
     its given class label.
@@ -97,7 +103,6 @@ def get_self_confidence_for_each_label(
 
     Parameters
     ----------
-
     labels : np.array
       A discrete vector of noisy labels, i.e. some labels may be erroneous.
       *Format requirements*: for dataset with K classes, labels must be in {0,1,...,K-1}.
@@ -111,19 +116,19 @@ def get_self_confidence_for_each_label(
 
     Returns
     -------
-      self_confidence : np.array (float)
-        Return the holdout probability that each example in pred_probs belongs to its
-        label. Assumes pred_probs is computed holdout/out-of-sample."""
+    self_confidence : np.array (float)
+      Return the holdout probability that each example in pred_probs belongs to its
+      label. Assumes pred_probs is computed holdout/out-of-sample."""
 
     # np.mean is used so that this works for multi-labels (list of lists)
-    label_quality_scores = np.array([np.mean(pred_probs[i, l]) for i, l in enumerate(labels)])
-    return label_quality_scores
+    self_confidence = np.array([np.mean(pred_probs[i, l]) for i, l in enumerate(labels)])
+    return self_confidence
 
 
 def get_normalized_margin_for_each_label(
-    labels,
-    pred_probs,
-):
+    labels: np.array,
+    pred_probs: np.array,
+) -> np.array:
     """Returns the "normalized margin" for every example associated pred_probs and
     labels.
     The normalized margin is (p(label = k) - max(p(label != k))), i.e. the probability
@@ -152,14 +157,245 @@ def get_normalized_margin_for_each_label(
 
     Returns
     -------
-      normalized_margin : np.array (float)
-        Return a score (between 0 and 1) for each example of its likelihood of
-        being correctly labeled. Assumes pred_probs is computed holdout/out-of-sample.
-        normalized_margin = prob_label - max_prob_not_label"""
+    normalized_margin : np.array (float)
+      Return a score (between 0 and 1) for each example of its likelihood of
+      being correctly labeled. Assumes pred_probs is computed holdout/out-of-sample.
+      normalized_margin = prob_label - max_prob_not_label"""
 
     self_confidence = get_self_confidence_for_each_label(labels, pred_probs)
     max_prob_not_label = np.array(
         [max(np.delete(pred_probs[i], l, -1)) for i, l in enumerate(labels)]
     )
-    label_quality_scores = (self_confidence - max_prob_not_label + 1) / 2
+    normalized_margin = (self_confidence - max_prob_not_label + 1) / 2
+    return normalized_margin
+
+
+def get_confidence_weighted_entropy_for_each_label(
+    labels: np.array, pred_probs: np.array
+) -> np.array:
+    """Returns the normalized entropy divided by "self-confidence".
+
+    Score is between 0 and 1.
+    1 - clean label (not an error).
+    0 - dirty label (label error).
+
+    Parameters
+    ----------
+    labels : np.array
+      A discrete vector of noisy labels, i.e. some labels may be erroneous.
+      *Format requirements*: for dataset with K classes, labels must be in {0,1,...,K-1}.
+
+    pred_probs : np.array (shape (N, K))
+      P(label=k|x) is a matrix with K model-predicted probabilities.
+      Each row of this matrix corresponds to an example x and contains the model-predicted
+      probabilities that x belongs to each possible class.
+      The columns must be ordered such that these probabilities correspond to class 0,1,2,...
+      `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
+
+    Returns
+    -------
+    confidence_weighted_entropy : np.array (float)
+      Return a score (between 0 and 1) for each example of its likelihood of
+      being correctly labeled. Assumes pred_probs is computed holdout/out-of-sample.
+
+    """
+
+    # Get confidence of given label
+    self_confidence = get_self_confidence_for_each_label(labels, pred_probs)
+
+    # Divide entropy by self confidence
+    confidence_weighted_entropy = get_entropy(**{"pred_probs": pred_probs}) / self_confidence
+
+    # Rescale
+    confidence_weighted_entropy = (
+        np.log(confidence_weighted_entropy + 1) / confidence_weighted_entropy
+    )
+
+    return confidence_weighted_entropy
+
+
+def get_entropy(pred_probs: np.array) -> np.array:
+    """Returns the normalized entropy of pred_probs.
+
+    Read more about normalized entropy here: https://en.wikipedia.org/wiki/Entropy_(information_theory)
+
+    Normalized entropy is used in active learning for uncertainty sampling: https://towardsdatascience.com/uncertainty-sampling-cheatsheet-ec57bc067c0b
+
+    Normalized entropy is between 0 and 1. Higher values of entropy indicate higher uncertainty in the model's prediction of the correct label.
+
+    Parameters
+    ----------
+    pred_probs : ndarray of shape (n_samples, n_classes)
+      Predicted probabilities for each class.
+
+    Returns
+    -------
+    entropy : np.array (float)
+
+    """
+
+    num_classes = pred_probs.shape[1]
+
+    # Note that dividing by log(num_classes) changes the base of the log which rescales entropy to 0-1 range
+    return -np.sum(pred_probs * np.log(pred_probs), axis=1) / np.log(num_classes)
+
+
+def subtract_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.array:
+    """Returns adjusted predicted probabilities by subtracting the class confident thresholds and renormalizing.
+
+    The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
+
+    See paper "Confident Learning: Estimating Uncertainty in Dataset Labels" by Northcutt et al.
+    https://arxiv.org/abs/1911.00068
+
+    Purpose of this adjustment is to handle class imbalance.
+
+    Parameters
+    ----------
+    labels : np.array
+      A discrete vector of noisy labels, i.e. some labels may be erroneous.
+      *Format requirements*: for dataset with K classes, labels must be in {0,1,...,K-1}.
+
+    pred_probs : np.array (shape (N, K))
+      P(label=k|x) is a matrix with K model-predicted probabilities.
+      Each row of this matrix corresponds to an example x and contains the model-predicted
+      probabilities that x belongs to each possible class.
+      The columns must be ordered such that these probabilities correspond to class 0,1,2,...
+      `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
+
+    Returns
+    -------
+    pred_probs_adj : np.array (float)
+    """
+
+    # Get expected (average) self-confidence for each class
+    confident_thresholds = __get_confident_thresholds(labels, pred_probs)
+
+    # Subtract the class confident thresholds
+    pred_probs_adj = pred_probs - confident_thresholds
+
+    # Renormalize by shifting data to take care of negative values from the subtraction
+    pred_probs_adj += 1
+    pred_probs_adj /= pred_probs_adj.sum(axis=1)[:, None]
+
+    return pred_probs_adj
+
+
+def __get_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.array:
+    """Returns expected (average) "self-confidence" for each class.
+
+    The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
+
+    See paper "Confident Learning: Estimating Uncertainty in Dataset Labels" by Northcutt et al.
+    https://arxiv.org/abs/1911.00068
+
+    Parameters
+    ----------
+    labels : np.array
+      A discrete vector of noisy labels, i.e. some labels may be erroneous.
+      *Format requirements*: for dataset with K classes, labels must be in {0,1,...,K-1}.
+
+    pred_probs : np.array (shape (N, K))
+      P(label=k|x) is a matrix with K model-predicted probabilities.
+      Each row of this matrix corresponds to an example x and contains the model-predicted
+      probabilities that x belongs to each possible class.
+      The columns must be ordered such that these probabilities correspond to class 0,1,2,...
+      `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
+
+    Returns
+    -------
+    confident_thresholds : np.array (shape (K))
+
+    """
+    confident_thresholds = np.array(
+        [np.mean(pred_probs[:, k][labels == k]) for k in range(pred_probs.shape[1])]
+    )
+    return confident_thresholds
+
+
+def score_label_quality(
+    labels: np.array,
+    pred_probs: np.array,
+    method: str = "self_confidence",
+    adj_pred_probs: bool = False,
+    **kwargs,
+) -> np.array:
+    """Returns the label quality scores.
+
+    The scoring methods are heuristics to enable users to quickly rank order data to find potential label quality issues.
+
+    Parameters
+    ----------
+    labels : np.array
+      A discrete vector of noisy labels, i.e. some labels may be erroneous.
+      *Format requirements*: for dataset with K classes, labels must be in {0,1,...,K-1}.
+
+    pred_probs : np.array (shape (N, K))
+      P(label=k|x) is a matrix with K model-predicted probabilities.
+      Each row of this matrix corresponds to an example x and contains the model-predicted
+      probabilities that x belongs to each possible class.
+      The columns must be ordered such that these probabilities correspond to class 0,1,2,...
+      `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
+
+    method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="self_confidence"
+      Label quality scoring method. Default is "self_confidence".
+
+      .. seealso::
+        :func:`self_confidence`
+        :func:`normalized_margin`
+        :func:`confidence_weighted_entropy`
+
+    adj_pred_probs : bool, default = True
+      Adjust predicted probabilities by subtracting the class confident thresholds and renormalizing.
+      The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
+      See paper "Confident Learning: Estimating Uncertainty in Dataset Labels" by Northcutt et al.
+      https://arxiv.org/abs/1911.00068
+
+    Returns
+    -------
+    label_quality_scores : np.array (float)
+
+    See Also
+    --------
+    self_confidence
+    normalized_margin
+    confidence_weighted_entropy
+    subtract_confident_thresholds
+
+    """
+
+    # Available scoring functions to choose from
+    scoring_funcs = {
+        "self_confidence": get_self_confidence_for_each_label,
+        "normalized_margin": get_normalized_margin_for_each_label,
+        "confidence_weighted_entropy": get_confidence_weighted_entropy_for_each_label,
+    }
+
+    # Select scoring function
+    try:
+        scoring_func = scoring_funcs[method]
+    except Exception as e:
+        print(f"Exception: {e}")
+        raise ValueError(
+            f"""
+            Scoring {method} must be one of the following: 
+                "self_confidence"
+                "normalized_margin"
+                "confidence_weighted_entropy"
+            
+            Scoring method provided: {method}
+            """
+        )
+
+    # Adjust predicted probabilities
+    if adj_pred_probs:
+        pred_probs = subtract_confident_thresholds(labels, pred_probs)
+
+    # Pass keyword arguments for scoring function
+    input = {"labels": labels, "pred_probs": pred_probs}
+
+    # Calculate scores
+    # Using keyword arguments will make it more convenient to add decorators to the scoring functions that check the inputs
+    label_quality_scores = scoring_func(**input)
+
     return label_quality_scores

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -30,7 +30,10 @@ If you aren't sure which method to use, try `get_normalized_margin_for_each_labe
 import numpy as np
 from typing import List
 import warnings
-from cleanlab.utils.label_quality_utils import subtract_confident_thresholds, get_normalized_entropy
+from cleanlab.utils.label_quality_utils import (
+    _subtract_confident_thresholds,
+    get_normalized_entropy,
+)
 
 
 def order_label_issues(
@@ -65,7 +68,7 @@ def order_label_issues(
     rank_by_kwargs : dict
       Optional keyword arguments to pass into `get_label_quality_scores()` method.
       Accepted args include:
-      adj_pred_probs : bool, default = False
+      adjust_pred_probs : bool, default = False
 
     Returns
     -------
@@ -96,7 +99,7 @@ def get_label_quality_scores(
     pred_probs: np.array,
     *,
     method: str = "normalized_margin",
-    adj_pred_probs: bool = False,
+    adjust_pred_probs: bool = False,
 ) -> np.array:
     """Returns label quality scores for each datapoint.
 
@@ -143,7 +146,7 @@ def get_label_quality_scores(
         :func:`normalized_margin`
         :func:`confidence_weighted_entropy`
 
-    adj_pred_probs : bool, default = False
+    adjust_pred_probs : bool, default = False
       Account for class-imbalance in the label-quality scoring by adjusting predicted probabilities
       via subtraction of class confident thresholds and renormalization.
       Set this = True if you prefer to account for class-imbalance.
@@ -160,7 +163,7 @@ def get_label_quality_scores(
     self_confidence
     normalized_margin
     confidence_weighted_entropy
-    subtract_confident_thresholds
+    _subtract_confident_thresholds
 
     """
 
@@ -183,8 +186,8 @@ def get_label_quality_scores(
         )
 
     # Adjust predicted probabilities
-    if adj_pred_probs:
-        pred_probs = subtract_confident_thresholds(labels, pred_probs)
+    if adjust_pred_probs:
+        pred_probs = _subtract_confident_thresholds(labels, pred_probs)
 
     # Pass keyword arguments for scoring function
     input = {"labels": labels, "pred_probs": pred_probs}
@@ -200,7 +203,7 @@ def get_label_quality_ensemble_scores(
     pred_probs_list: List[np.array],
     *,
     method: str = "normalized_margin",
-    adj_pred_probs: bool = False,
+    adjust_pred_probs: bool = False,
     weight_ensemble_members_by: str = "accuracy",
     verbose: int = 1,
 ) -> np.array:
@@ -237,8 +240,8 @@ def get_label_quality_ensemble_scores(
         :func:`normalized_margin`
         :func:`confidence_weighted_entropy`
 
-    adj_pred_probs : bool, default = False
-      Adj_pred_probs in the same format expected by the `get_label_quality_scores()` method.
+    adjust_pred_probs : bool, default = False
+      adjust_pred_probs in the same format expected by the `get_label_quality_scores()` method.
 
     weight_ensemble_members_by : {"uniform", "accuracy"}, default="accuracy"
       Weighting scheme used to aggregate scores from each model:
@@ -283,7 +286,7 @@ def get_label_quality_ensemble_scores(
             labels=labels,
             pred_probs=pred_probs,
             method=method,
-            adj_pred_probs=adj_pred_probs,
+            adjust_pred_probs=adjust_pred_probs,
         )
         scores_list.append(scores)
 

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -377,10 +377,10 @@ def score_label_quality(
     # Select scoring function
     try:
         scoring_func = scoring_funcs[method]
-    except:
+    except KeyError:
         raise ValueError(
             f"""
-            Provided rank_by scoring method {method} is not a valid method!
+            {method} is not a valid scoring method for rank_by!
             Please choose a valid rank_by: self_confidence, normalized_margin, confidence_weighted_entropy
             """
         )

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -58,10 +58,9 @@ def order_label_issues(
       Predicted-probabilities in the same format expected by the `score_label_quality()` method.
 
     rank_by : str ['normalized_margin', 'self_confidence', 'confidence_weighted_entropy']
-      Method to order label error indices (instead of a bool mask), either:
-        'normalized_margin' := normalized margin (p(label = k) - max(p(label != k)))
-        'self_confidence' := [pred_probs[i][labels[i]] for i in label_issues_idx]
-        'confidence_weighted_entropy' := entropy(pred_probs) / self_confidence
+      Score by which to order label error indices (in increasing order), either:
+      'normalized_margin', 'self_confidence', or 'confidence_weighted_entropy'.
+      See `score_label_quality()` documentation for description of these scores.
 
     rank_by_kwargs : dict
       Optional keyword arguments to pass into `score_label_quality()` method.
@@ -121,6 +120,12 @@ def score_label_quality(
 
     method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="normalized_margin"
       Label quality scoring method. Default is "normalized_margin".
+
+      Letting `k := labels[i]` and `P := pred_probs[i]` denote the given label and predicted class-probabilities
+      for the `i`th datapoint, its score can either be:
+      'normalized_margin' := P[k] - max_{k' != k}[ P[k'] ]
+      'self_confidence' := P[k]
+      'confidence_weighted_entropy' := entropy(P) / self_confidence
 
       Self-confidence works better for finding out-of-distribution (OOD) examples, weird examples, bad examples,
       multi-label, and other types of label errors.

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -187,6 +187,11 @@ def get_label_quality_scores(
 
     # Adjust predicted probabilities
     if adjust_pred_probs:
+
+        # Check if adjust_pred_probs is supported for the chosen method
+        if method == "confidence_weighted_entropy":
+            raise ValueError(f"adjust_pred_probs is not currently supported for {method}.")
+
         pred_probs = _subtract_confident_thresholds(labels, pred_probs)
 
     # Pass keyword arguments for scoring function

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -94,7 +94,7 @@ def score_label_quality(
     labels: np.array,
     pred_probs: np.array,
     *,
-    method: str = "self_confidence",
+    method: str = "normalized_margin",
     adj_pred_probs: bool = False,
 ) -> np.array:
     """Returns label quality scores for each datapoint.
@@ -119,8 +119,14 @@ def score_label_quality(
       The columns must be ordered such that these probabilities correspond to class 0,1,2,...
       `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
 
-    method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="self_confidence"
-      Label quality scoring method. Default is "self_confidence".
+    method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="normalized_margin"
+      Label quality scoring method. Default is "normalized_margin".
+
+      Self-confidence works better for finding out-of-distribution (OOD) examples, weird examples, bad examples,
+      multi-label, and other types of label errors.
+
+      Normalized margin works better for finding class conditional label errors where
+      there is another label in the class that is better than the given label.
 
       .. seealso::
         :func:`self_confidence`
@@ -183,7 +189,7 @@ def score_label_quality_ensemble(
     labels: np.array,
     pred_probs_list: List[np.array],
     *,
-    method: str = "self_confidence",
+    method: str = "normalized_margin",
     adj_pred_probs: bool = False,
     weight_ensemble_members_by: str = "accuracy",
     verbose: int = 1,
@@ -212,8 +218,9 @@ def score_label_quality_ensemble(
       expected by the `score_label_quality()` method.
       Each element of pred_probs_list corresponds to the predictions from one model for all datapoints.
 
-    method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="self_confidence"
-      Label quality scoring method. Default is "self_confidence".
+    method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="normalized_margin"
+      Label quality scoring method. Default is "normalized_margin".
+      See `score_label_quality()` for scenarios on when to use each method.
 
       .. seealso::
         :func:`self_confidence`
@@ -327,6 +334,9 @@ def get_self_confidence_for_each_label(
     The self-confidence is the holdout probability that an example belongs to
     its given class label.
 
+    Self-confidence works better for finding out-of-distribution (OOD) examples, weird examples, bad examples,
+    multi-label, and other types of label errors.
+
     Parameters
     ----------
     labels : np.array
@@ -363,6 +373,9 @@ def get_normalized_margin_for_each_label(
     the given label. This gives you an idea of how likely an example is BOTH
     its given label AND not another label, and therefore, scores its likelihood
     of being a good label or a label error.
+
+    Normalized margin works better for finding class conditional label errors where
+    there is another label in the class that is better than the given label.
 
     Parameters
     ----------

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -39,7 +39,9 @@ def order_label_issues(
     rank_by: str = "normalized_margin",
     rank_by_kwargs: dict = {},
 ) -> np.array:
-    """Sorts label issues by normalized margin.
+    """Sorts label issues by label quality score.
+
+    Default label quality score is "normalized margin".
     See https://arxiv.org/pdf/1810.05369.pdf (eqn 2.2)
     e.g. normalized_margin = prob_label - max_prob_not_label
 

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -52,18 +52,18 @@ def order_label_issues(
       Contains True if the index of labels is an error, o.w. false
 
     labels : np.array
-      Labels in the same format expected by the `score_label_quality()` method.
+      Labels in the same format expected by the `get_label_quality_scores()` method.
 
     pred_probs : np.array (shape (N, K))
-      Predicted-probabilities in the same format expected by the `score_label_quality()` method.
+      Predicted-probabilities in the same format expected by the `get_label_quality_scores()` method.
 
     rank_by : str ['normalized_margin', 'self_confidence', 'confidence_weighted_entropy']
       Score by which to order label error indices (in increasing order), either:
       'normalized_margin', 'self_confidence', or 'confidence_weighted_entropy'.
-      See `score_label_quality()` documentation for description of these scores.
+      See `get_label_quality_scores()` documentation for description of these scores.
 
     rank_by_kwargs : dict
-      Optional keyword arguments to pass into `score_label_quality()` method.
+      Optional keyword arguments to pass into `get_label_quality_scores()` method.
       Accepted args include:
         adj_pred_probs : bool, default = False
 
@@ -81,7 +81,9 @@ def order_label_issues(
     label_issues_idx = np.arange(len(labels))[label_issues_mask]
 
     # Calculate label quality scores
-    label_quality_scores = score_label_quality(labels, pred_probs, method=rank_by, **rank_by_kwargs)
+    label_quality_scores = get_label_quality_scores(
+        labels, pred_probs, method=rank_by, **rank_by_kwargs
+    )
 
     # Get label quality scores for label issues
     label_quality_scores_issues = label_quality_scores[label_issues_mask]
@@ -89,7 +91,7 @@ def order_label_issues(
     return label_issues_idx[np.argsort(label_quality_scores_issues)]
 
 
-def score_label_quality(
+def get_label_quality_scores(
     labels: np.array,
     pred_probs: np.array,
     *,
@@ -193,7 +195,7 @@ def score_label_quality(
     return label_quality_scores
 
 
-def score_label_quality_ensemble(
+def get_label_quality_ensemble_scores(
     labels: np.array,
     pred_probs_list: List[np.array],
     *,
@@ -219,16 +221,16 @@ def score_label_quality_ensemble(
     Parameters
     ----------
     labels : np.array
-      Labels in the same format expected by the `score_label_quality()` method.
+      Labels in the same format expected by the `get_label_quality_scores()` method.
 
     pred_probs_list : List of np.array (shape (N, K))
       Each element in this list should be an array of pred_probs in the same format
-      expected by the `score_label_quality()` method.
+      expected by the `get_label_quality_scores()` method.
       Each element of pred_probs_list corresponds to the predictions from one model for all datapoints.
 
     method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="normalized_margin"
       Label quality scoring method. Default is "normalized_margin".
-      See `score_label_quality()` for scenarios on when to use each method.
+      See `get_label_quality_scores()` for scenarios on when to use each method.
 
       .. seealso::
         :func:`self_confidence`
@@ -236,7 +238,7 @@ def score_label_quality_ensemble(
         :func:`confidence_weighted_entropy`
 
     adj_pred_probs : bool, default = False
-      Adj_pred_probs in the same format expected by the `score_label_quality()` method.
+      Adj_pred_probs in the same format expected by the `get_label_quality_scores()` method.
 
     weight_ensemble_members_by : {"uniform", "accuracy"}, default="accuracy"
       Weighting scheme used to aggregate scores from each model:
@@ -252,7 +254,7 @@ def score_label_quality_ensemble(
 
     See Also
     --------
-    score_label_quality
+    get_label_quality_scores
 
     """
 
@@ -267,7 +269,7 @@ def score_label_quality_ensemble(
         warnings.warn(
             """
             pred_probs_list only has one element. 
-            Consider using score_label_quality() if you only have a single array of pred_probs.
+            Consider using get_label_quality_scores() if you only have a single array of pred_probs.
             """
         )
 
@@ -277,7 +279,7 @@ def score_label_quality_ensemble(
     for pred_probs in pred_probs_list:
 
         # Calculate scores and accuracy
-        scores = score_label_quality(
+        scores = get_label_quality_scores(
             labels=labels,
             pred_probs=pred_probs,
             method=method,
@@ -348,10 +350,10 @@ def get_self_confidence_for_each_label(
     Parameters
     ----------
     labels : np.array
-      Labels in the same format expected by the `score_label_quality()` method.
+      Labels in the same format expected by the `get_label_quality_scores()` method.
 
     pred_probs : np.array (shape (N, K))
-      Predicted-probabilities in the same format expected by the `score_label_quality()` method.
+      Predicted-probabilities in the same format expected by the `get_label_quality_scores()` method.
 
     Returns
     -------
@@ -389,10 +391,10 @@ def get_normalized_margin_for_each_label(
     ----------
 
     labels : np.array
-      Labels in the same format expected by the `score_label_quality()` method.
+      Labels in the same format expected by the `get_label_quality_scores()` method.
 
     pred_probs : np.array (shape (N, K))
-      Predicted-probabilities in the same format expected by the `score_label_quality()` method.
+      Predicted-probabilities in the same format expected by the `get_label_quality_scores()` method.
 
     Returns
     -------
@@ -424,10 +426,10 @@ def get_confidence_weighted_entropy_for_each_label(
     Parameters
     ----------
     labels : np.array
-      Labels in the same format expected by the `score_label_quality()` method.
+      Labels in the same format expected by the `get_label_quality_scores()` method.
 
     pred_probs : np.array (shape (N, K))
-      Predicted-probabilities in the same format expected by the `score_label_quality()` method.
+      Predicted-probabilities in the same format expected by the `get_label_quality_scores()` method.
 
     Returns
     -------

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -65,7 +65,7 @@ def order_label_issues(
     rank_by_kwargs : dict
       Optional keyword arguments to pass into `get_label_quality_scores()` method.
       Accepted args include:
-        adj_pred_probs : bool, default = False
+      adj_pred_probs : bool, default = False
 
     Returns
     -------

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -36,7 +36,7 @@ def order_label_issues(
     pred_probs: np.array,
     *,
     rank_by: str = "normalized_margin",
-    **rank_by_kwargs,
+    rank_by_kwargs={},
 ) -> np.array:
     """Sorts label issues by normalized margin.
     See https://arxiv.org/pdf/1810.05369.pdf (eqn 2.2)

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -131,11 +131,10 @@ def score_label_quality(
         :func:`normalized_margin`
         :func:`confidence_weighted_entropy`
 
-    adj_pred_probs : bool, default = True
-      Account for class-imbalance in the label-quality scoring (by adjusting predicted probabilities
-      via subtraction of class confident thresholds and renormalization).
-      Set this = False if you prefer to emphasize label issues in classes that are more common
-      throughout the dataset
+    adj_pred_probs : bool, default = False
+      Account for class-imbalance in the label-quality scoring by adjusting predicted probabilities
+      via subtraction of class confident thresholds and renormalization.
+      Set this = True if you prefer to account for class-imbalance.
       See paper "Confident Learning: Estimating Uncertainty in Dataset Labels" by Northcutt et al.
       https://arxiv.org/abs/1911.00068
 
@@ -224,7 +223,7 @@ def score_label_quality_ensemble(
         :func:`normalized_margin`
         :func:`confidence_weighted_entropy`
 
-    adj_pred_probs : bool, default = True
+    adj_pred_probs : bool, default = False
       Adj_pred_probs in the same format expected by the `score_label_quality()` method.
 
     weight_ensemble_members_by : {"uniform", "accuracy"}, default="uniform"
@@ -285,8 +284,11 @@ def score_label_quality_ensemble(
 
         # Only print if the user specified to weight by accuracy
         if weight_ensemble_members_by == "accuracy":
+            print(
+                "Ensemble members will be weighted by: accuracy of member / (sum of accuracy from all members)"
+            )
             for i, acc in enumerate(accuracy_list):
-                print(f"Model {i} accuracy: {acc}")
+                print(f"  Model {i} accuracy: {acc}")
 
     # Transform list of scores into an array of shape (N, M) where M is the number of models in the ensemble
     scores_ensemble = np.vstack(scores_list).T

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -67,8 +67,12 @@ def order_label_issues(
 
     rank_by_kwargs : dict
       Optional keyword arguments to pass into scoring functions for ranking.
-      Accepted args includes:
+      Accepted args include:
         adj_pred_probs : bool, default = False
+          Adjust predicted probabilities by subtracting the class confident thresholds and renormalizing.
+          The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
+          See paper "Confident Learning: Estimating Uncertainty in Dataset Labels" by Northcutt et al.
+          https://arxiv.org/abs/1911.00068
 
     Returns
     -------

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -85,7 +85,7 @@ def order_label_issues(
 
     # Calculate label quality scores
     label_quality_scores = score_label_quality(
-        labels_er, pred_probs_er, method=rank_by, **rank_by_kwargs
+        labels=labels_er, pred_probs=pred_probs_er, method=rank_by, **rank_by_kwargs
     )
 
     return label_issues_idx[np.argsort(label_quality_scores)]

--- a/cleanlab/utils/label_quality_utils.py
+++ b/cleanlab/utils/label_quality_utils.py
@@ -17,38 +17,10 @@
 """Helper functions for computing label quality scores"""
 
 import numpy as np
+from cleanlab.count import get_confident_thresholds
 
 
-def get_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.array:
-    """Returns expected (average) "self-confidence" for each class.
-
-    The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
-
-    Parameters
-    ----------
-    labels : np.array
-      A discrete vector of noisy labels, i.e. some labels may be erroneous.
-      *Format requirements*: for dataset with K classes, labels must be in {0,1,...,K-1}.
-
-    pred_probs : np.array (shape (N, K))
-      P(label=k|x) is a matrix with K model-predicted probabilities.
-      Each row of this matrix corresponds to an example x and contains the model-predicted
-      probabilities that x belongs to each possible class.
-      The columns must be ordered such that these probabilities correspond to class 0,1,2,...
-      `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
-
-    Returns
-    -------
-    confident_thresholds : np.array (shape (K,))
-
-    """
-    confident_thresholds = np.array(
-        [np.mean(pred_probs[:, k][labels == k]) for k in range(pred_probs.shape[1])]
-    )
-    return confident_thresholds
-
-
-def subtract_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.array:
+def _subtract_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.array:
     """Returns adjusted predicted probabilities by subtracting the class confident thresholds and renormalizing.
 
     The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
@@ -58,10 +30,10 @@ def subtract_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.
     Parameters
     ----------
     labels : np.array
-      Labels in the same format expected by the `get_confident_thresholds()` method.
+      Labels in the same format expected by the `cleanlab.count.get_confident_thresholds()` method.
 
     pred_probs : np.array (shape (N, K))
-      Predicted-probabilities in the same format expected by the `get_confident_thresholds()` method.
+      Predicted-probabilities in the same format expected by the `cleanlab.count.get_confident_thresholds()` method.
 
     Returns
     -------

--- a/cleanlab/utils/label_quality_utils.py
+++ b/cleanlab/utils/label_quality_utils.py
@@ -82,7 +82,7 @@ def subtract_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.
     return pred_probs_adj
 
 
-def get_entropy(pred_probs: np.array) -> np.array:
+def get_normalized_entropy(pred_probs: np.array) -> np.array:
     """Returns the normalized entropy of pred_probs.
 
     Normalized entropy is between 0 and 1. Higher values of entropy indicate higher uncertainty in the model's prediction of the correct label.

--- a/cleanlab/utils/label_quality_utils.py
+++ b/cleanlab/utils/label_quality_utils.py
@@ -49,7 +49,9 @@ def _subtract_confident_thresholds(labels: np.array, pred_probs: np.array) -> np
 
     # Renormalize by shifting data to take care of negative values from the subtraction
     pred_probs_adj += 1
-    pred_probs_adj /= pred_probs_adj.sum(axis=1)[:, None]
+    pred_probs_adj /= pred_probs_adj.sum(axis=1)[
+        :, None
+    ]  # The [:, None] adds a dimension to make the /= operator work for broadcasting.
 
     return pred_probs_adj
 

--- a/cleanlab/utils/label_quality_utils.py
+++ b/cleanlab/utils/label_quality_utils.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2017-2022  Cleanlab Inc.
+# This file is part of cleanlab.
+#
+# cleanlab is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cleanlab is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Helper functions for computing label quality scores"""
+
+import numpy as np
+
+
+def get_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.array:
+    """Returns expected (average) "self-confidence" for each class.
+
+    The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
+
+    Parameters
+    ----------
+    labels : np.array
+      A discrete vector of noisy labels, i.e. some labels may be erroneous.
+      *Format requirements*: for dataset with K classes, labels must be in {0,1,...,K-1}.
+
+    pred_probs : np.array (shape (N, K))
+      P(label=k|x) is a matrix with K model-predicted probabilities.
+      Each row of this matrix corresponds to an example x and contains the model-predicted
+      probabilities that x belongs to each possible class.
+      The columns must be ordered such that these probabilities correspond to class 0,1,2,...
+      `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
+
+    Returns
+    -------
+    confident_thresholds : np.array (shape (K,))
+
+    """
+    confident_thresholds = np.array(
+        [np.mean(pred_probs[:, k][labels == k]) for k in range(pred_probs.shape[1])]
+    )
+    return confident_thresholds
+
+
+def subtract_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.array:
+    """Returns adjusted predicted probabilities by subtracting the class confident thresholds and renormalizing.
+
+    The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
+
+    The purpose of this adjustment is to handle class imbalance.
+
+    Parameters
+    ----------
+    labels : np.array
+      Labels in the same format expected by the `get_confident_thresholds()` method.
+
+    pred_probs : np.array (shape (N, K))
+      Predicted-probabilities in the same format expected by the `get_confident_thresholds()` method.
+
+    Returns
+    -------
+    pred_probs_adj : np.array (float)
+      Adjusted pred_probs.
+    """
+
+    # Get expected (average) self-confidence for each class
+    confident_thresholds = get_confident_thresholds(labels, pred_probs)
+
+    # Subtract the class confident thresholds
+    pred_probs_adj = pred_probs - confident_thresholds
+
+    # Renormalize by shifting data to take care of negative values from the subtraction
+    pred_probs_adj += 1
+    pred_probs_adj /= pred_probs_adj.sum(axis=1)[:, None]
+
+    return pred_probs_adj

--- a/cleanlab/utils/label_quality_utils.py
+++ b/cleanlab/utils/label_quality_utils.py
@@ -80,3 +80,35 @@ def subtract_confident_thresholds(labels: np.array, pred_probs: np.array) -> np.
     pred_probs_adj /= pred_probs_adj.sum(axis=1)[:, None]
 
     return pred_probs_adj
+
+
+def get_entropy(pred_probs: np.array) -> np.array:
+    """Returns the normalized entropy of pred_probs.
+
+    Normalized entropy is between 0 and 1. Higher values of entropy indicate higher uncertainty in the model's prediction of the correct label.
+
+    Read more about normalized entropy here: https://en.wikipedia.org/wiki/Entropy_(information_theory)
+
+    Normalized entropy is used in active learning for uncertainty sampling: https://towardsdatascience.com/uncertainty-sampling-cheatsheet-ec57bc067c0b
+
+    Unlike label-quality scores, entropy only depends on the model's predictions, not the given label.
+
+    Parameters
+    ----------
+    pred_probs : np.array (shape (N, K))
+      P(label=k|x) is a matrix with K model-predicted probabilities.
+      Each row of this matrix corresponds to an example x and contains the model-predicted
+      probabilities that x belongs to each possible class.
+      The columns must be ordered such that these probabilities correspond to class 0,1,2,...
+      `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
+
+    Returns
+    -------
+    entropy : np.array (float)
+
+    """
+
+    num_classes = pred_probs.shape[1]
+
+    # Note that dividing by log(num_classes) changes the base of the log which rescales entropy to 0-1 range
+    return -np.sum(pred_probs * np.log(pred_probs), axis=1) / np.log(num_classes)

--- a/cleanlab/utils/label_quality_utils.py
+++ b/cleanlab/utils/label_quality_utils.py
@@ -48,7 +48,7 @@ def _subtract_confident_thresholds(labels: np.array, pred_probs: np.array) -> np
     pred_probs_adj = pred_probs - confident_thresholds
 
     # Renormalize by shifting data to take care of negative values from the subtraction
-    pred_probs_adj += 1
+    pred_probs_adj += confident_thresholds.max()
     pred_probs_adj /= pred_probs_adj.sum(axis=1)[
         :, None
     ]  # The [:, None] adds a dimension to make the /= operator work for broadcasting.

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -188,6 +188,26 @@ def test_order_label_issues_using_scoring_func_ranking():
             labels=data["labels"],
             pred_probs=data["pred_probs"],
             rank_by=method,
+        )
+        scores = rank.score_label_quality(data["labels"], data["pred_probs"], method=method)
+        indices = np.arange(len(scores))[data["label_errors_mask"]]
+        scores = scores[data["label_errors_mask"]]
+        score_idx = sorted(list(zip(scores, indices)), key=lambda y: y[0])  # sort indices by score
+        label_issues_indices2 = [z[1] for z in score_idx]
+        assert all(label_issues_indices == label_issues_indices2)
+
+
+def test_order_label_issues_using_scoring_func_adj_pred_probs_ranking():
+
+    # test all scoring methods with the scoring function and setting adj_pred_probs=True
+    scoring_methods = ["self_confidence", "normalized_margin", "confidence_weighted_entropy"]
+
+    for method in scoring_methods:
+        label_issues_indices = rank.order_label_issues(
+            label_issues_mask=data["label_errors_mask"],
+            labels=data["labels"],
+            pred_probs=data["pred_probs"],
+            rank_by=method,
             rank_by_kwargs={
                 "adj_pred_probs": True
             },  # adjust predicted probabilities by subtracting class thresholds (as defined in confident learning paper)

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -175,3 +175,23 @@ def test_order_label_issues_using_confidence_weighted_entropy_ranking():
     score_idx = sorted(list(zip(scores, indices)), key=lambda y: y[0])  # sort indices by score
     label_issues_indices2 = [z[1] for z in score_idx]
     assert all(label_issues_indices == label_issues_indices2)
+
+
+def test_order_label_issues_using_scoring_func_ranking():
+
+    # test all scoring methods with the scoring function
+    methods = ["self_confidence", "normalized_margin", "confidence_weighted_entropy"]
+
+    for method in methods:
+        label_issues_indices = rank.order_label_issues(
+            label_issues_mask=data["label_errors_mask"],
+            labels=data["labels"],
+            pred_probs=data["pred_probs"],
+            rank_by=method,
+        )
+        scores = rank.score_label_quality(data["labels"], data["pred_probs"], method=method)
+        indices = np.arange(len(scores))[data["label_errors_mask"]]
+        scores = scores[data["label_errors_mask"]]
+        score_idx = sorted(list(zip(scores, indices)), key=lambda y: y[0])  # sort indices by score
+        label_issues_indices2 = [z[1] for z in score_idx]
+        assert all(label_issues_indices == label_issues_indices2)

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -273,3 +273,16 @@ def test_bad_pred_probs_list_parameter_error():
 
         # AssertionError because pred_probs_list is empty
         _ = rank.get_label_quality_ensemble_scores(labels=labels, pred_probs_list=[])
+
+
+def test_unsupported_method_for_adjust_pred_probs():
+    with pytest.raises(ValueError) as e:
+
+        labels = data["labels"]
+        pred_probs = data["pred_probs"]
+
+        # method that do not support adjust_pred_probs
+        # note: use a list of methods if there are multiple methods that do not support adjust_pred_probs
+        method = "confidence_weighted_entropy"
+
+        _ = rank.get_label_quality_scores(labels, pred_probs, adjust_pred_probs=True, method=method)

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -180,16 +180,19 @@ def test_order_label_issues_using_confidence_weighted_entropy_ranking():
 def test_order_label_issues_using_scoring_func_ranking():
 
     # test all scoring methods with the scoring function
-    methods = ["self_confidence", "normalized_margin", "confidence_weighted_entropy"]
+    scoring_methods = ["self_confidence", "normalized_margin", "confidence_weighted_entropy"]
 
-    for method in methods:
+    for method in scoring_methods:
         label_issues_indices = rank.order_label_issues(
             label_issues_mask=data["label_errors_mask"],
             labels=data["labels"],
             pred_probs=data["pred_probs"],
             rank_by=method,
+            adj_pred_probs=True,  # adjust predicted probabilities by subtracting class thresholds (as defined in confident learning paper)
         )
-        scores = rank.score_label_quality(data["labels"], data["pred_probs"], method=method)
+        scores = rank.score_label_quality(
+            data["labels"], data["pred_probs"], method=method, adj_pred_probs=True
+        )
         indices = np.arange(len(scores))[data["label_errors_mask"]]
         scores = scores[data["label_errors_mask"]]
         score_idx = sorted(list(zip(scores, indices)), key=lambda y: y[0])  # sort indices by score

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -254,3 +254,22 @@ def test_bad_weight_ensemble_members_by_parameter_error():
             pred_probs_list,
             weight_ensemble_members_by="not_a_real_method",  # this should raise ValueError
         )
+
+
+def test_bad_pred_probs_list_parameter_error():
+    with pytest.raises(AssertionError) as e:
+
+        labels = data["labels"]
+        pred_probs = data["pred_probs"]
+
+        # baseline scenario where all the pred_probs are the same in the ensemble list
+        num_repeat = 3
+        pred_probs_list = np.repeat(
+            [pred_probs], num_repeat, axis=0
+        )  # this should be a list not an array
+
+        # AssertionError because pred_probs_list is an array
+        _ = rank.score_label_quality_ensemble(labels, pred_probs_list)
+
+        # AssertionError because pred_probs_list is empty
+        _ = rank.score_label_quality_ensemble(labels=labels, pred_probs_list=[])

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -198,7 +198,15 @@ def test_subtract_confident_thresholds():
     ).all()  # all pred_prob sum to 1 with some small precision error
 
 
-def test_ensemble_scoring_func():
+@pytest.mark.parametrize(
+    "scoring_method",
+    [
+        "self_confidence",
+        "normalized_margin",
+        "confidence_weighted_entropy",
+    ],
+)
+def test_ensemble_scoring_func(scoring_method):
 
     labels = data["labels"]
     pred_probs = data["pred_probs"]
@@ -207,21 +215,16 @@ def test_ensemble_scoring_func():
     num_repeat = 3
     pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
 
-    # test all scoring methods with the scoring function and setting adj_pred_probs=True
-    scoring_methods = ["self_confidence", "normalized_margin", "confidence_weighted_entropy"]
+    # get label quality score with single pred_probs
+    label_quality_scores = rank.score_label_quality(
+        labels, pred_probs, method=scoring_method, adj_pred_probs=True
+    )
 
-    for method in scoring_methods:
+    # get ensemble label quality score
+    label_quality_scores_ensemble = rank.score_label_quality_ensemble(
+        labels, pred_probs_list, method=scoring_method, adj_pred_probs=True
+    )
 
-        # get label quality score with single pred_probs
-        label_quality_scores = rank.score_label_quality(
-            labels, pred_probs, method=method, adj_pred_probs=True
-        )
-
-        # get ensemble label quality score
-        label_quality_scores_ensemble = rank.score_label_quality_ensemble(
-            labels, pred_probs_list, method=method, adj_pred_probs=True
-        )
-
-        # if all pred_probs in the list are the same, then ensemble score should be the same as the regular score
-        # account for small precision error due to averaging of scores
-        assert (abs(label_quality_scores - label_quality_scores_ensemble) < 1e-6).all()
+    # if all pred_probs in the list are the same, then ensemble score should be the same as the regular score
+    # account for small precision error due to averaging of scores
+    assert (abs(label_quality_scores - label_quality_scores_ensemble) < 1e-6).all()

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -188,10 +188,10 @@ def test_order_label_issues_using_scoring_func_ranking():
             labels=data["labels"],
             pred_probs=data["pred_probs"],
             rank_by=method,
-            adj_pred_probs=True,  # adjust predicted probabilities by subtracting class thresholds (as defined in confident learning paper)
+            adj_pred_probs=False,  # adjust predicted probabilities by subtracting class thresholds (as defined in confident learning paper)
         )
         scores = rank.score_label_quality(
-            data["labels"], data["pred_probs"], method=method, adj_pred_probs=True
+            data["labels"], data["pred_probs"], method=method, adj_pred_probs=False
         )
         indices = np.arange(len(scores))[data["label_errors_mask"]]
         scores = scores[data["label_errors_mask"]]

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -233,3 +233,31 @@ def test_subtract_confident_thresholds():
     assert (
         abs(1 - pred_probs_adj.sum(axis=1)) < 1e-6
     ).all()  # all pred_prob sum to 1 with some small precision error
+
+
+def test_ensemble_scoring_func():
+
+    labels = data["labels"]
+    pred_probs = data["pred_probs"]
+
+    # baseline scenario where all the pred_probs are the same
+    n = 3
+    pred_probs_list = list(np.repeat([pred_probs], n, axis=0))
+
+    # test all scoring methods with the scoring function and setting adj_pred_probs=True
+    scoring_methods = ["self_confidence", "normalized_margin", "confidence_weighted_entropy"]
+
+    for method in scoring_methods:
+
+        # get label quality score with single pred_probs
+        label_quality_scores = rank.score_label_quality(
+            labels, pred_probs, method=method, adj_pred_probs=True
+        )
+
+        # get ensemble label quality score
+        label_quality_scores_ensemble = rank.score_label_quality_ensemble(
+            labels, pred_probs_list, method=method, adj_pred_probs=True
+        )
+
+        # if all pred_probs in the list are the same, then ensemble score should be the same as the regular score
+        assert label_quality_scores == label_quality_scores_ensemble

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -241,8 +241,8 @@ def test_ensemble_scoring_func():
     pred_probs = data["pred_probs"]
 
     # baseline scenario where all the pred_probs are the same in the ensemble list
-    n = 3
-    pred_probs_list = list(np.repeat([pred_probs], n, axis=0))
+    num_repeat = 3
+    pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
 
     # test all scoring methods with the scoring function and setting adj_pred_probs=True
     scoring_methods = ["self_confidence", "normalized_margin", "confidence_weighted_entropy"]
@@ -260,4 +260,5 @@ def test_ensemble_scoring_func():
         )
 
         # if all pred_probs in the list are the same, then ensemble score should be the same as the regular score
-        assert (label_quality_scores == label_quality_scores_ensemble).all()
+        # account for small precision error due to averaging of scores
+        assert (abs(label_quality_scores - label_quality_scores_ensemble) < 1e-6).all()

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -188,10 +188,10 @@ def test_order_label_issues_using_scoring_func_ranking():
             labels=data["labels"],
             pred_probs=data["pred_probs"],
             rank_by=method,
-            adj_pred_probs=False,  # adjust predicted probabilities by subtracting class thresholds (as defined in confident learning paper)
+            adj_pred_probs=True,  # adjust predicted probabilities by subtracting class thresholds (as defined in confident learning paper)
         )
         scores = rank.score_label_quality(
-            data["labels"], data["pred_probs"], method=method, adj_pred_probs=False
+            data["labels"], data["pred_probs"], method=method, adj_pred_probs=True
         )
         indices = np.arange(len(scores))[data["label_errors_mask"]]
         scores = scores[data["label_errors_mask"]]

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -229,7 +229,7 @@ def test_subtract_confident_thresholds():
     # subtract confident class thresholds and renormalize
     pred_probs_adj = rank.subtract_confident_thresholds(labels, pred_probs)
 
-    assert (pred_probs_adj > 0).all()  # all pred_prob are positive numbers
-    assert (
+    assert all(pred_probs_adj > 0)  # all pred_prob are positive numbers
+    assert all(
         abs(1 - pred_probs_adj.sum(axis=1)) < 1e-6
-    ).all()  # all pred_prob sum to 1 with some small precision error
+    )  # all pred_prob sum to 1 with some small precision error

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -160,3 +160,18 @@ def test_order_label_issues_using_self_confidence_ranking():
     score_idx = sorted(list(zip(scores, indices)), key=lambda y: y[0])  # sort indices by score
     label_issues_indices2 = [z[1] for z in score_idx]
     assert all(label_issues_indices == label_issues_indices2)
+
+
+def test_order_label_issues_using_confidence_weighted_entropy_ranking():
+    label_issues_indices = rank.order_label_issues(
+        label_issues_mask=data["label_errors_mask"],
+        labels=data["labels"],
+        pred_probs=data["pred_probs"],
+        rank_by="confidence_weighted_entropy",
+    )
+    scores = rank.get_confidence_weighted_entropy_for_each_label(data["labels"], data["pred_probs"])
+    indices = np.arange(len(scores))[data["label_errors_mask"]]
+    scores = scores[data["label_errors_mask"]]
+    score_idx = sorted(list(zip(scores, indices)), key=lambda y: y[0])  # sort indices by score
+    label_issues_indices2 = [z[1] for z in score_idx]
+    assert all(label_issues_indices == label_issues_indices2)

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -240,7 +240,7 @@ def test_ensemble_scoring_func():
     labels = data["labels"]
     pred_probs = data["pred_probs"]
 
-    # baseline scenario where all the pred_probs are the same
+    # baseline scenario where all the pred_probs are the same in the ensemble list
     n = 3
     pred_probs_list = list(np.repeat([pred_probs], n, axis=0))
 
@@ -260,4 +260,4 @@ def test_ensemble_scoring_func():
         )
 
         # if all pred_probs in the list are the same, then ensemble score should be the same as the regular score
-        assert label_quality_scores == label_quality_scores_ensemble
+        assert (label_quality_scores == label_quality_scores_ensemble).all()

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -188,7 +188,9 @@ def test_order_label_issues_using_scoring_func_ranking():
             labels=data["labels"],
             pred_probs=data["pred_probs"],
             rank_by=method,
-            adj_pred_probs=True,  # adjust predicted probabilities by subtracting class thresholds (as defined in confident learning paper)
+            rank_by_kwargs={
+                "adj_pred_probs": True
+            },  # adjust predicted probabilities by subtracting class thresholds (as defined in confident learning paper)
         )
         scores = rank.score_label_quality(
             data["labels"], data["pred_probs"], method=method, adj_pred_probs=True

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -229,7 +229,7 @@ def test_subtract_confident_thresholds():
     # subtract confident class thresholds and renormalize
     pred_probs_adj = rank.subtract_confident_thresholds(labels, pred_probs)
 
-    assert all(pred_probs_adj > 0)  # all pred_prob are positive numbers
-    assert all(
+    assert (pred_probs_adj > 0).all()  # all pred_prob are positive numbers
+    assert (
         abs(1 - pred_probs_adj.sum(axis=1)) < 1e-6
-    )  # all pred_prob sum to 1 with some small precision error
+    ).all()  # all pred_prob sum to 1 with some small precision error

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -220,3 +220,16 @@ def test_order_label_issues_using_scoring_func_adj_pred_probs_ranking():
         score_idx = sorted(list(zip(scores, indices)), key=lambda y: y[0])  # sort indices by score
         label_issues_indices2 = [z[1] for z in score_idx]
         assert all(label_issues_indices == label_issues_indices2)
+
+
+def test_subtract_confident_thresholds():
+    labels = data["labels"]
+    pred_probs = data["pred_probs"]
+
+    # subtract confident class thresholds and renormalize
+    pred_probs_adj = rank.subtract_confident_thresholds(labels, pred_probs)
+
+    assert (pred_probs_adj > 0).all()  # all pred_prob are positive numbers
+    assert (
+        abs(1 - pred_probs_adj.sum(axis=1)) < 1e-6
+    ).all()  # all pred_prob sum to 1 with some small precision error

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -149,6 +149,8 @@ def test_order_label_issues_using_scoring_func_ranking(scoring_method_func, adju
     method, scoring_func = scoring_method_func
 
     # check if method supports adjust_pred_probs
+    # do not run the test below if the method does not support adjust_pred_probs
+    # confidence_weighted_entropy scoring method does not support adjust_pred_probs
     if not (adjust_pred_probs == True and method == "confidence_weighted_entropy"):
 
         indices = np.arange(len(data["label_errors_mask"]))[
@@ -220,6 +222,8 @@ def test_ensemble_scoring_func(method, adjust_pred_probs, weight_ensemble_member
     pred_probs = data["pred_probs"]
 
     # check if method supports adjust_pred_probs
+    # do not run the test below if the method does not support adjust_pred_probs
+    # confidence_weighted_entropy scoring method does not support adjust_pred_probs
     if not (adjust_pred_probs == True and method == "confidence_weighted_entropy"):
 
         # baseline scenario where all the pred_probs are the same in the ensemble list

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -161,7 +161,7 @@ def test_order_label_issues_using_scoring_func_ranking(scoring_method_func, adj_
     )
 
     # test scoring function with scoring method passed as arg
-    scores = rank.score_label_quality(
+    scores = rank.get_label_quality_scores(
         data["labels"],
         data["pred_probs"],
         method=method,
@@ -219,12 +219,12 @@ def test_ensemble_scoring_func(method, adj_pred_probs, weight_ensemble_members_b
     pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
 
     # get label quality score with single pred_probs
-    label_quality_scores = rank.score_label_quality(
+    label_quality_scores = rank.get_label_quality_scores(
         labels, pred_probs, method=method, adj_pred_probs=adj_pred_probs
     )
 
     # get ensemble label quality score
-    label_quality_scores_ensemble = rank.score_label_quality_ensemble(
+    label_quality_scores_ensemble = rank.get_label_quality_ensemble_scores(
         labels,
         pred_probs_list,
         method=method,
@@ -249,7 +249,7 @@ def test_bad_weight_ensemble_members_by_parameter_error():
         num_repeat = 3
         pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
 
-        _ = rank.score_label_quality_ensemble(
+        _ = rank.get_label_quality_ensemble_scores(
             labels,
             pred_probs_list,
             weight_ensemble_members_by="not_a_real_method",  # this should raise ValueError
@@ -269,7 +269,7 @@ def test_bad_pred_probs_list_parameter_error():
         )  # this should be a list not an array
 
         # AssertionError because pred_probs_list is an array
-        _ = rank.score_label_quality_ensemble(labels, pred_probs_list)
+        _ = rank.get_label_quality_ensemble_scores(labels, pred_probs_list)
 
         # AssertionError because pred_probs_list is empty
-        _ = rank.score_label_quality_ensemble(labels=labels, pred_probs_list=[])
+        _ = rank.get_label_quality_ensemble_scores(labels=labels, pred_probs_list=[])

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -237,3 +237,20 @@ def test_ensemble_scoring_func(method, adj_pred_probs, weight_ensemble_members_b
     assert (
         abs(label_quality_scores - label_quality_scores_ensemble) < 1e-6
     ).all(), f"Test failed with scoring method: {method}"
+
+
+def test_bad_weight_ensemble_members_by_parameter_error():
+    with pytest.raises(ValueError) as e:
+
+        labels = data["labels"]
+        pred_probs = data["pred_probs"]
+
+        # baseline scenario where all the pred_probs are the same in the ensemble list
+        num_repeat = 3
+        pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
+
+        _ = rank.score_label_quality_ensemble(
+            labels,
+            pred_probs_list,
+            weight_ensemble_members_by="not_a_real_method",  # this should raise ValueError
+        )

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -199,14 +199,14 @@ def test_subtract_confident_thresholds():
 
 
 @pytest.mark.parametrize(
-    "scoring_method",
+    "method",
     [
         "self_confidence",
         "normalized_margin",
         "confidence_weighted_entropy",
     ],
 )
-def test_ensemble_scoring_func(scoring_method):
+def test_ensemble_scoring_func(method):
 
     labels = data["labels"]
     pred_probs = data["pred_probs"]
@@ -217,14 +217,16 @@ def test_ensemble_scoring_func(scoring_method):
 
     # get label quality score with single pred_probs
     label_quality_scores = rank.score_label_quality(
-        labels, pred_probs, method=scoring_method, adj_pred_probs=True
+        labels, pred_probs, method=method, adj_pred_probs=True
     )
 
     # get ensemble label quality score
     label_quality_scores_ensemble = rank.score_label_quality_ensemble(
-        labels, pred_probs_list, method=scoring_method, adj_pred_probs=True
+        labels, pred_probs_list, method=method, adj_pred_probs=True
     )
 
     # if all pred_probs in the list are the same, then ensemble score should be the same as the regular score
     # account for small precision error due to averaging of scores
-    assert (abs(label_quality_scores - label_quality_scores_ensemble) < 1e-6).all()
+    assert (
+        abs(label_quality_scores - label_quality_scores_ensemble) < 1e-6
+    ).all(), f"Test failed with scoring method: {method}"


### PR DESCRIPTION
This PR adds new label quality scoring capabilities:

- Add "confidence_weighted_entropy" as new label quality score that performed well in internal benchmarks to detect label issues.
- Add option for users to adjust pred_probs by subtracting class thresholds (as defined in confident learning paper) and renormalizing. This improved label issue detection in internal benchmarks.
- Add user API to score label quality by choosing the scoring method.
- Add user API to score label quality for ensemble models where we have a list of pred_probs.
- Add rank_by_kwargs dict to accept keyword args for find_label_issues() and order_label_issues(). This allows us to pass the optional adj_pred_probs arg to adjust pred_probs by subtracting class thresholds. This also allows us to add more optional args in the future for scoring and ranking.

This PR also includes:

- New tests for CI to test the new label quality scoring functions
- Refactor order_label_issues()

**Context:**

Originally was planning to add more scores from the internal benchmark study. However, it was decided that we would exclude the active learning scores for now due to poor performance in internal benchmarks. We can create a separate PR in the future to add the active learning scores.