### PR TITLE
Fix sklearn estimator cloning

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -31,8 +31,8 @@
 from sklearn.linear_model import LogisticRegression as LogReg
 from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import confusion_matrix
+import sklearn.base
 import numpy as np
-import copy
 
 from cleanlab.internal.util import (
     value_counts,
@@ -650,7 +650,7 @@ def estimate_confident_joint_and_cv_pred_proba(
 
     # Split X and labels into "cv_n_folds" stratified folds.
     for k, (cv_train_idx, cv_holdout_idx) in enumerate(kf.split(X, labels)):
-        clf_copy = copy.deepcopy(clf)
+        clf_copy = sklearn.base.clone(clf)
 
         # Select the training and holdout cross-validated sets.
         X_train_cv, X_holdout_cv = X[cv_train_idx], X[cv_holdout_idx]


### PR DESCRIPTION
Arbitrary scikit-learn estimators are not safe to clone via `copy.deepcopy()`, for example when they contain state that cannot be pickled, such as a Keras model that contains a `_thread.RLock` [[1]]. The correct way to clone an estimator is to use `sklearn.base.clone()` [[2]], which constructs a new unfitted estimator with the same parameters as the original by calling `get_params()` followed by creating a new object of the class, passing the parameters to `__init__()`. This patch switches from `copy.deepcopy` to `sklearn.base.clone`.

This patch also updates the MNIST PyTorch CNN example model to be compatible with `sklearn.base.clone`. Writing a custom `get_params` implementation usually wouldn't be necessary with a more standard estimator that inherits from `BaseEstimator`, but it was necessary to override the method in this case because of the nonstandard implementation that supports multiple datasets and does data loading within the estimator itself based on the `dataset` argument.

[1]: https://github.com/cleanlab/cleanlab/issues/87
[2]: https://scikit-learn.org/stable/modules/generated/sklearn.base.clone.html
