### PR TITLE
Enable use of find_label_issues_kwargs for hyper-parameter search

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -214,7 +214,6 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
         self.inverse_noise_matrix = None
         self.clf_kwargs = None
         self.clf_final_kwargs = None
-
         self._process_label_issues_kwargs(find_label_issues_kwargs)
 
     def fit(

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -203,6 +203,7 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
         self.cv_n_folds = cv_n_folds
         self.converge_latent_estimates = converge_latent_estimates
         self.pulearning = pulearning
+        self.find_label_issues_kwargs = find_label_issues_kwargs
         self.verbose = verbose
         self.label_issues_mask = None
         self.sample_weight = None

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -162,9 +162,9 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
       perfectly labeled (certain no errors in that class).
 
     find_label_issues_kwargs : dict, default = {}
-        Optional keyword arguments to pass into `filter.find_label_issues()`.
-        Options that may especially impact accuracy include:
-        `filter_by`, `frac_noise`, `min_examples_per_class`
+      Optional keyword arguments to pass into `filter.find_label_issues()`.
+      Options that may especially impact accuracy include:
+      `filter_by`, `frac_noise`, `min_examples_per_class`
 
     verbose : :obj:`int` (0 or 1, default: 1)
       Controls how much output is printed. Set = 0 to suppress print statements.

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -161,6 +161,11 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
       Only works for 2 class datasets. Set to the integer of the class that is
       perfectly labeled (certain no errors in that class).
 
+    find_label_issues_kwargs : dict, default = {}
+        Optional keyword arguments to pass into `filter.find_label_issues()`.
+        Options that may especially impact accuracy include:
+        `filter_by`, `frac_noise`, `min_examples_per_class`
+
     verbose : :obj:`int` (0 or 1, default: 1)
       Controls how much output is printed. Set = 0 to suppress print statements.
     """
@@ -174,6 +179,7 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
         cv_n_folds=5,
         converge_latent_estimates=False,
         pulearning=None,
+        find_label_issues_kwargs={},
         verbose=1,
     ):
 
@@ -206,9 +212,10 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
         self.K = None
         self.noise_matrix = None
         self.inverse_noise_matrix = None
-        self.find_label_issues_kwargs = None
         self.clf_kwargs = None
         self.clf_final_kwargs = None
+
+        self._process_label_issues_kwargs(find_label_issues_kwargs)
 
     def fit(
         self,
@@ -219,7 +226,6 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
         thresholds=None,
         noise_matrix=None,
         inverse_noise_matrix=None,
-        find_label_issues_kwargs={},
         clf_kwargs={},
         clf_final_kwargs={},
     ):
@@ -272,11 +278,6 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
           inverse_noise_matrix will be computed from pred_probs and labels.
           Assumes columns of inverse_noise_matrix sum to 1.
 
-        find_label_issues_kwargs : dict, default = {}
-          Optional keyword arguments to pass into `filter.find_label_issues()`.
-          Options that may especially impact accuracy include:
-            `filter_by`, `frac_noise`, `min_examples_per_class`
-
         clf_kwargs : dict, default = {}
           Optional keyword arguments to pass into `clf` fit() method.
 
@@ -302,7 +303,6 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
             t = np.round(np.trace(inverse_noise_matrix), 2)
             raise ValueError("Trace(inverse_noise_matrix) is {}. Must exceed 1.".format(t))
 
-        self._process_label_issues_kwargs(find_label_issues_kwargs)
         clf_final_kwargs = {**clf_kwargs, **clf_final_kwargs}
         self.clf_kwargs = clf_kwargs
         self.clf_final_kwargs = clf_final_kwargs


### PR DESCRIPTION
This PR is to move `find_label_issues_kwargs` parameter from the `fit()` method to the `__init__()` method of `LearningWithNoisyLabels()`.

Moving `find_label_issues_kwargs` to `__init__()` allows us to use it for hyper-parameter search. For example, scikit-learn [GridSearchCV](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html) requires hyper-parameters from `param_grid` to be passed to the the init of the estimator.