### PR TITLE
Improve user-control

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -312,7 +312,7 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
         self.K = len(np.unique(labels))
         if len(labels) / self.K < self.cv_n_folds:
             raise ValueError(
-                "Need more data from each class for cross-validation."
+                "Need more data from each class for cross-validation. "
                 "Try decreasing `cv_n_folds` (eg. to 2,3) in LearningWithNoisyLabels()"
             )
         # 'ps' is p(labels=k)

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -103,7 +103,6 @@ to the classifier during training. `labels` denotes the noisy label instead of
 \\tilde(y) (used in confident learning paper), for ASCII encoding reasons.
 """
 
-from copy import deepcopy
 from sklearn.linear_model import LogisticRegression as LogReg
 from sklearn.metrics import accuracy_score
 from sklearn.base import BaseEstimator
@@ -305,7 +304,7 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
 
         self._process_label_issues_kwargs(find_label_issues_kwargs)
         clf_final_kwargs = {**clf_kwargs, **clf_final_kwargs}
-        self.clf_kwargs = deepcopy(clf_kwargs)
+        self.clf_kwargs = clf_kwargs
         self.clf_final_kwargs = clf_final_kwargs
 
         # Number of classes

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -683,12 +683,6 @@ def estimate_confident_joint_and_cv_pred_proba(
             )
             for missing_class in missing_classes:
                 holdout_inds = np.where(s_holdout_cv == missing_class)[0]
-                if (
-                    len(holdout_inds) == 0
-                ):  # should never be in this situation but raise Error just in case:
-                    raise ValueError(
-                        f"Cannot run on this dataset, it needs more examples from class: {missing_class}"
-                    )
                 # Duplicate one instance of missing_class from holdout data to the training data:
                 dup_ind = holdout_inds[0]
                 s_train_cv = np.append(s_train_cv, s_holdout_cv[dup_ind])

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -93,7 +93,7 @@ def num_label_issues(
 
     Returns
     -------
-        An integer estimate the number of label issues."""
+        An integer estimate of the number of label issues."""
 
     if confident_joint is None:
         confident_joint = compute_confident_joint(labels=labels, pred_probs=pred_probs)

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -23,6 +23,12 @@ of the dataset you choose (including the entire dataset) and provide a `label qu
 every example. You can then do something like: `np.argsort(label_quality_score)` to obtain ranked
 indices of individual data.
 
+CAUTION: These label quality scores are computed based on `pred_probs` from your model that must be out-of-sample!
+You should never provide predictions on the same datapoints used to train the model,
+as these will be overfit and unsuitable for finding label-errors.
+To obtain out-of-sample predicted probabilities for every datapoint in your dataset, you can use cross-validation.
+Alternatively it is ok if your model was trained on a separate dataset and you are only evaluating
+labels in data that was previously held-out.
 """
 
 
@@ -119,7 +125,13 @@ def get_label_quality_scores(
       Each row of this matrix corresponds to an example x and contains the model-predicted
       probabilities that x belongs to each possible class.
       The columns must be ordered such that these probabilities correspond to class 0,1,2,...
-      `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
+      
+      CAUTION: `pred_probs` from your model must be out-of-sample!
+      You should never provide predictions on the same datapoints used to train the model,
+      as these will be overfit and unsuitable for finding label-errors.
+      To obtain out-of-sample predicted probabilities for every datapoint in your dataset, you can use cross-validation.
+      Alternatively it is ok if your model was trained on a separate dataset and you are only evaluating
+      labels in data that was previously held-out.
 
     method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="self_confidence"
       Label quality scoring method.
@@ -232,7 +244,7 @@ def get_label_quality_ensemble_scores(
     pred_probs_list : List of np.array (shape (N, K))
       Each element in this list should be an array of pred_probs in the same format
       expected by the `get_label_quality_scores()` method.
-      Each element of pred_probs_list corresponds to the predictions from one model for all datapoints.
+      Each element of `pred_probs_list` corresponds to the predictions from one model for all datapoints.
 
     method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="self_confidence"
       Label quality scoring method. Default is "self_confidence".

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -125,7 +125,7 @@ def get_label_quality_scores(
       Each row of this matrix corresponds to an example x and contains the model-predicted
       probabilities that x belongs to each possible class.
       The columns must be ordered such that these probabilities correspond to class 0,1,2,...
-      
+
       CAUTION: `pred_probs` from your model must be out-of-sample!
       You should never provide predictions on the same datapoints used to train the model,
       as these will be overfit and unsuitable for finding label-errors.
@@ -310,7 +310,6 @@ def get_label_quality_ensemble_scores(
             accuracy = (pred_probs.argmax(axis=1) == labels).mean()
             accuracy_list.append(accuracy)
 
-    # Print statements if enabled by verbose
     if verbose:
         print(f"Weighting scheme for ensemble: {weight_ensemble_members_by}")
 
@@ -319,19 +318,12 @@ def get_label_quality_ensemble_scores(
 
     # Aggregate scores with chosen weighting scheme
     if weight_ensemble_members_by == "uniform":
-
-        # Uniform weights (simple average)
-        label_quality_scores = scores_ensemble.mean(axis=1)
+        label_quality_scores = scores_ensemble.mean(axis=1)  # Uniform weights (simple average)
 
     elif weight_ensemble_members_by == "accuracy":
-
-        # Weight by accuracy
-        weights = np.array(accuracy_list) / sum(accuracy_list)
-
+        weights = np.array(accuracy_list) / sum(accuracy_list)  # Weight by relative accuracy
         if verbose:
-            print(
-                "Ensemble members will be weighted by: accuracy of member / (sum of accuracy from all members)"
-            )
+            print("Ensemble members will be weighted by: their relative accuracy")
             for i, acc in enumerate(accuracy_list):
                 print(f"  Model {i} accuracy : {acc}")
                 print(f"  Model {i} weights  : {weights[i]}")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,8 +8,8 @@ cleanlab documentation
 Quickstart
 ==========
 
-1. Install ``cleanlab``.
-------------------------
+1. Install ``cleanlab``
+-----------------------
 
 .. tabs::
 
@@ -32,12 +32,12 @@ Quickstart
          pip install git+https://github.com/cleanlab/cleanlab.git
 
 
-2. Find label errors with ``find_label_issues``.
-------------------------------------------------
+2. Find label errors in your data
+---------------------------------
 
-``cleanlab``'s ``find_label_issues`` function tells you which examples in your dataset are likely mislabeled. At a minimum, it expects two inputs - your data's given labels, ``y``, and predicted probabilities, ``pred_probs``, from some trained model (Note: these must be out-of-sample predictions where the data points were held out from the model during training, which can be obtained via cross-validation).
+``cleanlab``'s ``find_label_issues`` function tells you which examples in your dataset are likely mislabeled. At a minimum, it expects two inputs - your data's given labels, ``y``, and predicted probabilities, ``pred_probs``, from some trained classification model (Note: these must be out-of-sample predictions where the data points were held out from the model during training, which can be obtained via cross-validation).
 
-Setting ``return_indices_ranked_by`` instructs ``cleanlab`` to return the indices of potential mislabeled examples, ordered by the likelihood of label error estimate via ``self_confidence`` scores (predicted probability of given label according to the model).
+Setting ``return_indices_ranked_by`` in this function instructs ``cleanlab`` to return the indices of potential mislabeled examples, ordered by how likely their given label is incorrect. This is estimated via a **label quality score**, which for example can be specified as the ``self_confidence`` (predicted probability of given label according to the model).
 
 .. code-block:: python
 
@@ -49,15 +49,15 @@ Setting ``return_indices_ranked_by`` instructs ``cleanlab`` to return the indice
       return_indices_ranked_by='self_confidence')
 
 .. important::
-   The predicted probabilities, ``pred_probs``, from your model **must be out-of-sample**! You should never provide predictions on the same data points used to train the model - this would reflect predictions of an overfitted model, making it unsuitable for finding label errors. To compute the out-of-sample predicted probabilities of the entire dataset, you can use cross-validation.
+   The predicted probabilities, ``pred_probs``, from your model **must be out-of-sample**! You should never provide predictions on the same data points used to train the model as these predictions are overfit and  unsuitable for finding label errors. To compute out-of-sample predicted probabilities for your entire dataset, you can use cross-validation.
 
 ..
    TODO - include the url for tf and torch beginner tutorials
 
-3. Train robust models with noisy labels using ``LearningWithNoisyLabels``.
----------------------------------------------------------------------------
+3. Train robust models with noisy labels
+----------------------------------------
 
-``cleanlab``'s ``LearningWithNoisyLabels`` adapts any existing (scikit-learn compatible) classification model, ``clf``, to a more reliable one by allowing it to train directly on partially mislabeled datasets. 
+``cleanlab``'s ``LearningWithNoisyLabels`` class adapts any existing (scikit-learn compatible) classification model, ``clf``, to a more reliable one by allowing it to train directly on partially mislabeled datasets. 
 
 When the ``.fit()`` method is called, it automatically removes any examples identified as "noisy" in the provided dataset and returns a model trained only on the clean data.
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -123,8 +123,9 @@ def test_rare_label():
     data = make_rare_label(DATA)
     test_rp(data)
 
+
 def test_invalid_inputs():
-    data = make_data(sparse=False, sizes=[1,1,1])
+    data = make_data(sparse=False, sizes=[1, 1, 1])
     try:
         test_rp(data)
     except Exception as e:
@@ -133,21 +134,32 @@ def test_invalid_inputs():
         rp = LearningWithNoisyLabels(
             clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED)
         )
-        rp.fit(data["X_train"], data["labels"], find_label_issues_kwargs={"return_indices_ranked_by":"self_confidence"})
+        rp.fit(
+            data["X_train"],
+            data["labels"],
+            find_label_issues_kwargs={"return_indices_ranked_by": "self_confidence"},
+        )
     except Exception as e:
         assert "not supported" in str(e)
+
 
 def test_aux_inputs():
     data = DATA
     K = len(np.unique(data["labels"]))
-    confident_joint = np.ones(shape=(K,K))
+    confident_joint = np.ones(shape=(K, K))
     np.fill_diagonal(confident_joint, 10)
     rp = LearningWithNoisyLabels(
-            clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED)
-        )   
-    find_label_issues_kwargs = {"confident_joint":confident_joint, "min_examples_per_class": 2}
-    rp.fit(data["X_train"], data["labels"], find_label_issues_kwargs=find_label_issues_kwargs,
-           clf_kwargs={}, clf_final_kwargs={})
+        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED),
+        verbose=0,
+    )
+    find_label_issues_kwargs = {"confident_joint": confident_joint, "min_examples_per_class": 2}
+    rp.fit(
+        data["X_train"],
+        data["labels"],
+        find_label_issues_kwargs=find_label_issues_kwargs,
+        clf_kwargs={},
+        clf_final_kwargs={},
+    )
     score = rp.score(data["X_test"], data["true_labels_test"])
     assert True
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -130,6 +130,8 @@ def test_invalid_inputs():
         test_rp(data)
     except Exception as e:
         assert "Need more data" in str(e)
+    else:
+        raise Exception("expected test to raise Exception")
     try:
         rp = LearningWithNoisyLabels(
             clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED)
@@ -141,6 +143,8 @@ def test_invalid_inputs():
         )
     except Exception as e:
         assert "not supported" in str(e)
+    else:
+        raise Exception("expected test to raise Exception")
 
 
 def test_aux_inputs():
@@ -161,7 +165,6 @@ def test_aux_inputs():
         clf_final_kwargs={},
     )
     score = rp.score(data["X_test"], data["true_labels_test"])
-    assert True
 
 
 def test_raise_error_no_clf_fit():

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -387,9 +387,10 @@ def test_fit_pred_probs(sparse):
 @pytest.mark.parametrize("sparse", [True, False])
 def test_get_label_issues(sparse):
     data = SPARSE_DATA if sparse else DATA
-    lnl = LearningWithNoisyLabels(n_jobs=1)
+    lnl = LearningWithNoisyLabels()
     lnl.fit(
         X=data["X_train"],
         labels=data["true_labels_train"],
+        find_label_issues_kwargs = {"n_jobs":1, "min_examples_per_class":5}
     )
     assert all((lnl.get_label_issues() == lnl.label_issues_mask))


### PR DESCRIPTION
* Fixes LearningWithNoisyLabels on dataset with rare labels. Should address:
https://github.com/cleanlab/cleanlab/issues/51
https://github.com/cleanlab/cleanlab/issues/91

* Increases flexibility of LearningWithNoisyLabels by optionally allowing any kwarg of `find_label_issues()` to be specified there and passing kwargs into `clf.fit()`. Partially addresses (although full solution is nontrivial):
https://github.com/cleanlab/cleanlab/issues/110

* Adds warnings for edge-cases like when find_label_issues purposefully does not flag some issues in rare classes.

* Improves user-control over many previously hardcoded thresholds and non-settable kwargs throughout.

* Improves documentation language/formatting, with more cautionary statements about out-of-sample pred_probs. 