### PR TITLE
Add explanation that estimators must be clonable

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -31,6 +31,12 @@ contains the contains targets formatted as ``0, 1, 2, ..., K-1``, and
 ``sample_weight`` (of length *n*) re-weights examples in the loss function while
 training.
 
+Furthermore, your estimator should be correctly clonable via
+`sklearn.base.clone`: cleanlab internally creates multiple instances of your
+estimator, and if you e.g. manually wrap a PyTorch model, you must ensure that
+every call to your estimator's `__init__()` creates an independent instance of
+the model.
+
 Note
 ----
 There are two new notions of confidence in this package:


### PR DESCRIPTION
Inspired by [[1]] and similar examples. See also: the pull request that switches from `copy.deepcopy` to `sklearn.base.clone` [[2]]. Even the latter calls `sklearn.base.clone(..., safe=False)` on the values returned by `get_params()`, so the user has to be sure that their model is correctly clonable, otherwise they may get silently incorrect behavior.

[1]: https://github.com/cleanlab/cleanlab/issues/87
[2]: https://github.com/cleanlab/cleanlab/pull/144
