### PR TITLE
Fix NumPy deprecation warning

### DIFF
--- a/tests/test_model_pytorch_cnn.py
+++ b/tests/test_model_pytorch_cnn.py
@@ -27,8 +27,10 @@ if python_version.is_compatible():
     # Get sklearn digits data labels
     _, y_all = load_digits(return_X_y=True)
     # PyTorch requires type long targets.
-    y_train = y_all[:-SKLEARN_DIGITS_TEST_SIZE].astype(np.long)
-    true_labels_test = y_all[-SKLEARN_DIGITS_TEST_SIZE:].astype(np.long)
+    print(y_all)
+    print(type(y_all))
+    y_train = y_all[:-SKLEARN_DIGITS_TEST_SIZE].astype(np.int32)
+    true_labels_test = y_all[-SKLEARN_DIGITS_TEST_SIZE:].astype(np.int32)
 
 
 def test_loaders(


### PR DESCRIPTION
`np.long` was deprecated in NumPy 1.20, and this was making the test output noisy with deprecation warnings. This patch replaces the type with `np.int32` (the labels are 0--9).