### PR TITLE
Change cleanlab version in Image Tutorial

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -48,6 +48,33 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install -r docs/requirements.txt
 
+      - name: Find and replace "%pip install cleanlab" with master branch in .ipynb files
+        if: ${{ github.ref_type == 'branch' }}
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: "%pip install cleanlab  ${{ '#' }} for colab"
+          replace: "%pip install git+https://github.com/${{ github.repository }}.git@${{ github.sha }}"
+          include: "docs/source**.ipynb"
+
+      - name: Find and replace "%pip install cleanlab" with release tag in .ipynb files
+        if: ${{ github.ref_type == 'tag' }}
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: "%pip install cleanlab  ${{ '#' }} for colab"
+          replace: "%pip install cleanlab==${{ github.ref_name }}"
+          include: "docs/source**.ipynb"
+
+      - name: Add and Commit changes to .ipynb files
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add -A && git commit -m "Change cleanlab ver in .ipynb files"
+          
+      - name: Change tag to the latest commit
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          git tag -f $GITHUB_REF_NAME
+
       - name: Run Sphinx with sphinx-multiversion wrapper - branch trigger
         if: ${{ github.ref_type == 'branch' }}
         run: sphinx-multiversion docs/source cleanlab-docs -D smv_branch_whitelist=${{ github.ref_name }} -D smv_tag_whitelist=None

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+jinja2==3.0.3
 sphinx==4.4.0
 nbsphinx==0.8.8
 autodocsumm==0.2.7

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,7 +118,7 @@ if gh_env_file is not None:
     with open(gh_env_file, "a") as f:
         f.write(f"\nDOCS_SITE_URL={DOCS_SITE_URL}")  # Set to Environment Var
 
-GITHUB_REPOSITORY = os.getenv("GITHUB_REPOSITORY") or "cleanlab/cleanlab"
+GITHUB_REPOSITORY_OWNER = os.getenv("GITHUB_REPOSITORY_OWNER") or "cleanlab"
 GITHUB_REF_NAME = os.getenv("GITHUB_REF_NAME") or "master"
 
 # Pass additional variables to Jinja templates
@@ -153,10 +153,10 @@ nbsphinx_prolog = (
             h1_element[0].insertAdjacentHTML("afterend", `
             <p>
                 <a style="background-color:white;color:black;padding:4px 12px;text-decoration:none;display:inline-block;border-radius:8px;box-shadow:0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 3px 10px 0 rgba(0, 0, 0, 0.19)" href="https://colab.research.google.com/github/"""
-    + GITHUB_REPOSITORY
-    + """/blob/"""
+    + GITHUB_REPOSITORY_OWNER
+    + """/cleanlab-docs/blob/master/"""
     + GITHUB_REF_NAME
-    + """/docs/source/{{ docname|e }}" target="_blank">
+    + """/{{ docname|e }}" target="_blank">
                 <img src="https://colab.research.google.com/img/colab_favicon_256px.png" alt="Google Colab Logo" style="width:40px;height:40px;vertical-align:middle">
                 <span style="vertical-align:middle">Run in Google Colab</span>
                 </a>
@@ -169,7 +169,6 @@ nbsphinx_prolog = (
 )
 
 # Change this to "always" before running in the doc's CI/CD server
-nbsphinx_execute = "never"
 if os.getenv("CI"):
     nbsphinx_execute = "always"
 

--- a/docs/source/notebooks/Image_Tut.ipynb
+++ b/docs/source/notebooks/Image_Tut.ipynb
@@ -17,9 +17,9 @@
     "\n",
     "- Build a simple PyTorch neural net and wrap it with Skorch to make it scikit-learn compatible.\n",
     "\n",
-    "- Compute the out-of-sample predicted probabilities, `psx`, via cross-validation.\n",
+    "- Compute the out-of-sample predicted probabilities, `pred_probs`, via cross-validation.\n",
     "\n",
-    "- Generate a list of potential label errors with Cleanlab's `get_noise_indices`.\n"
+    "- Generate a list of potential label errors with Cleanlab's `find_label_issues`.\n"
    ]
   },
   {
@@ -51,25 +51,12 @@
    },
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "\n",
-    "%pip install --force-reinstall cleanlab==1.0.1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
     "dependencies = [\"cleanlab\", \"pandas\", \"matplotlib\", \"torch\", \"torchvision\", \"skorch\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install cleanlab pandas matplotlib torch torchvision skorch\n",
+    "    %pip install cleanlab  # for colab\n",
+    "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
+    "    %pip install $cmd\n",
     "else:\n",
     "    missing_dependencies = []\n",
     "    for dependency in dependencies:\n",
@@ -81,7 +68,7 @@
     "    if len(missing_dependencies) > 0:\n",
     "        print(\"Missing required dependencies:\")\n",
     "        print(*missing_dependencies, sep=\", \")\n",
-    "        print(\"\\nPlease install them before running the rest of this notebook.\")"
+    "        print(\"\\nPlease install them before running the rest of this notebook.\")\n"
    ]
   },
   {
@@ -104,7 +91,7 @@
     "X = mnist.data.astype(\"float32\").to_numpy()  # 2D numpy array of image features\n",
     "X /= 255.0  # Scale the features to the [0, 1] range\n",
     "\n",
-    "y = mnist.target.astype(\"int64\").to_numpy()  # 1D numpy array of the image labels"
+    "y = mnist.target.astype(\"int64\").to_numpy()  # 1D numpy array of the image labels\n"
    ]
   },
   {
@@ -147,7 +134,7 @@
     "    nn.Dropout(0.5),\n",
     "    nn.Linear(128, 10),\n",
     "    nn.Softmax(dim=-1),\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -172,7 +159,7 @@
    "source": [
     "from skorch import NeuralNetClassifier\n",
     "\n",
-    "model_skorch = NeuralNetClassifier(model)"
+    "model_skorch = NeuralNetClassifier(model)\n"
    ]
   },
   {
@@ -186,7 +173,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we'd like Cleanlab to identify potential label errors in the whole dataset and not just the training set, we can consider using the entire dataset when computing the out-of-sample predicted probabilities, `psx`, via cross-validation.\n"
+    "If we'd like Cleanlab to identify potential label errors in the whole dataset and not just the training set, we can consider using the entire dataset when computing the out-of-sample predicted probabilities, `pred_probs`, via cross-validation.\n"
    ]
   },
   {
@@ -197,7 +184,7 @@
    "source": [
     "from sklearn.model_selection import cross_val_predict\n",
     "\n",
-    "psx = cross_val_predict(model_skorch, X, y, cv=3, method=\"predict_proba\")"
+    "pred_probs = cross_val_predict(model_skorch, X, y, cv=3, method=\"predict_proba\")\n"
    ]
   },
   {
@@ -211,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Cleanlab has a `get_noise_indices` function to generate a list of potential label errors. Setting `sorted_index_method=\"prob_given_label\"` returns the indices of all the most likely label errors, sorted by the most suspicious example first.\n"
+    "Cleanlab has a `find_label_issues` function to generate a list of potential label errors. Setting `return_indices_ranked_by=\"self_confidence\"` returns the indices of all the most likely label errors, sorted by the most suspicious example first.\n"
    ]
   },
   {
@@ -220,11 +207,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cleanlab.pruning import get_noise_indices\n",
+    "from cleanlab.filter import find_label_issues\n",
     "\n",
-    "ordered_label_errors = get_noise_indices(\n",
-    "    s=y, psx=psx, sorted_index_method=\"prob_given_label\"\n",
-    ")"
+    "ranked_label_issues = find_label_issues(y, pred_probs, return_indices_ranked_by=\"self_confidence\")\n"
    ]
   },
   {
@@ -240,10 +225,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"Cleanlab found {len(ordered_label_errors)} potential label errors.\")\n",
-    "print(\n",
-    "    f\"Here are the indices of the top 15 most likely ones: \\n {ordered_label_errors[:15]}\"\n",
-    ")"
+    "print(f\"Cleanlab found {len(ranked_label_issues)} potential label errors.\")\n",
+    "print(f\"Here are the indices of the top 15 most likely ones: \\n {ranked_label_issues[:15]}\")\n"
    ]
   },
   {
@@ -279,7 +262,7 @@
     "        plt.title(f\"id: {id} \\n label: {y[id]}\")\n",
     "        plt.axis(\"off\")\n",
     "\n",
-    "    plt.tight_layout(h_pad=2.0)"
+    "    plt.tight_layout(h_pad=2.0)\n"
    ]
   },
   {
@@ -304,7 +287,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_examples(ordered_label_errors[range(15)], 3, 5)"
+    "plot_examples(ranked_label_issues[range(15)], 3, 5)\n"
    ]
   },
   {
@@ -327,7 +310,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_examples([59915])"
+    "plot_examples([59915])\n"
    ]
   },
   {
@@ -343,7 +326,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_examples([24798])"
+    "plot_examples([24798])\n"
    ]
   },
   {
@@ -359,7 +342,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_examples([18598, 1352, 61247], 1, 3)"
+    "plot_examples([18598, 1352, 61247], 1, 3)\n"
    ]
   },
   {


### PR DESCRIPTION
This PR introduces:

1. Updated Image Tutorial using `cleanlab`'s latest API (AKA the upcoming v2.0.0 API)
2. Additional steps and conditions in the CI workflow (`gh-pages.yaml`) to dynamically install different versions of `cleanlab` in the .ipynb notebooks based on whether it is triggered by a push to `master` branch or a new release.
3. The Colab hyperlink in the tutorial will now link to the executed version of the notebook from the `cleanlab-docs` repo.
3. Fix the `cannot import name 'escape' from 'jinja2'` [issue](https://github.com/pallets/jinja/issues/1626).