### PR TITLE
Update doc site quickstart page to reflect v2.0 API

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,9 +1,9 @@
 cleanlab documentation
 ======================
 
-`cleanlab <https://github.com/cleanlab/cleanlab>`_ **automatically finds and fixes errors in your ML datasets.**
+`cleanlab <https://github.com/cleanlab/cleanlab>`_ **automatically finds and fixes label issues in your ML datasets.**
 
-| This reduces manual work needed to fix data issues and helps train reliable ML models on noisy real-world datasets. ``cleanlab`` has already found thousands of `label errors <https://labelerrors.com>`_ in ImageNet, MNIST, and other popular ML benchmarking datasets, so let's get started with yours!
+| This reduces manual work needed to fix data errors and helps train reliable ML models on noisy real-world datasets. ``cleanlab`` has already found thousands of `label errors <https://labelerrors.com>`_ in ImageNet, MNIST, and other popular ML benchmarking datasets, so let's get started with yours!
 
 Quickstart
 ==========
@@ -35,31 +35,31 @@ Quickstart
 2. Find label errors with ``find_label_issues``.
 ------------------------------------------------
 
-``cleanlab``'s ``find_label_issues`` function tells you which examples in your dataset are likely mislabeled. At a minimum, it expects two inputs - your data's given labels, ``y``, and predicted probabilities, ``pyx``, from some trained model (Note: these must be out-of-sample predictions where the data points were held out from the model during training, which can be obtained via cross-validation).
+``cleanlab``'s ``find_label_issues`` function tells you which examples in your dataset are likely mislabeled. At a minimum, it expects two inputs - your data's given labels, ``y``, and predicted probabilities, ``pred_probs``, from some trained model (Note: these must be out-of-sample predictions where the data points were held out from the model during training, which can be obtained via cross-validation).
 
-Setting ``sorted_index_method`` instructs ``cleanlab`` to return the indices of potential mislabeled examples, ordered by the likelihood of label error estimate via ``self_confidence`` scores (predicted probability of given label according to the model).
+Setting ``return_indices_ranked_by`` instructs ``cleanlab`` to return the indices of potential mislabeled examples, ordered by the likelihood of label error estimate via ``self_confidence`` scores (predicted probability of given label according to the model).
 
 .. code-block:: python
 
    from cleanlab.pruning import find_label_issues
 
    ordered_label_issues = find_label_issues(
-      s=y, 
-      pred_probs=pyx,
-      sorted_index_method='self_confidence')
+      labels=y, 
+      pred_probs=pred_probs,
+      return_indices_ranked_by='self_confidence')
 
 .. important::
-   The predicted probabilities, ``psx``, from your model **must be out-of-sample**! You should never provide predictions on the same data points used to train the model - this would reflect predictions of an overfitted model, making it unsuitable for finding label errors. To compute the out-of-sample predicted probabilities of the entire dataset, you can use cross-validation.
+   The predicted probabilities, ``pred_probs``, from your model **must be out-of-sample**! You should never provide predictions on the same data points used to train the model - this would reflect predictions of an overfitted model, making it unsuitable for finding label errors. To compute the out-of-sample predicted probabilities of the entire dataset, you can use cross-validation.
 
 ..
-   todo - include the url for tf and torch beginner tutorials
+   TODO - include the url for tf and torch beginner tutorials
 
 3. Train robust models with noisy labels using ``LearningWithNoisyLabels``.
 ---------------------------------------------------------------------------
 
-``cleanlab``'s ``LearningWithNoisyLabels`` adapts any classification model, ``clf``, to a more reliable one by allowing it to train directly on partially mislabeled datasets. 
+``cleanlab``'s ``LearningWithNoisyLabels`` adapts any existing (scikit-learn compatible) classification model, ``clf``, to a more reliable one by allowing it to train directly on partially mislabeled datasets. 
 
-When the ``.fit()`` method is called, it automatically identifies and removes any examples that are deemed "noisy" in the provided dataset before returning a final trained model.
+When the ``.fit()`` method is called, it automatically removes any examples identified as "noisy" in the provided dataset and returns a model trained only on the clean data.
 
 .. code-block:: python
 
@@ -68,7 +68,7 @@ When the ``.fit()`` method is called, it automatically identifies and removes an
 
    clf = LogisticRegression() # Here we've used sklearn's Logistic Regression model, but this can be any classifier that implements sklearn's API.
    lnl = LearningWithNoisyLabels(clf=clf)
-   lnl.fit(X=X, s=y)
+   lnl.fit(X=X, labels=y)
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
This PR updates the doc's site quickstart page to reflect the v2.0 API. 