### PR TITLE
Remove unnecessary print statement

### DIFF
--- a/tests/test_model_pytorch_cnn.py
+++ b/tests/test_model_pytorch_cnn.py
@@ -27,8 +27,6 @@ if python_version.is_compatible():
     # Get sklearn digits data labels
     _, y_all = load_digits(return_X_y=True)
     # PyTorch requires type long targets.
-    print(y_all)
-    print(type(y_all))
     y_train = y_all[:-SKLEARN_DIGITS_TEST_SIZE].astype(np.int32)
     true_labels_test = y_all[-SKLEARN_DIGITS_TEST_SIZE:].astype(np.int32)
 


### PR DESCRIPTION
This was accidentally included in 0a6b55b32312875f2acaad644ecec2ca7e2b3993.