### PR TITLE
Add fix and test for sklearn GridSearchCV with LearningWithNoisyLabels

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -215,7 +215,6 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
         self.inverse_noise_matrix = None
         self.clf_kwargs = None
         self.clf_final_kwargs = None
-        self._process_label_issues_kwargs(find_label_issues_kwargs)
 
     def fit(
         self,
@@ -302,6 +301,8 @@ class LearningWithNoisyLabels(BaseEstimator):  # Inherits sklearn classifier
         if inverse_noise_matrix is not None and (np.trace(inverse_noise_matrix) <= 1):
             t = np.round(np.trace(inverse_noise_matrix), 2)
             raise ValueError("Trace(inverse_noise_matrix) is {}. Must exceed 1.".format(t))
+
+        self._process_label_issues_kwargs(self.find_label_issues_kwargs)
 
         clf_final_kwargs = {**clf_kwargs, **clf_final_kwargs}
         self.clf_kwargs = clf_kwargs

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -17,6 +17,7 @@
 from copy import deepcopy
 from sklearn.linear_model import LogisticRegression
 from sklearn.base import BaseEstimator
+from sklearn.model_selection import GridSearchCV
 from numpy.random import multivariate_normal
 import scipy
 import warnings
@@ -497,3 +498,24 @@ def test_dimN(N):
     lnl.predict(X)
     lnl.predict_proba(X)
     lnl.score(X, labels)
+
+
+def test_sklearn_gridsearchcv():
+
+    param_grid = {
+        "find_label_issues_kwargs": [
+            {"filter_by": "prune_by_noise_rate"},
+            {"filter_by": "prune_by_class"},
+            {"filter_by": "both"},
+        ],
+        "converge_latent_estimates": [True, False],
+    }
+
+    clf = LogisticRegression(random_state=0, solver="lbfgs", multi_class="auto")
+
+    cv = GridSearchCV(
+        estimator=LearningWithNoisyLabels(clf),
+        param_grid=param_grid,
+    )
+
+    cv.fit(X=DATA["X_train"], y=DATA["labels"])

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -502,6 +502,7 @@ def test_dimN(N):
 
 def test_sklearn_gridsearchcv():
 
+    # hyper-parameters for grid search
     param_grid = {
         "find_label_issues_kwargs": [
             {"filter_by": "prune_by_noise_rate"},

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -514,9 +514,6 @@ def test_sklearn_gridsearchcv():
 
     clf = LogisticRegression(random_state=0, solver="lbfgs", multi_class="auto")
 
-    cv = GridSearchCV(
-        estimator=LearningWithNoisyLabels(clf),
-        param_grid=param_grid,
-    )
+    cv = GridSearchCV(estimator=LearningWithNoisyLabels(clf), param_grid=param_grid, cv=3)
 
     cv.fit(X=DATA["X_train"], y=DATA["labels"])


### PR DESCRIPTION
This PR is to fix an issue with calling a method (e.g. `self._process_label_issues_kwargs()`) in the constructor of `LearningWithNoisyLabels()`

This PR also adds a test for CI to make sure sklearn GridSearchCV runs properly when we pass `find_label_issues_kwargs` dict args as hyper-parameters.

The issue is similar to the one discussed [here](https://stackoverflow.com/questions/24510510/python-scikit-learn-cannot-clone-object-as-the-constructor-does-not-seem-to).

Code below to reproduce the issue:

```Python
from cleanlab.classification import LearningWithNoisyLabels
from sklearn.datasets import make_classification
from sklearn.preprocessing import StandardScaler
from sklearn.model_selection import train_test_split
from sklearn.model_selection import GridSearchCV
from sklearn.linear_model import LogisticRegression
import numpy as np


def make_linear_dataset(n_classes=3, n_samples=300):
    X, y = make_classification(
        n_samples=n_samples,
        n_features=2,
        n_redundant=0,
        n_informative=2,
        random_state=1,
        n_clusters_per_class=1,
        n_classes=n_classes,
    )
    rng = np.random.RandomState(2)
    X += 2 * rng.uniform(size=X.shape)
    return (X, y)

param_grid = {
    "find_label_issues_kwargs": [
        {"filter_by": "prune_by_noise_rate"},
        {"filter_by": "prune_by_class"},
        {"filter_by": "both"},
    ],
    "converge_latent_estimates": [True, False],
}

ds = make_linear_dataset(n_classes=3, n_samples=600)
X, y = ds
X = StandardScaler().fit_transform(X)
X_train, X_test, y_train, y_test = train_test_split(
    X, y, test_size=0.4, random_state=0
)

clf = LogisticRegression(random_state=0, solver="lbfgs", multi_class="auto")

cv = GridSearchCV(
    estimator=LearningWithNoisyLabels(clf),
    param_grid=param_grid,
)

cv.fit(X=X_train, y=y_train)
```
