### PR TITLE
Allow n-dim data in LearningWithNoisyLabels

### DIFF
--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -54,6 +54,7 @@ def assert_inputs_are_valid(X, s, pred_probs=None):  # pragma: no cover
         dtype=None,
         force_all_finite=False,
         ensure_2d=False,
+        allow_nd=True,
     )
 
 


### PR DESCRIPTION
LearningWithNoisyLabels used `sklearn.utils.check_X_y` to enforce that `X` was 2D, to be in line with what sklearn's standard estimators expect. However, LearningWithNoisyLabels is dataset-agnostic: it doesn't look at the data points themselves. If the underlying classifier supports data in a different shape, there's no reason LearningWithNoisyLabels should prohibit it. Users have requested that we relax this unnecessary restriction [[1]] so LearningWithNoisyLabels will more naturally support e.g. image datasets and CNN models.

Thanks to @kothari1997narayan for suggesting this change.

[1]: https://github.com/cleanlab/cleanlab/issues/86