### PR TITLE
Add audio tutorial to doc site

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ ipykernel==6.8.0
 tqdm==4.62.3
 ipywidgets==7.6.5
 sphinx-multiversion==0.2.4
-torchvision==0.11.2
+torchvision==0.12.0
 scikit-learn==1.0.2
 sphinx-copybutton==0.5.0
 pandas==1.3.2
@@ -18,3 +18,6 @@ skorch==0.11.0
 tensorflow-datasets==4.5.2
 tensorflow==2.8.0
 scikeras==0.6.1
+speechbrain==0.5.11
+tensorflow-io==0.24.0
+torchaudio==0.11.0

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,6 +82,7 @@ When the ``.fit()`` method is called, it automatically removes any examples iden
    tutorials/image
    tutorials/text
    tutorials/tabular
+   tutorials/audio
 
 .. toctree::
    :caption: API Reference

--- a/docs/source/tutorials/audio.ipynb
+++ b/docs/source/tutorials/audio.ipynb
@@ -1,0 +1,1162 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eVufWTY3jRPx"
+      },
+      "source": [
+        "# Audio Classification with SpeechBrain and Cleanlab\n",
+        "\n",
+        "In this quickstart tutorial, we will use Cleanlab to find label issues in the Spoken Digit dataset (it's like MNIST for audio). The dataset contains 2,500 audio clips with English pronunciations of the digits 0 to 9 (these are the labels to predict from the audio).\n",
+        "\n",
+        "**Overview of what we'll do in this tutorial:**\n",
+        "\n",
+        "- Extract features from audio clips (.wav files) using a pre-trained Pytorch model (available via HuggingFace) that was previously fit to the [VoxCeleb](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/) speech dataset.\n",
+        "\n",
+        "- Train a cross-validated linear model using the extracted features and generate out-of-sample predicted probabilities.\n",
+        "\n",
+        "- Use cleanlab to identify a list of audio clips with potential label errors.\n",
+        "\n",
+        "**Data:** https://www.tensorflow.org/datasets/catalog/spoken_digit\n",
+        "\n",
+        "**Pre-Trained Model:** https://huggingface.co/speechbrain/spkrec-xvect-voxceleb\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eqsqBq3PiUHA"
+      },
+      "source": [
+        "## 1. Install dependencies and import them\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "i7nT-U9qc8MS"
+      },
+      "source": [
+        "To get started, we first need to install the following packages with `pip install`:\n",
+        "\n",
+        "1. cleanlab\n",
+        "2. speechbrain\n",
+        "3. tensorflow_io\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
+      "outputs": [],
+      "source": [
+        "dependencies = [\"cleanlab\", \"speechbrain\", \"tensorflow_io\"]\n",
+        "\n",
+        "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
+        "    %pip install cleanlab  # for colab\n",
+        "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
+        "    %pip install $cmd\n",
+        "else:\n",
+        "    missing_dependencies = []\n",
+        "    for dependency in dependencies:\n",
+        "        try:\n",
+        "            __import__(dependency)\n",
+        "        except ImportError:\n",
+        "            missing_dependencies.append(dependency)\n",
+        "\n",
+        "    if len(missing_dependencies) > 0:\n",
+        "        print(\"Missing required dependencies:\")\n",
+        "        print(*missing_dependencies, sep=\", \")\n",
+        "        print(\"\\nPlease install them before running the rest of this notebook.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "x-oboEbRdhf6"
+      },
+      "source": [
+        "Let's import some of the packages needed throughout this tutorial.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 88,
+      "metadata": {
+        "id": "LaEiwXUiVHCS"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "import random\n",
+        "import tensorflow as tf\n",
+        "import torch\n",
+        "\n",
+        "SEED = 456\n",
+        "\n",
+        "\n",
+        "def set_seed(seed=0):\n",
+        "    \"\"\"Ensure reproducibility.\"\"\"\n",
+        "    np.random.seed(seed)\n",
+        "    torch.manual_seed(seed)\n",
+        "    torch.backends.cudnn.deterministic = True\n",
+        "    torch.backends.cudnn.benchmark = False\n",
+        "    torch.cuda.manual_seed_all(seed)\n",
+        "\n",
+        "\n",
+        "set_seed(SEED)\n",
+        "\n",
+        "pd.options.display.max_colwidth = 500\n",
+        "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"3\"  # Suppress TF info, warnings and errors\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SOen_sxQidLC"
+      },
+      "source": [
+        "## 2. Load the data\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "uHVskN2eeNj6"
+      },
+      "source": [
+        "We must first fetch the dataset. To run the below command, you'll need to have `wget` installed; alternatively you can manually navigate to the link in your browser and download from there.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 89,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "GRDPEg7-VOQe",
+        "outputId": "cb886220-e86e-4a77-9f3a-d7844c37c3a6"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "--2022-04-05 04:29:55--  https://github.com/Jakobovski/free-spoken-digit-dataset/archive/v1.0.9.tar.gz\n",
+            "Resolving github.com (github.com)... 13.114.40.48\n",
+            "Connecting to github.com (github.com)|13.114.40.48|:443... connected.\n",
+            "HTTP request sent, awaiting response... 302 Found\n",
+            "Location: https://codeload.github.com/Jakobovski/free-spoken-digit-dataset/tar.gz/refs/tags/v1.0.9 [following]\n",
+            "--2022-04-05 04:29:56--  https://codeload.github.com/Jakobovski/free-spoken-digit-dataset/tar.gz/refs/tags/v1.0.9\n",
+            "Resolving codeload.github.com (codeload.github.com)... 52.68.31.213\n",
+            "Connecting to codeload.github.com (codeload.github.com)|52.68.31.213|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: unspecified [application/x-gzip]\n",
+            "Saving to: ‘v1.0.9.tar.gz.5’\n",
+            "\n",
+            "v1.0.9.tar.gz.5         [     <=>            ]  11.42M  10.3MB/s    in 1.1s    \n",
+            "\n",
+            "2022-04-05 04:29:57 (10.3 MB/s) - ‘v1.0.9.tar.gz.5’ saved [11975353]\n",
+            "\n",
+            "mkdir: cannot create directory ‘spoken_digits’: File exists\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%capture\n",
+        "\n",
+        "!wget https://github.com/Jakobovski/free-spoken-digit-dataset/archive/v1.0.9.tar.gz\n",
+        "!mkdir spoken_digits\n",
+        "!tar -xf v1.0.9.tar.gz -C spoken_digits"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tRvNnyB0e_IE"
+      },
+      "source": [
+        "The audio data are .wav files in the **recordings/** folder. Note that the label for each audio clip (i.e. digit from 0 to 9) is indicated in the prefix of the file name (e.g. **6_nicolas_32.wav** has the label 6).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 90,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "FDA5sGZwUSur",
+        "outputId": "0cedc509-63fd-4dc3-d32f-4b537dfe3895"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/7_george_26.wav',\n",
+              " 'spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/0_nicolas_24.wav',\n",
+              " 'spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/0_nicolas_6.wav']"
+            ]
+          },
+          "execution_count": 90,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "DATA_PATH = \"spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/\"\n",
+        "\n",
+        "# Get list of .wav file names\n",
+        "file_paths = []\n",
+        "\n",
+        "# The returned order of os.walk can be arbitrary so we use deterministic shuffle with SEED below\n",
+        "# See: https://stackoverflow.com/questions/18282370/in-what-order-does-os-walk-iterates-iterate)\n",
+        "for (dirpath, dirnames, filenames) in os.walk(DATA_PATH):\n",
+        "\n",
+        "    # sort before shuffling\n",
+        "    filenames = sorted(filenames)\n",
+        "\n",
+        "    # Use deterministic shuffle with SEED on pre-sorted list\n",
+        "    # See: https://stackoverflow.com/questions/19306976/python-shuffling-with-a-parameter-to-get-the-same-result)\n",
+        "    random.Random(SEED).shuffle(filenames)\n",
+        "    file_paths += [os.path.join(dirpath, file) for file in filenames if file.endswith(\".wav\")]\n",
+        "\n",
+        "# Check out first 3 files\n",
+        "file_paths[:3]\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Xi2592bVhSab"
+      },
+      "source": [
+        "Let's listen to some example audio clips from the dataset. The utility functions below help process the .wav file so we can listen to it in this notebook.\n"
+      ]
+    },
+    {
+      "cell_type": "raw",
+      "metadata": {},
+      "source": [
+        "<!-- This cell is for the collapsible block in the doc site -->\n",
+        "\n",
+        "<details>\n",
+        "    <summary markdown=\"1\">Click here to view its code.</summary>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 91,
+      "metadata": {
+        "id": "8Ev5dIgwaTw6"
+      },
+      "outputs": [],
+      "source": [
+        "import tensorflow_io as tfio\n",
+        "from pathlib import Path\n",
+        "from IPython import display\n",
+        "\n",
+        "# Utility function for loading audio files and making sure the sample rate is correct.\n",
+        "@tf.function\n",
+        "def load_wav_16k_mono(filename):\n",
+        "    \"\"\"Load a WAV file, convert it to a float tensor, resample to 16 kHz single-channel audio.\"\"\"\n",
+        "    file_contents = tf.io.read_file(filename)\n",
+        "    wav, sample_rate = tf.audio.decode_wav(file_contents, desired_channels=1)\n",
+        "    wav = tf.squeeze(wav, axis=-1)\n",
+        "    sample_rate = tf.cast(sample_rate, dtype=tf.int64)\n",
+        "    wav = tfio.audio.resample(wav, rate_in=sample_rate, rate_out=16000)\n",
+        "    return wav\n",
+        "\n",
+        "\n",
+        "def display_example(wav_file_name, audio_rate=16000):\n",
+        "    \"\"\"Allows us to listen to any wav file and displays its given label in the dataset.\"\"\"\n",
+        "    wav_file_example = load_wav_16k_mono(wav_file_name)\n",
+        "    label = Path(wav_file_name).parts[-1].split(\"_\")[0]\n",
+        "    print(f\"Given label for this example: {label}\")\n",
+        "    display.display(display.Audio(wav_file_example, rate=audio_rate))\n"
+      ]
+    },
+    {
+      "cell_type": "raw",
+      "metadata": {},
+      "source": [
+        "<!-- This cell is for the collapsible block in the doc site -->\n",
+        "\n",
+        "</details>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2bLlDRI6hzon"
+      },
+      "source": [
+        "Click the play button below to listen to this example .wav file. Feel free to change the `wav_file_name_example` variable below to listen to other audio clips in the dataset.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 92,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 92
+        },
+        "id": "dLBvUZLlII5w",
+        "outputId": "c6a4917f-4a82-4a89-9193-415072e45550"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Given label for this example: 7\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "                <audio controls=\"controls\" >\n",
+              "                    <source src=\"data:audio/wav;base64,UklGRmBDAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YTxDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAP//AAACAAAA/v///wMAAgD9//z/AwAGAP3/+P8CAAoAAADz////EAAFAO7/9v8UABAA7P/o/xMAIQDv/9X/CwA2AP7/v//2/04AHACm/8n/ZQBdAJD/aP94AAcBgf9x/cT9bgAiAu4A4f7S/m0AQgGIALT/vv/5/8X/qf8dAJgAgQAfAPj/CgAqAFwAaAD1/13/gf87ADsAL/+v/tr/QwH8AKX/X/9OAIYAg/8M//j/kQCo/+H+AAChAUsBlP9L/+kAzgGLABP/bf+SAHoAfP92/4gA+AAVAET/uv/GAPgADwAY/yH/HgDnAGgAHP/B/gIANQGbAB//Bf9YAOIA6P9K/w4AegBS/3b+v/9QAWYAUf6s/kAB/gG8/03+IgAFAm8Anf36/dsAswGV/2L+FQC0AagA9v5Z/5wAIgC4/iH/CAFPAUH/4v1G/3oBmwHI/2v+0f4jAPwAvgCy/8v+//4qABAB2gAdAMn/3P/w/zkA7QAzAR8Akv6U/n0AFgJcATT/Of5h/wgBTgFCAEX/IP+P/ywA2QArAYYAQv/a/iIAwgGcAaL/EP6J/iAA8ACFAMf/Vf9D/9X/+ABsARUAOv5+/v0AeAK0AOj9vP0ZAHcBJQCL/jz/MwGgARQAzf5V/7kAPQF+AGr/Df/Q/yMBuwG2APH+aP7N/3QBVQGY/0j+z/50AHwBAgGe/6f+Dv98AIUBCAGC/4/+Dv9HAAIB4AA+AIT/JP+s/+kAewFNAHT+N/4HALEBQwGT/8b+WP8CACMATwChAD4AL/8E/20AmQGYAIL+Lf4XAKcB7AAy/8v+yf9yABcApv+9/9v/q/+7/1AAnwD9/y3/af+LACQBcwBl/0//MwDYAGMAXP/m/lr///8PAKP/V/95/+X/YQC1AHwArv8m/9H/IQFaAen/i/4N/7IAOwEaABb/hf+JALsALgDM/5//Nv8J/9z/AQHXAEL/Qf44/+EAEwGt/5f+Ef9QAO4AmwAAALH/0v9kACEBWQGZAHj/Jf8HACUBOwE8AE//cP9eABUB9QBGALL/kf/a/0wAkgBVAKD/Dv9L/zkA4AB8AHj//P6W/5QA+ACfADQAIAAVAMj/k//4/68A1QAeAGT/o/+zAGYB5wCu/+T+L/8qAOsAzwDk/9r+jP5N/3wA8wArAO7+nf62/zIBoAGfADX/sP52/8cAbAG1AC//VP4t//0A1QGwALn+Bf4//xYB2gEiAdb/H/+N/7sAkQEkAcH/zv5T/7UAaAGqAD//dv7e/u3/mwA6AA3/N/6e/tT/aQCe/0r+zf1y/mP/1v+t/wr/HP5v/an9hf7G/rr9WPwa/An9wP1Y/WD8z/vT+yj8zPye/ej9Kf0i/CP8TP1b/lj+t/12/dz9kv5S/9P/g/9E/j/94f3x/2kB0AAR/1v+jv9jASsCqwEBASgBGwI1A/gDPgQiBPkDSQRcBcQGlgdgB8gG4wYGCGMJ+AmfCR0JOwn8CcUKEQvoCqoKjwqNCokKagr0CeQIYwclBq0FlAX5BK4DfwIfAikCsgGPAH//Af+0/iH+mv3G/Yf+Ev8D/7f+S/4S/bP6Gvhu9lv1rfN48R3wke9A7Ujnzd8l287aLdyY3J7cWN7/4d/ltuhy6kzr8+tj7o30jv22BUEK+AuHDTEQHBMTFcEVqBXMFRsXPBkrGvwXBxOnDeAJ5wfIBoIFhgMIAQr/Of6l/Z/7Tvg39nf3Uvti/1ICXQTXBewGbQg6C40OdxCoEDcRqRNkFo4WtRMeEM4N0AxKDJELpglvBYz/uvoD+Sr5W/gY9sH0LPYm+R37Fvsb+ob5+/mp+1z+HgGtAq0CDQLoAVoCogJFAsIBIwLUA+UFpgYyBVwC8P8U/47/SABFAED/8f2r/Rb/MwFDAtIBYgG0AtEFLwlkCxAMSAsHCakFiQIKAWkA7vzN8vXiKdRrzdzOotHQzwfL9sk60JnaxeIC5Vjipd8F43bvFgE/D5oUZxT3FcgbZSHdIawdZRmFGNgaUx0YHAkVJgrBAKn8Xfxh++X3bvT78z72Wfj59/30YfFm8KD0b/3IBsYMNg/aEHkTFBbuFiAWmRVGF54bHyHCJKEjPR0pFBcMKgcFBeYDTwISABr+5/ww+/f2g/BX69/qqe4V85L1j/ZR9833lvdc9/v3A/nR+Ur7v/4oA4AFUASHARQAzACCAukDTgRTA00Biv8G/yz/tf6x/ZD9Vf+iAl0GQgkZCsMIKAe7B6YK2A3+D9wRARQnFSAUmRGNDu0KvgcBCBQMNA6FCBn+xvdy9inv39lKv/ywS7XRweLJmsu/zErRTdll4yjshe6S6vjp7fZ7DqUh7SX4H4kboR09IigkCSIvHf4XWBXOFRAVqg00AOTzvO6l71PxffB/7VzqdOlo7MTxFPXw8/7xIfUh/voHUQ5hET0TixRvFYIW7xZdFHQPjA0bEjcYdBfaDiAGEgPRAgYAMftz+D/4tPfu9v/4Hf2c/YT4i/Qc+TEE8wxOD+AP0RNkGeka3RVlDCUCqfox+f39pwM0Axb8hPXT9Zz6Gfwa95jwWu+X9Nj7CwBp/6D7MPgk+Oz78QAhBBAFNAb/CUYQlxa8GqQc5x1cH3of1htnFGUMMAcpBVME/AJmADD8VPfv9OL21fmQ+En0XvTy+b746uNzwamo+amnvfPO3NP504va7Ohv95r9tPeg6ZHf7ObGAD8doilNI3QYKBaoGnQbHxSmCgQHBws2EvgVCBGAAv7v1eJV4ArlY+ma6vzsHfXUAIcI+wbF/iX4D/oTBeET9B/HJY4lGiHWGX0Q8QUS/Mj11/VR/OsEDQkCBWj76vKb8Nz08vwSBnwOIxWXGf8bVxwsGg4WCBMTFT8d1SfoLpgu/yYJG34OZQSp/Y74iPJK64XlqeNR5DjjJN4b2NzWV93q6K7z3vij9wXzvO8f8fT2Mv5gBP8J5hBfGEwcIRlLEMQHGgUrCTsQRRUcFZgP5AbR/Sr2U/BP7BLrf+6X9xoEUg7YEBsMPQckCY0QyRVeFRIVLRoSHbUNcOeUuwOjTKb5t3rFAcnlyVPQGNxw5RrkZddAymzNCOmCEu8zRD88OfYwoC83MhUxCSpoIvUgQiZPKkQilAoD7DjVXs5l00PaNd1D3mDi9uoC9JT3pvNo7fXtD/rPDMkbkSBfHXEY5RRDEZkLGwWmAVoEZQxfFKAV/w2HAl/7YPxiAssHegqTDK4QoBbBGz4dVBpLFWQSlBSPGpQfsx8YG9oUKA93CUcCpvlB8V7qsORb34DaCNck1RjU8tOD1mrdKOd57z/zj/NY9Hr4yP89CAsQaRZrG4QfZyIwIqwcexJNCJMDyAVyC5EPGQ+ZCYoADPfU8K7vZfI491b+EgiHEb4VChMMDbIIPwgIDKoT3xtNHjMY1Q8YDf8Lg/2U2v2xYpwKo8u3HMb6xofCs8NazhneGuq36z/mqOdC/O8fOj+ySStB2zQXMBQxHC+AJXQXyAtBBsUDWPyR6kTSlL4duLi9r8eO0B/ZvOQX9NsD2w6REV8N7widC+YWGCUSL0YySjBtKjEg1xEcAsn0sOxN613wyfiB/x4BrP4E/CX85P8fB0IReBz1Jb8rci0zKzMl3xxNFT4RHhGVE/cW5RiQFSoK4fim6GzfLt2z3VHeOeAt5err8PAH8jjwvu6z8Dz3qwA6CYsNPQ3WCgUJSgi+B28H5Ai7DJcQixDnCjECJvsw+br8rANeCswM8gjuALL5rPZm98P5LP0CAh4H+glJCZUF5f9H+kT5lgAJDc8VQRfpF+AcGhwLBDXU8aVCldSj3LlRwsG+f77kyRvbyOaX5t/dINny5roK0jRHTfRJrjdSK3EshTGdLusiKxcxEucQtAiI8UjPorFEqHO1zMyn33fpn+/992MCjgqmDWcNlQ8qGp8tF0JcTGNHBTilJvsW3wdQ+QLvYuwj8PL0hfW97+Dl+N2L3p7p3fqbC1sYkyECKIEqPihrIzAgIiFxJSgqdSzsKn4luxwQEaoCl/LK4zLaw9dE2sPc+ds52Z/YYNzE4iPp2e+x+UAHRRSrGu0XCw/oBUcBaQIZB+cLNQ8LEi0V/BU6EJcD7/W97gvxN/raBEULFgn7/XzviOXg4w7oAO6b9Or84wZLEIoVdhNBC3sFTAzmHvouuDDvKSUoeSj9FarmHbDpk9KaoK6Qt2601rKruofIPNW92m7WOc811gX3lCa+SVtQ0kN9OEE3Nzp7OdozfiwdJnQgjRaYANPc5bYHoWSjZLWeyJ7W3eGm7Zz5fwNvCTQLdAxjFAEnQD6UTYNNB0EtL3ob4wad9I/pjefb673xSvRg7/niFNaX0mfchO7kAUwUQCZBNR083Dh8L2omOCKFJBEseTQOONQz6ihDGcoE8OsE1NXFksbi0qzhCOuW7NvoL+Rl4vPl4u+M/xQSciL0KgQohBoMCHb4iPHE8zT7nQNVC1ERIxKzCd34Secg3mXhw+57AKgPuhXZD9YBs/Nz61jqkO+O+sMJMBmlI84k2hrACeL8jf/3D6UeXiBaHHQfXyPqDyfbYZ4BgLiLB6rgvYLAnL5KxEnSruCI5efc79C61mH6gy3aUChSWjyaKNwkUSz8MvoxMCrSIN8ZRxIhALDd+7Rwm46ebbdc09/ljO/e9pT/7QjuD24ShBIJFz4lxzg+ReBBgjF8HZIL8Puq7pvmG+ao663yCfZI8lzoDN8S39DrzgAOF9MqODuDRgxKXEVKOygwFigJJsspkS75LYElABh7CR37BeyK3GvPnMg4y+fWCeY98DrxFO0k7LfyKP5zCTcSWhgDGwoYbw5cAH7yb+k558rqkPFQ+RQATgPeAKj59vGW7tTxNPtsCIUVPx1uG+EPQ/8q8SDsJfHP+q4C5gdYDVgRJA2CAJb3Ev1rCscQeRCcGGUpFyfo+hG5IZKknE++etBWy5XCCMXoz//aL+AF2UHGu7sr05EKYj2EShA4IyazJhIx/zciOm86qTf1MQQtJiX5DJ/gBbSyodmtx8Q61GjbxuHV6dnx8Pih/cL9O/25BnkedzitQ+s8hS/vJOAbWBA+BIv8R/uw/2UHBwzrBBrx+NwR2LflrfvbDkccviWeK6Eseyg6IFoWQhCJFC0kezYCP1s4Hyg9GGUNvQNU9FzeK8s2xz/VjekB9AXvReOd3WzjZvCh/DgDsgTABK8FigV2AD32X+zb6U/xYv+eDTcWrRYDEYsK/QcDCsYN4hDrE0sYzxsIGIcIFPIG4f/d4+Vl7yX2hvu2/kr8T/c7+VYDowkSBsUHDB4rN5Uqle2Fq7KYUreG26njPtf6zUvPKdTG1jDSGMAQqBSnjNLAFY1AZzwPIlwVDx07KUAxRTnKQd9EeUJiP2k2TRox7P3CkrNduhbFkcqwzrXUUdoK35vl/OyY8RX3XQeLI6E9JketQHM1yixGJn0gnRuzFh0RJg5iEFIRhQUH7KPTaczb1xTrEfyxB0EOSxGeFDwbCiLeIv4eXiHVMfFIklV5Tro6SyijHeIVbgjl8ebW6MAfuKq9Gcr/0h3UA9M72BnlH/IK+Dj4TPrzAmUPaRn9HMsZcBIDDMsLORLpGHYYsRAcCYoIzw2fEZgOKgbW/f74Y/YV8xTulOit5IHl8e0r+8UChv1Q9Oz4aA2AHUoaDhKGGjko6BSi1jyZ6Y0FsNPQENVazMjMQdRM1z3VN842ujCf656I0h4fb0thQmMm9B3EJ3ou8C5SNPg92UF5QbhE10LXKBP6Y9RGy7rQic3vwAe64L0xxQLNndh25Q3tg/OCBfUjYz4dR5JCpjzKOLU0HzIpM2IyTSkTHCMUEBDmA7rrJNTEy1zTLuF/7aj1VfgX94r59wb8G5UsMzL/Mtw4HkXvT4ZR9EhaO+ouFCZsHUgO2PRY1Ii1aaGOnCClUrRAw9XP/dvV5yHvt+6z6mDs6flnEdIqqDw9QMU1HiXkF0wRbA2xCCUFEwfdDqcXbRrOEQb+Lufm2JzYRuEh6oLvXfNt+H3/VwYNB3z9q/FR9RIOlShILuMj+x97IoINg9Oll8eI/aZQx4TNr8Z0x7rMSct1xrzDlLqDqKmnidP3GqFK9Uk/NBktcDXdOt46hj/dRndGGEHyQH4+fiUp9+TQWscPzczJ27unsjG0Crp1wh/S7eWH85P6+wasHXMzWz1TP81CiEc5RwRCKD19OAAvjSBkEhEGIvgM6WbfBd7P3sbbHtg22/rlyvIA/kIJbxazIykukzXLO8NBY0Y7SLpH6Ea7RVo/2y3qEe3zS9tEx86zB6OMnJKj57Kow/vSQ98n5S7kGeOO6kP8xhIxKLE4LUCpO24uySB1FxAQFAjZAgAF/AxLFPEVHxAtAqLuB95o2YjgR+oO8A30VfoaAXgDBAAp+dvybPP5ALsXCCgLJ9sdEhx2HCkHQ9Vqo7WTBaYOvbbEJMJwv967d7Z6tni9G7/ftZ+1Vdb9D5A+g0urQlU6qjjAObQ//kw7WBBW20pGQ3s97SmOBAbeTMZTuye0HLH8tWO9Vb+6vxjJkNrn547sy/IPBJQcqTMaR/ZW0102V7VJ+kDlPhM79zCqJfkdyhZAC+77keuP2pLLfcdK1J/p2Pa19V7w6PLS/cgKKBhbKDw58kStS0tUtF9sYhtRVTAVEf/9LfKs4+bQQsC+tg6047XRuUK80LpXuXfA69PH7HEApgs3EygbnyGnI9Ii+CKcJPsk9SJ2IFUeLxp3EmMKeQa0BYsB6/XG5u3bTdlv3U/l1+2F8gfw9ek46YHxH/yaAccE2Q3LHBAphy6KMJ4sFRZg6fe7NqoHttjEOMHOsXapRK2mtMG5FLyZuAKv4K23yFn8fSrKOQQxqylzMK8+REzDWPxiiWXQX7ZXZk04NxkRe+i6z/jJmMuAy1DKtMnwxijBUL1+v4jFl8yN1/bqZwWTII03dUdnTKNEeze8Mos9iFC0Xb5dQVO3Q4gxAh2JBz/0vuZ64Zfjteeu5nvdetBIyHTLhdpk8NQFdRZDJPQ0aUlxWNVVMkBNJdcVwhVgGqwW1ga28NDcGtCNye3DtLvTtFS4q8n/30Lt0+u94lzd6uEb8BkERBjKJjYtzS2YK18m9hxzEpAN2hENG7sfARhHAwnqQ9kg2O/gWuem5hrmA+3l9tn4cPA456fnCfSmCJsfrC9aL54gZRRJGCQi8hjc9FzMxLqSwerLXMpmvxKz2Kj1pBGusMA4y6XCZbVhvDTbsPzMD+YZdCerOIZH6VXpZvpvk2GVP2AiqxrZH0sgAhjADf0C5/NJ4wPZaNQfzKi+KbjnwUTUqOCp4z/lBet48+399w1KJLU6xkruUyNYsFbXTsZEGD+kP/VBeUCMOMkp3RRB/Hjkh9JeyrrNUdpe6cHz0ffY+WL+1wXXDVEUIRhIGZEaPCDPKdkuISY5EL73p+bJ3kLddOA+53ntF+5O6EjfTdUAy6bD08UM1d7sZAR5FbMegCCLGxwSlAiaAx8G8A8PHGoh8RjKBKPv++Jm34LfeuB65CHttPaM+lT1jerx4gHncPgtD8seQiH+G6wYQxqcGzIYKxJjDgwO/Q5fDxENUQPW7u3UScHIuSe4SLMnq8mm2ajerO6vgbUXwXvQTuAF8gAIZR7eLco07TfNOXo3NTCDKgAtajVtO3o6cjTFKyQglxGMAgH1rei93cPWqtVZ2H3ayNln16zWjdt/6H/7dA7aHA4oxzNHP1lFREOsPKc3RzecOiA+czzQMAgc7gUB9wvx5++D8OzznvsJBh0QsRcEGx0YaA8WBkgD4Am7FQgf7R/NF4UK9/y68cro++Gu3hngmuTM52bl09tMzeG/ervDxLXYXu4d/qYGBQutDecOYw5NDEgJNwdlCV4R2hr2HLEREPxE5vnZVtqO41zuVfRS8y7u0+nN6N7pDetg7Vr0bQGnEMUaTRvJFPwOjhDAGZIk4ikUJ9MfjhpAGs0aIBRTAhLrn9lz1FfXSNiO0RHG57zPuue/OMnI0rLZgd4L5fDvGPx7Alj/j/Zn8NHy2v25DN0Ybx1mGnUUoxCtD3oOewomBJH9v/jB9wL82ANYCrcLZwlJCEgLWhFRGCMfDSXJKP4pACp8KaEmbR9TFZcM7AcoBnsERAFQ/ED2JfFa8ML1R/+yCPwPhxbwHUElByodK3spNieZJgYp9iymLcUmLxm6CsgA8vsn+W/1k++z5yvfP9gm1MbR/c+q0AfXW+LN7BPx6+9W7q/vUvMS91v5Ifkx9lnyOvD679juPuuh537ntOrs7Srvxu/d8cf1n/qF/38DuAXjBiUJMg2qEPsQMA/hDnURaBS7FE0SDQ9iDKIK2Ql2CfcHgQRmAHL94/oW9pnu0eek5fnoHPCu+KL/iAHu/cf5Gfu4AUAHOQdKBBADxgKS/uH0len84Hbcndxp4o7r+fD97Azi9dcs0yTSA9Oh1yfi5PAcAJUNnhfSGjEVeQtZB4EOoB1RLSI50z+WP8A2Gii0GooTdxHHEJEQMBLwFGsVkBHuClkEbf+E/dYAEApyFc4c2hwXF7kO/QVN/zj+mQRYD0kYfBsuGfMSmQnS/pj2kPRi+Cr+PQJKA24BUP2l+Ar2Ffcx+78AlAajCyIOPgyeBcr7WPEO6eDkbuTW5C/jeN8a3Fjaj9jm1OrQKdHO2AvmBfNc+hr7y/jz92X6uv64ApcFDggGC5UOxhEmEwISXw8fDf4LEQubCVAIywfNBoADGv7D+Bz1VPOx88L2Y/uF/nf+J/15/XH/zADHABEBAQO3BYcHygfUBqEFBQZ9CZAOphDxCxcBW/QF6kbk7uKM4+HiO+CN3hLg3+ET36XYT9bm3XvsVvpxAz4J8A3yEWIVSBjoGGwVXRDFD5cVzBsaG7kTTAx3CUUKZAyaD64TfRazFisWGhdyGKMX3RTCElgSERIhEdgQ0BFUEi4R8A80EDwQAQ38BhQCegAqAGP+Zfsq+QP4nvaf9FHzwvPT9R/5bP3gAUAFcQeACWAL7QqHBu3///rd+Uj7zPz8/D770fZj72Pm8t4f3P7e3OUE7QLx3/Ah7p7q7+Z94xfiAOVZ7LX1ff6xBfEKFQ1eC3cH3QTnBRAKRA+nE6EVdBNYDDQCJvmn9Bb13ver+Z34LPVd8d/uv+047eLtDvL8+vUFjg2tDtQLuwrBDi0WlRwrH28eihy7GkEYUhMRC+gA9vfK8lzxC/Gs7v7otuF93EDc0OAs57XswfFH+AcAewVABdP/Gvkk9Sz2ePzGBfMM2QwuBVz7U/V/9Mv26fpWAZgJLBHEFcQWFhS6DdgFRwG8A/kLWRWDHNogIyKHH4sZ4xIIDmkLyAqcDFUQfhIID6UFbvr38RLuLu4M8T71UvnL/EgA0AO0BW8ERwGy/9wBjAahCucLQQruBlsDTQCV/bj6Lvhu9z75SvwH/u78V/lU9KTuGelB5bHkjOcR7NjvhvGJ8XDxdPKF9Lf2gPhM+tb8RQAlBKoHzwnXCVgIMAdXBzAHdwTv/yj9sP1K/vL6qvTM8JzyyvcN/Pj91P6Z/3IAOQK6BW8JXQoUCNcFiwYBCeEJPAhDBsoFFAY3BUICj/1d+OH0OvVa+af+rAJTBZEHHQk6CQEJZwrBDLcM0ggUBDUCpgKHAfP8CvfU8lHxE/Jr9OP2fvda9oX2R/pv/5ABm//1/OT8A//sAE0BLAAz/kH9IAAlB/gNKA80CgYESQE0AmQEYQbSBwEIeAZrBGoD8AIJAZP9H/sd/FoA0gVrCjkMswlkA8n8zflY+zT/zwLLBCME+P8o+f/y7PDC85L5i/+cAyUF/QRtBHEDqgD2+yX4gPjJ/GsBvwNBBA8EaAJp/uP5KPhE+iv+gwGSAzIEJwNEAXgAOAE2AXf+5vqj+rj+WgMJBPD/vvnW9MnzzvdU/3kFuAUtAXX+agLrCeMMyAcGALj9UgKHB/wGDAEv+4j5u/u0/j//RfuQ8zbtcu6R96MAbQEs+0z3zvsnBJMH5QNG/1wAmAfRDwYTiw5cBbz+yP9cBQUHlQHw+1r+XgdtDdwK1wOT/5//dwCk/yv+Nv7BAOAELQdoA5359fCi8fz66AL9APb36/HU9CL94gKcATf7gvWL9WT7nQESAkX8RvZu9sr8lQObBREDNwBHAG8CfAO7Aa3+B/24/WL/NwCh/yf+wPxW/D79tf6L/4P/ev/+/6QAIwHbAaICNQIhAFT+Ef/TAcgDTANUAW//SP6e/nEB6wXUCP8HQgU5BJ8FvgZfBYECwQBfATgD9gMbApn+Qfye/M39Jf2Z++784gHlBbkEjACM/zMErwoGDlkNUwtiCq8KgArMB54Cif7e/x0Grgp2BzL+BPeN9xf9GABD/G30ke9W8o76cQCf/dDzEOzv7av38f9T/2v36vA489v9AwmCDAgHL/8O/YUCCgrKDCoJAAPS/iz+IgBRA0wGLAeMBHn/bftf+9z+YAKgAkL/2vrA+J76Ff9dAjwBPPye91X3Ffvx/qz/ff21+ub4B/iY93r34fcM+Qj7Mf1O/sj9n/xl/CX9MP14+475Yfrt/qAEWwcQBaz/dfts+93+VQIaA5oBbgAhAV4ChwHX/WP5QPcY+Y3+nwXeCnIKkgNE+zP54v9ICYoNBwzbCnwNzA9rDNwE3f//AIoFRgmrCn4JJQXA/m76Zfu4/5kCWwK/AZwDlAdOC7IMkAp4BcAAZQA+BGIHNgZBA1oDkgZECA8GEwMYA3UFywbSBfwDhAI3Acr/LP7I+1b4bfUP9Tf2NPXX8CPtuO6z9JD57vkg+Hj4D/xQAEECygDt/F75UPmP/YcC/AK2/W73K/Yr+yQCwQX8A/D+5PpO++//nAQ8BYACMwH3A3MHcQa4AIH7QPse/wwDWAQPA7AA9P7P/ij/j/3L+aj3pfo9AJwB8fuS9NPynvd7/Zz//P0I+3b4Yve1+I37G/0d/Cb7H/2YAF8Be/51+9v6q/p2+Gz2q/hv/tUBUf83+j34vfqx/qYBxAN4BUEGYgZkB74JuQv4C44L9wtrDFQLcwkECb4JgggZBO7/AQChA2MGyQWuA/8CQAQcBoAH0gdYBjgDjwDmAFcEYAinCuAK1An7B+YF7gQDBhoI9wikBz4FSAMZAjcBOQCl/vD7q/gI94z4RPsG+4f2CvJI89L6AgPSBbwCUf76/GL/MwPZBQYGswO5/077hPf49ODz9/N59ML0IvVQ9sj3sPdc9UnzGfVr++ICfQftB18FtQH7/lX/VQN6CPIKZAnWBZwC1//H/Ej6Sfoc/ZUALwIrAWn+EPv49wT2WvaX+Zr+WwINAh3+ffqr+qr9N/86/Vb6G/ov/Pf8Ufql9VDxTe4P7aTu//JL9zL4+fVy9D32nfkl+376y/qa/swECAoSDCQL4AgiB34HgwrtDkISCBMYEkcRExFFELwN1QkYBjYEfQX9CU8PMhH8DM0EPf5E/RgBEAaNCTkLigvACmAJUQj6B/4HUAijCRgMLQ7/DVcLtgdyBKkBA/9v/OX5V/dv9Wv1JvcU+KP1vvB87czucvP296D6cPzG/msBCQOGAub/ovw7+0X9XQH5A90CCf/h+p73d/X/9Hj2avju+Hv4VPnN+1b9WvwI+1383v+rAt8DAAU8BkoFSwFV/Qn9GQAJA5sDmALIAUQCogSWCKgLTgrbA4f8/PnM/e4DvwbqA8b9kPi19n73tfjt+Oz32fUj8/rwTfAO8Bzuuepn6Zvs6PGw9NnzRPLB8eDw5O6y7j/zxPqGAIICfgIFAqcA5P6S/1gEwgoKD34QDhGjEVcR7w+LDpUNZgyIC/gMxBBXE0gRzgtXBy8GowZsBsYFSQZNCKIK/gu7C9gJVAcDBvYGUAl+Cy8NEQ/oEFkR4w/CDRsMhQpKCD0GzgW0BtwG9ATOAcn+9/uu+A31+vEN8HnvmvBh8xr2OfY087Tv2+7G8NLyLfP28lv0r/cn+/383PxY+yT5R/c296X5Uv3j/0QAnv+c/2YA2QBWAIz/eP99AHsC8ASRBskFnQJ1/+b+7ABYA+YEZgaBCAYKrAlpCHIINArcC+MLvAq0CUcJDglNCAoGqAEK/DH38vMd8dXtd+tt6zDs1upd593k4eRU5W7kKeRO567sbvBi8QDy1PNI9S31mPXc+Ln9IwGtAlEEhQaBB9QGwwbNCDYL3gujC7QMow7aDqgMVwqzCccJFQkvCGYIGAlICK4FeQO1AxoGuAjwCXIJSQhTCNQKzA5iEecQ5w5wDnMQGBOeFIMVBxeNGPwXsBS7EKEOqA74DuQNLQuCB8EDxgDQ/uT8x/kk9oj0Afaq92L15+5k6Inl2OW85nDn1ui06p7rmOtk7Kbu4/BP8pL0+Ph+/QX/s/2n/F/9A/7v/Ij7FPxk/osAvAFyAoICOAF7/5r/XwLqBUkIpgm/CtwKKgkWBxwHYgl4C8kLWgtkCywLtQkiCFsI/QnECtkJvQhqCHgHLgT6/ov5uPS28GnuSe5T7lrrJOVa303dS95q36PfWuCs4lrmHuvU8NT1gvf09U/1mfneAXIJSg0sDsUNRQzjCXMIZQlbC88LmQrYCUkK0wmKBoYBlP03/CL9kv+bAqYEZASbAowBLAI1A4EDFwTEBoQLghAxFCEWKhZlFFESfRLlFWIauxz/G+QZOBj/FkgV1hJdEJEOjA3gDMILYgmeBYYBq/6h/VP9F/xo+V32YfSW87PyjPCA7SDrgeof643r7Oqm6QDpIuo27efwB/Nt8mnw1O838kb2aflr+ir6C/qu+g/85/1w/6f/i/7Q/VD/zAL7Be8G+wX8BGgFUAehCdMKBwooCJkHyQkpDYkOnQxQCWMHwAe7CaUMxw94ESUQfgwVCRcHlAQY/z73dPB17cvti+6b7KfmWN7t10DXMtyC4u/lEuba5f3nvux08hj3k/nQ+oD9fQMVCwAQ4A/qDE4LmQyjDpIOwAvCB68EiwOPA6ECQv9t+v72yfbM+K/6Y/uX+z/8r/0EAFID+QbHCTsLXgypDl8SRRbLGDEZ1xcRFooVJxcxGtYclh0qHC8ZeBXhERsPPA2uCwYKpwgSCM0HjQavA/X/rfy2+nL62vvl/ZT+r/xu+Uz3Gfc99xL23PO+8e3vIu7y7PrsEO0U6xnnBeRQ5FHnyOrV7dXwbPOp9Pn0CvZb+KD6KvxN/g4C5QVOB/QFyQNuAiEC+QI5BQIIYAmbCD0H3gYGB3wGwQWkBrIJdg07EDYRFxAiDScKsAkmDPYOjw9PDjYNqAwNCwMHUgBR94ztzeZp5lTqh+ub5Xrc6teI2t7fAOPD49vkBeil7XD1Nf0GAaT/nP3SABMJEBBBEbsOIQ2eDeMNHAxmCHwDjv6n+9X73fw8+7/2BfPV8vr0zfbl97P52vzSADUFhAk8DC8MzAo5C70OfRMNF8gYJhloGPYW3BWCFeMUTxM2EoITgBYgGGAWFhIcDX4IDQUJBJsFkgdZB/YEnAKIAdkAz/9Q/zUAXQH+AFP/Cv45/aj6FfXE7lLrpetU7dvt3Owq607p7+dA6Hbqguwl7EnqjerP7qH0OPiw+Cn4b/ho+aL6jfxn/zwC/wPQBEEFDAW7A0QCgwLcBIEHvAj/COoJ3QuJDdcNQA0MDdoNXA/oEMgRaRHWDw8OLg05DUoN8AxyDGcLAAj3AMT3j+/+6TrmTuPB4efhH+Kb4DLect0h357hHuRI6Gnvs/f8/VgBPgPSBAMGGQcVCQYMcg4jDzkO3QtxBx0BDPuc99z2EPcu94j3Uvjy+AH51vjd+Hr5pvtiAPUG5wyFEHcSHhRtFYQVshRHFL4UYRW2FfkV7hWaFMcRxw72DEEM+QtEDIsN+Q7WDpQMjwl8B9gGKgfwB7AI1AgTCOAGvwV4BHcC8P/a/cj8KfwA++34OPZE81zw7O1b7KbreOuv613sQO2y7XztX+1K7ifw0/Fq8iXy6fFd8pTzJPVI9kH2P/Wp9AX2aPlD/cn/MwAF/5H9av1I/xYClgOiApMA1v9kASoEoAY8CE0JXArkCwUO9A9xEFYPMQ6KDuoPVhCqDq4L4wgTB1AGdAYVB3IHEwctBuwE7gI4ADf+lP4EAXIDtgTPBYoHOAhuBZX/vPnf9TDz2PAB8FbxCfJc7uLmgOCD3iLfMd/03gXh2OUt63XvD/MF9nD3NfjH+wwEBw6uFHcW7BVwFcwUHBP9EK4PZg+MD3cPIA4wCr0DYv08+s/6y/zO/X/9DP2d/Xz//gHtA5wE8QTCBtwKBRAgFOYVZRWEE30RVxAzEEQQ3A8rD5oOvQ2qC0cIhgROAcv+9vwT/B38S/y8+2X6u/jh9uL0h/P+80n25PhU+nD6hfku91Pz1e9z73DyoPXg9ZTzkfFL8aXxY/EV8e7xHvQE9xr6tPyu/a/8WPvV+1f+9wBRAgUDXARrBjEI7gidCKsHxAaVBiQHrQeQBwkHfgaUBb0DgQFYAC4BkQNbBocIewlJCfEIggmlCsIKLgmPBywIKgsfDmIOUQt5Bi0CyP/J/qr9x/sO+gP5y/by8FfoeeGy31vhO+L94FXg4uL05/TsaPCd8qX05/eU/RAFZAviDUENpwyiDaAO3Q02DOMLYA3lDpwOLgyACPoE+gLkAnQD5AIrATwAgwHSA4EEWwLE/j38WfzU/gAC/QMUBDkD3QI5Ay4DBgLSAIgB3wRsCd0Mzw19DCwKNghtB9oH4wi4Cd4JWglQCJwGAgTFANH9GPzJ+0f8y/zf/En87PoC+Tr3WPas9gb47fmk+z38SPuH+W74oPhT+Yj5Yfm/+dT62Psd/L37KPup+of68Ppm++j6Tvnn9/b3Fvnq+RP6YvpJ+0j8Jf1r/hYAEgHkAOwApAI7BXEGnQVnBFoEHwWQBWIF4gQQBPICKAIWAvQBvQDq/ir+UP9PAZkCywKeAtICeQMKBOMDAANZAvoCkAReBRUEYwE6/9T+y//oAFcBKwE+AVgCDgS2BCoDjwCA/y0BAQR4BccEFwO8Af8AfADq/1b/Mv8vAH4C6AR1BXADgAAx/3IA+wLiBGkFHQXRBL0EWATVAv7/yPzO+q/6+Poy+Vn0J+6s6Y7o2Olq60vsVO2771rzlfbf9z/3Z/ZW98P6hv+RA5wFCQYsBroGMAfdBigGYAYeCDIKkgpfCOQEfgKOAoEEmAZxB/AGAgavBUoGPgehByUHawY8BoUGWQYSBTQD1gFhASYBRQCr/hT9Wfy0/JP9G/71/az9GP5B/y4ADQBf/5T/fQFABAAGfgUaA3wAV/8dALoBjwIGAhUBDQH1AVwC5wDh/R77W/qz+5H9E/6h/Gf6L/m3+SP7EPwV/Aj83Px7/vT/lAChAOMAugG2AioDBQP3ArgDIgU0BvkFdgSzAtkBLgLYAqkCVwHw/8H/uQAXARv/E/tn92/2UPj5+gP8jfqr92P1GvWi9pz47fm8+un7n/3I/iD+uvtU+QL5afsZ/5cBbwFi/4X9N/35/XD+KP74/dv+yADCAqkDEwOuAfwAOwIXBbsHigi3B6gGEQZFBaUD7AGHAeQC/QRoBm0GKQVEA7sBfwHSAioFywdACgsMZgzlClwIjAasBmEIRwoyC8wKWwlIB+IEWQLw/0b+Lv7R//EBkgK6AHD9t/qr+dj5O/pr+rb6jPsF/ZP+CP9l/Sb6avcY9+j4tPq2+uP4MvZm8/LwOu9Y7gXuTu7P75/yWvVK9l/1UPSs9J/2nvlE/QkB/wN8BbkFUwWlBDEE4wQXB50JqgrBCe8HMAaGBMgCegEvAbgBdAIkA8kDCgReA9gBRQB7/8j/DQHnAqQEgwVLBYAE1gObA8sDhwQKBi4IOQpaC0YLPwrBCEQHRQYVBo0GDgf6BhYGbwQdAmr/Df3i+yD8K/0u/qr+XP79/JT69vd19tz2zvgc+5v8tvyA+4D5a/fq9XD1D/Zg95n4/PhB+Kf2ufQy89zyKfTE9sT5ZPxw/vH/yAD9ABsB4wGSA8MFAQgNCosL2gu+CtoISAetBv4G9QdLCXQKlQouCaoGIQSOAlYCUQPrBFQG1gYwBpEETAK8/3j9QPxl/F/9Kf4S/hf9ofso+ij5EPn2+XP77PwK/sH+/v6Q/n39TPzH+3r8Xv7MAKkCxQK3AIT9Hvvj+nv8Xf5k/7D/DgDZAIABEgFA//j8B/yf/QAB0AMnBD8CAAAL/3b/QAChALIAJAFHAl8DCwOnAF/9cfsq/LP+/wDLAXABCwEiATIBeAAT/0n+c/90AnMFXgbJBCcCZABQAEwBGQL5ATQBpACcAF0A3P4f/Ij5iPhA+ZX6cfuY+4H7pvss/OX8k/0u/hb/uQDzAs4EQQUvBI0CgQFxAfQBcAKbAnsCMQLPAToBPQDx/vj9EP4v/10AtwBpAGgARQGRAnYDngNnA4MDbgQFBm0HqAeHBt8ErgMfA6UC3gH/AFEAuf/O/l79iPup+UD4sffo91X4c/hI+Dz4ffjP+AH5SPkJ+lP7tPyH/Xv95fyR/Bb9Nf4C/8/+6v1G/Xf9JP55/g3+Sf32/IX9sP7I/1gAhwDPAHsBXAL9AhgD1gLBAkgDSwQcBR8FbAS6A5sD9wNPBFkEOwRLBLIETwXJBdsFlQVmBawFUwbnBgkHuAYpBosF+ASJBEUEFwTxA9kD1QPBA2ADmQKYAboAVQB2AM8A5gB5AK3/3v5F/uT9tf26/en9I/5U/nz+lP57/iL+qf1S/T79Wf1v/VT97vw3/Ez7bfrW+Yv5T/nm+Fb46PfP9+z39ffL95n3mffZ9zz4nPjY+OT43fj++GL53/k9+n760fpH+7r7Gvye/Jn9Gv/YAGgCfgMQBGME7wQKBo8H/AjqCVUKdApSCtcJDQk7CKEHRQcNB+EGmAYEBiYFTgTUA7QDrgO6AxgE2wSjBfEFpAUJBYgEYwSkBBIFRAUBBYMENAQUBJ8DegIDAQ4AGgDKAD4BzwCf/3v+N/7x/vj/ZQD+/1//aP9IACoB3AAI/8T8qPse/Lz8l/tI+Gz0CfKi8d7x//Ca7hbseuuG7cDwnvLi8dnvCO+t8K7zBPbS9hr3hviz+4n/MQLNAlIClAJUBHkGYAfABu0FSQbNBzcJZQl2CKMHCwiLCcYKhgoYCQIIRgg/CXwJgwhUBzkHWwioCdkJlQi8Bq4FBgYIB3QH8wZwBuEGDgjLCFIIBQfbBWMFZAU7BXUEOgM1AvABHQK8ASQA2f0Y/Jb7z/uu+6L6C/m29xD30vZb9mj1c/Q49N70sfXe9V71BvWh9Rz3mPg6+fz4tfha+Qz77vz+/Rz+D/6Y/qH/fgDFALkA9ADEAdoCfwMyAzcCewHCAd8C1wPkAzkDsgLpAqoDQwRHBPsDCATFBMAFFAZBBbcDbwIOAmQCvgKRAukBSQEhAVYBXQHQAPX/e/+8/0oAaQDO/+H+O/4D/uL9c/22/BL86/s4/HT8Hfwx+zr6v/nI+ej5yPmJ+Z35S/ph+1n80Pzv/Fv9oP6cAI0CxgNWBNMEjgU0BkEGsgUWBfsEZAXTBboF9QTyA2oDwwOgBDcFIgXYBCUFRAaeB2IISAi8B1wHZweUB2gHswatBawEuQOkAloBGQA6/8r+df7G/Z38avvf+jj7zPuj+5D6kfnZ+W/77fyy/GP6Yfek9fb1JvcU99n0zvFI8ErxhvOv9KPzXfHs743wn/Jf9LX0VfTw9GL3xfpn/Xv+u/6D/28B4AOrBVQGjgZzB0oJLwsODM4LXgu3C+EM9w38DcUMJAswCjUKdgoSCgoJMQgbCHMIZAiIB0kGZQVGBawF+AXQBY0F0wXBBp0HggdMBr4EvwOTA7oDhAOxApoBxQBJALv/tv5h/UH8lfsX+036EPmm94P26vW79Yb1/vRT9AD0LfRd9PvzG/OL8gPzdPQU9g73H/e+9sD2uPeC+Wr73vzx/Rz/jgDvAc4CNwO3A9EEeAYbCCAJYQkyCQQJAAn9CMoIdQhMCIQI9AgfCaAIhAdHBmQF6gSSBB4EngNCAxMD4gJ9AuwBaAEzAV4BtwHgAZgB9ABQAPL/xP9//wX/gv4w/v39mf3M/MD74vp8+n76mfqQ+lr6APp++c74Dfh590z3iff290H4Nfjm96b3yPdf+D35Ivry+rX7evxB/ez9U/5q/nT+9f45AOYBGQMcAxMC6ACaAHcB5wLyAxcEwQPeA9wEJwarBvQFsgQaBM0EXwbCBy0IpwfjBp8GDQe8BxUI7gerB8kHSgiyCJIIBgiZB6UH7AffBz0HSwaCBRkF2gRfBHIDQwJKAdYAsgBUAH//kP4S/gP+uP2X/MP6APnj90f3hfY79cPz5fIB85HznPO28n/xDvHM8QPzoPNO88ryFfNq9Bb2Nveb9+n36/jB+rX82/38/dj9Zf7P/0oB+AHhAeMBwQJOBKAF9wVtBdwEEAUFBt8GxwbWBRAFVwV6BnEHfAfhBoIG5wa1BxkIoAe4BlAG/AZWCFQJSAmACNkHzQcCCM4HBgcyBvcFawbwBsUGvQVoBIUDPQP7Ag8CcADX/vr90f2a/aP8AfuC+eP4Kvmo+aT5+fgm+Mr3CviJ+Nz4AvlS+QP63fp0+5n7jfuz+zr8//y4/Tv+o/4t/+3/mwDgAL8AsAAlAQ0C3QIgA+ACkgKhAhYDmgPQA7IDkgO5A/4D5QMrAyQCeAF+AewBHAKoAbsA2/9f/yD/q/7J/cb8IPwL/Ez8iPyO/Gb8L/wN/Bj8TvyU/Nb8G/1u/cf9Ef5M/pH+4f4b/xj/4/6x/rL+3/4J/w3/Bv8u/5//IwBvAHkAlQAcAQkC8AJdAz8D+wIDA2QDtwOHA9cCIwLYAdgBmwHEAIj/e/4G/g7+Hv7b/Un9vPx9/Ij8n/yX/IX8o/wM/aL9Lv6S/tb+FP9l/9T/WgDjAFoBtAH6ATsCeQKpArwCrwKOAnECcQKTAroCtwJ1AhwC5AHaAckBegH4AIYAUQBVAGkAagBJABMA8f8MAGAArgDNAN0AGQF3AaABYQH8AOsAXgEMAn0CfQI2AvgB9AEPAgMCowEXAb0AzAATASgB1gBXABMALgBhAE0A6v+Q/6D/BQA8ANn/Df+G/rr+ZP/P/6D/PP9P/wcA3gAgAaYABAAEAN4A9AFeAtYBDQH1ALABYgIYAtYAmf9C/6z/zf/C/rf8xfrt+Sb6cfre+YX4Yfc69833HPiA91j2nvXv9fv23/f794D3Nve49+H48flc+lX6kPp5+8j82P1b/pr+Ef/z/woBDALZAo0DTAQXBckFRAafBh0H5QfMCHUJpAl+CV0JeQmyCcAJhgk1CRAJHwklCewIiQhFCEoIeQiSCHUIPwghCCEICgiUB7gG0AVJBTEFHQWLBGkDJAI7AbsAMgAv/7/9bfyw+2/7H/ta+j35Qvi494j3YPcT98j2w/YM91n3WPcK98X26/aS93j4N/md+c/5GvqQ+u369frZ+hb74PvU/Ff9OP3V/MX8S/0q/t/+Jv8//6T/dgBOAa0BkAFoAZ8BMgLKAhED7gKPAjoCDgLxAcUBnQGuAQECWgJzAkUC+gHLAdUBGQJ5AsYC4gLWAsMCrQKAAioCwwGAAYMBvgH6AQkC7gHaAfIBIAImAuwBoQGTAdgBNgJjAlICMQIgAgwC1QGHAUoBKAH6AJUA+v9M/6/+Mf7H/Vz95/yA/ED8G/zS+zn7f/oJ+g36WPqI+nf6Uvpb+qL6/fo++2T7oPsk/PL81/2Y/iz/vP9tAEABFQLPAmkD9QOGBB0FoQXuBe8FvQWJBXgFgwWKBXAFLgXOBGMEBgTGA58DigOMA60D4QMCBPgDzAOkA5oDpQOmA4MDPQPqApoCQALDASkBngBQADkAIwDc/1b/s/4X/pL9G/2i/Cr8zvud+4H7Tvvw+of6Qvov+jP6MPoq+jn6b/q1+uH64/rh+h/7tftx/Av9a/24/Rr+h/7Z/v7+D/83/5P/GQCcAN8A0gCkAJ4A2QAmAUYBMAEOAQwBLQFUAWIBRAEGAcsAvQDfAAcBAQHLAIcATgATAMr/iv+B/7D/2v/K/4//b/+Z/+//IgAFALv/mP/S/0EAhgBpAB8AFAByAO0AFAHPAHQAZQCtAP4ADwHjAMAA6QBaAcoB9QHmAfYBbQIpA7YDxwOEA2IDqwM+BLQExgSKBFEESgRSBCcEtwM6A+UCsAJeAswBGAF9AB4A5/+j/zX/t/5l/ln+Zv5G/u/9nv2V/cr98P3J/Wj9G/0Z/Uv9Zv05/ef8vvza/AX9+Pys/Gj8cPy7/P389vyr/GH8VfyE/Lj8wfyo/Jv8u/z7/DL9SP1H/Uj9W/1//aj9zf3p/Qj+NP5u/qf+y/7X/uH+Cf9a/8b/LwCLAOAAMgF4AaYByAH7AVQCwgIgA1kDbgN2A4kDtgP5AzgEVwRcBHYEywRJBbAF0gXCBbkF2AUSBj8GTQZNBloGcAZsBjMG2AWJBV8FOgXvBHUE6gNoA+oCYALKAT0BxgBfAPH/YP+n/uP9P/3W/Jb8V/wA/JP7KPvX+qb6evot+rf5QfkC+ff43/iI+AH4gfcm9+j2vvay9sj29fY094L30fcH+Cr4aPjl+Iv5L/rS+pH7aPwl/bH9Nf7q/sj/lwA2AbwBTwL6ArQDcgQnBbsFJQaDBgMHqQdHCLAI4gj5CP8I5AikCFQIGAj/B/UH1weMBxkHmgYnBrkFNgWWBPgDfAMiA8YCTQK6AR8BhQDs/1r/2/50/iP+3v2S/Sr9pPwk/NL7uPux+5D7T/sL++X64Prg+sz6qfqP+o/6q/rc+iD7cvvG+wz8Qfxs/J788fx2/R/+uf4c/1D/fv+//w0AYgC9ABMBSAFcAW8BmgHHAdMBxgHMAfoBPwKDArgC1QLYAtQC5wILAxgDAAPvAg0DQANMAxsDzwKOAmcCYgKDAqoCnwJQAuwBqQGKAWgBLwHrAKIATADt/6D/d/9g/zv/A//L/qT+jv6C/n7+gP6L/pz+qf6k/oz+ef6K/r/+7f7m/qj+Xv47/kr+dP6a/rP+xP7a/vv+K/9f/4T/k/+h/8r/BwAtACAA/f/3/xoASgBmAHUAhQCSAIoAcQBbAFMAUQBPAFAAUwBHAB8A5f+z/5b/h/93/2j/Yv9k/2X/Yv9e/1j/Sv86/z7/XP9//43/jf+g/9T/DAAnACUAJAAvADgANAAuACwAHgD2/8L/pP+u/9X/DgBRAIoAmwB9AFIARgBfAHwAggB+AIsAtgDxACYBQgFAATQBQgF+AdQBEgIkAh0CGwIfAiACJAI7AlYCSgIDAqABUwExAS0BNQE9ATgBGAHlAK8AdgAoAMP/Yf8c/+n+qv5Y/gD+qf1O/fT8s/yU/Ib8dvxs/G/8aPw6/O/7ufu3+9v7/fsS/Cb8Rfxs/JT8sfy+/Lz8wvzm/Cb9bv20/QX+Y/6v/tD+2/4C/13/0f83AI4A3wApAWMBmQHlAUsCqgLsAiIDaAPEAywElwQCBVsFiAWFBWYFQAUgBRMFHgUsBRoF3wSgBIEEcQRHBPsDsQN+A0oD/AKfAkwCAAKlAT4B5ACTACEAff/Z/n7+av5b/in+6v29/Yr9Jv2n/Fv8YvyC/HT8PPwN/PT7y/uF+0n7OvtP+3j7vvsf/F/8QPzh+6v71vs4/Iv8z/wq/Zn98f0p/mf+wv4i/3P/0v9kABcBrwEOAk0CjALMAgADMgNxA7gD8QMPBBQEBATfA6YDaQNBA0EDZwOXA6kDhQM6A+UClgJGAvABlgE+AfEAuACVAG4AHwCw/1v/Vf+L/6//mP9e/zH/Iv8p/0P/av+I/4z/hP+J/4v/YP8A/5v+Y/5P/jj+FP4A/hH+Nv5N/kP+IP7+/fX9DP4q/i/+Dv7a/bH9p/3B/fH9Gf4i/hL+Df4o/lP+bv5x/mr+Yv5W/lX+iP79/o3/AAA9AFMAUQA+ACoAMABZAJYA1AATAU4BbQFbAScBBwEcAVcBlwHMAf0BIgIkAv8ByQGZAW0BRQE7AW0BwgH4AekBtgGXAZQBigFsAVIBTQFAARQB3wDGAMQAtwCZAJIArwDIALUAhwB3AJMAswC7ALkAxQDVAM4AqQB7AE4AIAD5/+n/9v8EAPX/vv95/0X/MP84/0r/Vf9Q/0H/M/8v/zf/Rv9U/1f/Uv9N/03/SP8z/wv/2P6q/o/+lf60/tP+2v7T/tz+/P4N/+j+of53/pD+1P4I/wv/5f6w/n7+YP5h/oD+pv61/qT+h/59/pv+2f4d/0z/Yv9o/2r/bv97/5v/zv8LAEUAbwCCAHoAZwBpAJYA4QAmAVABbgGbAd4BJQJeAn4CggJzAmcCdgKfAsUCyQKpAnwCWAJBAjcCNQIzAiAC+wHcAdwB9wEOAgsC8wHPAZMBNwHaALYA1gADAf4AygCWAHgAUQAEAKH/Tv8g/w//Ef8Z/xH/6f6t/nf+S/4T/s39nv2j/c79+P0Q/hP+/v3L/ZL9ef2B/Yn9g/2H/ar91v3o/eT96v0G/iX+Qf5o/qL+2v77/hD/LP9L/13/Z/92/4r/kP+H/4//vP/4/xgACgDq/9v/4f/g/8z/xv8AAH8AAAFGAVEBTAE+AQsBswByAHkApgC7ALEAtQDQANgAtACUAKkA4QAHAQsBCAEHAfQA0AC7AMMAxwCmAHsAfACsANsA5wDZAMwAxwDEAMoA4wAGARwBHAEQAQgBAgH5AOcA0wDBALIAoQCMAHcAcwCGAKMAtgC1AKAAeAA9APn/v/+e/5P/lv+m/8D/1f/R/7f/mP9//3L/e/+k/9f/6v/Z/9b//f8kAAsAwP+W/73/AgAjACcANwBOAEEAFQADACAAMwAPANn/0P/s//b/3//Q/9H/sv9d/w//Cf83/0r/Jf/w/s/+rP5w/jH+G/41/mr+qP7k/gj/Av/b/q/+jP5n/kb+Q/5s/qX+yP7N/sT+tP6e/o3+l/6+/u/+IP9k/7z/BgAZAAEA7//z//L/1//C/+H/KABeAGYAXgBrAIoAqQDQABQBYwGVAagBzQEfAncCnwKgAq0C\" type=\"audio/wav\" />\n",
+              "                    Your browser does not support the audio element.\n",
+              "                </audio>\n",
+              "              "
+            ],
+            "text/plain": [
+              "<IPython.lib.display.Audio object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "wav_file_name_example = \"spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/7_jackson_43.wav\"  # change this to hear other examples\n",
+        "display_example(wav_file_name_example)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-QvbZA7yHwkh"
+      },
+      "source": [
+        "## 3. Use pre-trained SpeechBrain model to featurize audio\n",
+        "\n",
+        "The [SpeechBrain](https://github.com/speechbrain/speechbrain) package offers many Pytorch neural networks that have been pretrained for speech recognition tasks. Here we instantiate an audio feature extractor using SpeechBrain's `EncoderClassifier()`. We'll use the \"spkrec-xvect-voxceleb\" network which has been pre-trained on the [VoxCeleb](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/) speech dataset.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 93,
+      "metadata": {
+        "id": "vL9lkiKsHvKr"
+      },
+      "outputs": [],
+      "source": [
+        "%%capture\n",
+        "\n",
+        "from speechbrain.pretrained import EncoderClassifier\n",
+        "\n",
+        "feature_extractor = EncoderClassifier.from_hparams(\n",
+        "  \"speechbrain/spkrec-xvect-voxceleb\",\n",
+        "  # run_opts={\"device\":\"cuda\"}  # Uncomment this to run on GPU if you have one (optional)\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vXlE6IK4ibcr"
+      },
+      "source": [
+        "Next, we run the audio clips through the pre-trained model to extract vector features (aka embeddings).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 94,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 143
+        },
+        "id": "obQYDKdLiUU6",
+        "outputId": "4e923d5c-2cf4-4a5c-827b-0a4fea9d87e4"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <div id=\"df-61254466-60f8-433b-9870-cc518010ec20\">\n",
+              "    <div class=\"colab-df-container\">\n",
+              "      <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>wav_audio_file_path</th>\n",
+              "      <th>label</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/7_george_26.wav</td>\n",
+              "      <td>7</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/0_nicolas_24.wav</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/0_nicolas_6.wav</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-61254466-60f8-433b-9870-cc518010ec20')\"\n",
+              "              title=\"Convert this dataframe to an interactive table.\"\n",
+              "              style=\"display:none;\">\n",
+              "        \n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "       width=\"24px\">\n",
+              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
+              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
+              "  </svg>\n",
+              "      </button>\n",
+              "      \n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      flex-wrap:wrap;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "      <script>\n",
+              "        const buttonEl =\n",
+              "          document.querySelector('#df-61254466-60f8-433b-9870-cc518010ec20 button.colab-df-convert');\n",
+              "        buttonEl.style.display =\n",
+              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "        async function convertToInteractive(key) {\n",
+              "          const element = document.querySelector('#df-61254466-60f8-433b-9870-cc518010ec20');\n",
+              "          const dataTable =\n",
+              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                     [key], {});\n",
+              "          if (!dataTable) return;\n",
+              "\n",
+              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "            + ' to learn more about interactive tables.';\n",
+              "          element.innerHTML = '';\n",
+              "          dataTable['output_type'] = 'display_data';\n",
+              "          await google.colab.output.renderOutput(dataTable, element);\n",
+              "          const docLink = document.createElement('div');\n",
+              "          docLink.innerHTML = docLinkHtml;\n",
+              "          element.appendChild(docLink);\n",
+              "        }\n",
+              "      </script>\n",
+              "    </div>\n",
+              "  </div>\n",
+              "  "
+            ],
+            "text/plain": [
+              "                                                         wav_audio_file_path  \\\n",
+              "0   spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/7_george_26.wav   \n",
+              "1  spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/0_nicolas_24.wav   \n",
+              "2   spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/0_nicolas_6.wav   \n",
+              "\n",
+              "   label  \n",
+              "0      7  \n",
+              "1      0  \n",
+              "2      0  "
+            ]
+          },
+          "execution_count": 94,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Create dataframe with .wav file names\n",
+        "df = pd.DataFrame(file_paths, columns=[\"wav_audio_file_path\"])\n",
+        "df[\"label\"] = df.wav_audio_file_path.map(lambda x: int(Path(x).parts[-1].split(\"_\")[0]))\n",
+        "\n",
+        "df.head(3)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 95,
+      "metadata": {
+        "id": "I8JqhOZgi94g"
+      },
+      "outputs": [],
+      "source": [
+        "import torchaudio\n",
+        "\n",
+        "\n",
+        "def extract_audio_embeddings(model, wav_audio_file_path: str) -> tuple:\n",
+        "    \"\"\"Feature extractor that embeds audio into a vector.\"\"\"\n",
+        "    signal, fs = torchaudio.load(wav_audio_file_path)  # Reformat audio signal into a tensor\n",
+        "    embeddings = model.encode_batch(\n",
+        "        signal\n",
+        "    )  # Pass tensor through pretrained neural net and extract representation\n",
+        "    return embeddings\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 96,
+      "metadata": {
+        "id": "2FSQ2GR9R_YA"
+      },
+      "outputs": [],
+      "source": [
+        "# Extract audio embeddings\n",
+        "embeddings_list = []\n",
+        "for i, file_name in enumerate(df.wav_audio_file_path):  # for each .wav file name\n",
+        "    embeddings = extract_audio_embeddings(feature_extractor, file_name)\n",
+        "    embeddings_list.append(embeddings.cpu().numpy())\n",
+        "\n",
+        "embeddings_array = np.squeeze(np.array(embeddings_list))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dELkcdXgjTn_"
+      },
+      "source": [
+        "Now we have our features in a 2D numpy array. Each row in the array corresponds to an audio clip. We're now able to represent each audio clip as a 512-dimensional feature vector!\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 97,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "kAkY31IVXyr8",
+        "outputId": "fd70d8d6-2f11-48d5-ae9c-a8c97d453632"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[-14.196314    7.319463   12.478973  ...   2.289077    2.8170207\n",
+            "  -10.892647 ]\n",
+            " [-24.898058    5.2561903  12.559641  ...  -3.5597146   9.620667\n",
+            "  -10.28525  ]\n",
+            " [-21.709621    7.5033717   7.913801  ...  -6.81983     3.1831474\n",
+            "  -17.208763 ]\n",
+            " ...\n",
+            " [-16.084263    6.3210497  12.005459  ...   1.2161485   9.478238\n",
+            "  -10.682177 ]\n",
+            " [-15.053809    5.242468    1.0914198 ...  -0.7833452   9.039536\n",
+            "  -23.569172 ]\n",
+            " [-19.761091    1.1258258  16.753227  ...   3.3508904  11.598279\n",
+            "  -16.237118 ]]\n",
+            "Shape of array:  (2500, 512)\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(embeddings_array)\n",
+        "print(\"Shape of array: \", embeddings_array.shape)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "o4RBcaARmfVG"
+      },
+      "source": [
+        "## 4. Fit linear model and compute out-of-sample predicted probabilities\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "y9BIVyI9kHa4"
+      },
+      "source": [
+        "A typical way to leverage pretrained networks for a particular classification task is to add a linear output layer and fine-tune the network parameters on the new data. However this can be computationally intensive. Alternatively, we can freeze the pretrained weights of the network and only train the output layer without having to rely on GPU(s). Here we do this conveniently by fitting a `sklearn` linear model on top of the extracted network embeddings.\n",
+        "\n",
+        "To identify label issues, cleanlab requires a probabilistic prediction from your model for every datapoint that should be considered. However these predictions will be _overfit_ (and thus unreliable) for datapoints the model was previously trained on. Cleanlab is intended to only be used with **out-of-sample** predicted probabilities, i.e. on datapoints held-out from the model during the training.\n",
+        "\n",
+        "K-fold cross-validation is a straightforward way to produce out-of-sample predicted probabilites for every datapoint in the dataset, by training K copies of our model on different data subsets and using each copy to predict on the subset of data it did not see during training. An additional benefit of cross-validation is that it provides more reliable evaluation of our model than a single training/validation split. We can obtain cross-validated out-of-sample predicted probabilities from any classifier via the [cross_val_predict](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_val_predict.html) wrapper provided in `sklearn`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 98,
+      "metadata": {
+        "id": "i_drkY9YOcw4"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.linear_model import LogisticRegression\n",
+        "from sklearn.model_selection import cross_val_predict\n",
+        "\n",
+        "model = LogisticRegression(C=0.01, max_iter=1000, tol=1e-1, random_state=SEED)\n",
+        "\n",
+        "# Generate cross-validated predicted probabilities for each datapoint\n",
+        "cv_pred_probs = cross_val_predict(\n",
+        "    estimator=model, X=embeddings_array, y=df.label.values, cv=5, method=\"predict_proba\"\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FW1yI9Ryrfkj"
+      },
+      "source": [
+        "For each audio clip, the corresponding predicted probabilities in `cv_pred_probs` are produced by a copy of our LogisticRegression model that has never been trained on this audio clip. Hence we call these predictions _out-of-sample_. An additional benefit of cross-validation is that it provides more reliable evaluation of our model than a single training/validation split.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 99,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "_b-AQeoXOc7q",
+        "outputId": "15ae534a-f517-4906-b177-ca91931a8954"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Cross-validated estimate of accuracy on held-out data: 0.9772\n"
+          ]
+        }
+      ],
+      "source": [
+        "from sklearn.metrics import accuracy_score\n",
+        "\n",
+        "predicted_labels = cv_pred_probs.argmax(axis=1)\n",
+        "cv_accuracy = accuracy_score(df.label.values, predicted_labels)\n",
+        "print(f\"Cross-validated estimate of accuracy on held-out data: {cv_accuracy}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SPz8WBwIlxUE"
+      },
+      "source": [
+        "## 5. Use cleanlab to find label issues\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "laui-jXMm6qR"
+      },
+      "source": [
+        "Based on the given labels and out-of-sample predicted probabilities, `cleanlab` can quickly help us identify label issues. Here we request that the indices of the identified label issues should be sorted by cleanlab's _self-confidence_ score, which measures the quality of each given label via the probability assigned it in our model's prediction.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 100,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "HIlBwv17gJvH",
+        "outputId": "136accc8-7fa6-4d54-b30c-5df7c5def0f6"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[ 516 1946  469 1871 1955 2132]\n"
+          ]
+        }
+      ],
+      "source": [
+        "import cleanlab\n",
+        "\n",
+        "label_issues_indices = cleanlab.filter.find_label_issues(\n",
+        "    labels=df.label.values,\n",
+        "    pred_probs=cv_pred_probs,\n",
+        "    return_indices_ranked_by=\"self_confidence\",  # ranks the label issues\n",
+        ")\n",
+        "\n",
+        "print(label_issues_indices)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "iI07jQ0BnTgt"
+      },
+      "source": [
+        "The datapoints flagged by `cleanlab` are those we worth inspecting more closely.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 101,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 237
+        },
+        "id": "FQwRHgbclpsO",
+        "outputId": "fee5c335-c00e-4fcc-f22b-718705e93182"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <div id=\"df-b06ea290-25ea-47a4-8ffb-4077889f55c6\">\n",
+              "    <div class=\"colab-df-container\">\n",
+              "      <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>wav_audio_file_path</th>\n",
+              "      <th>label</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>516</th>\n",
+              "      <td>spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_yweweler_36.wav</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1946</th>\n",
+              "      <td>spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_yweweler_14.wav</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>469</th>\n",
+              "      <td>spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_yweweler_35.wav</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1871</th>\n",
+              "      <td>spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_theo_27.wav</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1955</th>\n",
+              "      <td>spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/4_george_31.wav</td>\n",
+              "      <td>4</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2132</th>\n",
+              "      <td>spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_nicolas_8.wav</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-b06ea290-25ea-47a4-8ffb-4077889f55c6')\"\n",
+              "              title=\"Convert this dataframe to an interactive table.\"\n",
+              "              style=\"display:none;\">\n",
+              "        \n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "       width=\"24px\">\n",
+              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
+              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
+              "  </svg>\n",
+              "      </button>\n",
+              "      \n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      flex-wrap:wrap;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "      <script>\n",
+              "        const buttonEl =\n",
+              "          document.querySelector('#df-b06ea290-25ea-47a4-8ffb-4077889f55c6 button.colab-df-convert');\n",
+              "        buttonEl.style.display =\n",
+              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "        async function convertToInteractive(key) {\n",
+              "          const element = document.querySelector('#df-b06ea290-25ea-47a4-8ffb-4077889f55c6');\n",
+              "          const dataTable =\n",
+              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                     [key], {});\n",
+              "          if (!dataTable) return;\n",
+              "\n",
+              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "            + ' to learn more about interactive tables.';\n",
+              "          element.innerHTML = '';\n",
+              "          dataTable['output_type'] = 'display_data';\n",
+              "          await google.colab.output.renderOutput(dataTable, element);\n",
+              "          const docLink = document.createElement('div');\n",
+              "          docLink.innerHTML = docLinkHtml;\n",
+              "          element.appendChild(docLink);\n",
+              "        }\n",
+              "      </script>\n",
+              "    </div>\n",
+              "  </div>\n",
+              "  "
+            ],
+            "text/plain": [
+              "                                                             wav_audio_file_path  \\\n",
+              "516   spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_yweweler_36.wav   \n",
+              "1946  spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_yweweler_14.wav   \n",
+              "469   spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_yweweler_35.wav   \n",
+              "1871      spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_theo_27.wav   \n",
+              "1955    spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/4_george_31.wav   \n",
+              "2132    spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_nicolas_8.wav   \n",
+              "\n",
+              "      label  \n",
+              "516       6  \n",
+              "1946      6  \n",
+              "469       6  \n",
+              "1871      6  \n",
+              "1955      4  \n",
+              "2132      6  "
+            ]
+          },
+          "execution_count": 101,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df.iloc[label_issues_indices]\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PsDmd5WDnZJG"
+      },
+      "source": [
+        "Let's listen to some audio clips below of label issues that were identified in this list.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "p9jLn3Lp85rU"
+      },
+      "source": [
+        "In this example, the given label is **6** but it sounds like **8**.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 102,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 92
+        },
+        "id": "ff1NFVlDoysO",
+        "outputId": "8141a036-44c1-4349-c338-880432513e37"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Given label for this example: 6\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "                <audio controls=\"controls\" >\n",
+              "                    <source src=\"data:audio/wav;base64,UklGRiAiAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YfwhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD//wAAAQAAAP//AAACAAAA/f8AAAUAAADy/+n/9P8BAPz/6P/k//j/BwD+/+z/7f/8//7/9f/3/wYACgD5/+r/8f/3/+3/5//7/xAABQDu//P/CQD//9T/yv/4/xcA8v+9/8//DAAPAM7/r//x/zoAKADb/8X/+/8lAA8A7f/y/wgAAgDr/+r/+f/1/+H/4f/2////8f/r//3/CwAFAP7/AgAFAPz/9//+//j/5f/u/xIADADL/7n/EABMAOX/b//Y/34Aaf9I/Br69fumAFwDQgHZ/L/6hvz0/3kCZAPzAmQBsP+P/4ABmwO1AyYCKQGyAVQClwELAFL/5v/bAEUB7wDt/3b+Yf3A/ZX/WQF9AQsAhf4z/hP/RQARATsB5QBiABkAOACJAK4AlQCCAKcA0QCXAOP/G//Y/kT/9P9DAPD/Of+V/lf+lP44//X/UAD//03/8/5V/w4AdABdADsAZQCgAIUAJAD6/z4AqQDTAK0AXwABAKD/df+8/0cAhgAjAHv/Kf9e/7z/6f/t//f/AgDp/7b/qv/g/yoAVwBkAGIASwARANX/0v8VAGsAmQCWAG0AIQDK/6v/9f9uAJoAQgCy/1f/VP+A/6//0v/a/8n/t/++/8j/vP+//wgAegCcAEoA+P8ZAH0AlQBRADAAZwB/ABAAdv9W/7z/DwD3/7f/nf+L/1D/KP9p/+7/MwAJAMP/rP+u/6b/uf8QAHMAdwAPAJ7/ef+e/+L/LgBsAGwAFQCc/1P/ZP+v////JwAPAML/bv9P/3P/tP/p/wAA9//I/5D/f/+r//P/KgBDAD8AFADJ/5T/sf8WAG0AbAAcAMH/kv+Z/8z/EQBLAFoAOAAAANr/3v8AACQAOwBSAGgAXwAfANb/0/8sAJgAuACDADsAFQAbAEIAcwCIAGcALAARAB4AJQASAAUAFQAoACMAIwA7AEEAEgD0/0EAyQDdADsAgv9w//P/VwA9AOz/u/+a/2H/NP9U/67/6P/P/4v/V/9H/1X/ev+l/8D/zP/j/woAJgAgAAkAAgAQACgARgBnAHEARgD1/7D/l/+h/7b/x/++/4v/Qv8i/0P/df98/2P/YP92/3L/S/9N/6T/AADk/07/1P76/qH/MwBJAPn/of+P/9L/PQCRAKYAiwBxAHAAdgB2AIMAsgDnAO8AwQCFAF8ASwBKAG4AqgC6AGsA9f/H/wwAegC4AL0AqAB4ACcA8P8aAJMA4QC0AEcACgAbAEMAXQB3AJQAigBHAAAA8P8NABsABQDw//H/8f/W/63/jf95/3r/q/8GADQA7P9o/0T/s/8zADcA3f+0//H/NgAyAAsAEABBAHAAmQDPAPIA0ACXALkAQQGkAXEB6gCdAJMASAB//5v+D/7B/Uz9ofwH/Jz7N/vT+rz6JfvQ+1L8kvzT/E39B/73/gwADQGpAeEBEgKKAh0DZwNRAyQDEgPxAowC+wGHAUMBAAGdADMA5/+r/2L/I/8n/3P/vf/K/77/6v9TALEA1wD6AFQBuQHNAYkBSgFWAYABcgEvAf8AAgEDAdEAiQBsAIYAmwB6ACwA5P/E/+L/IgAhAGj/D/4I/T39bP50/93/cAC+AdUChQJzAYcBNgPdBDkFAAUmBT8FCQXhBXsItwrUCm4L4Q9mFVAWJRXqGqYjBRdn5faqAqBP2NYeJieZ4oySAYBusJjsBgS/9onhS9js3HDrw/7zDYMSahLyGSsppDDMJdETURCcISE3sjscKusODftb99wAKwxCDUoAyewC32bdWeRO62DsmOdo4TjfjuOt657xOvL48DD0fP1uB5oLvQnLB2cLPhSQHG4euhgYEDkLNw3PElkV8hC9B1X/p/tt/Hj+hP5f+632w/O39CT4lPqY+nv6Gf3dAUwFdAVlBJ8FEApZD1wSuBFjDvcKKQqkDNwP9g+QC0UFBwFWAHABoQG7/6H8O/rB+Zr6FPui+qX6TvyI/mb/M/8VALsCjAWeB98JRwz4DCgMhg1lEkwW0xa0GlsmJip5DEvQ0KQYuej+GS7VEITAyoj2lKrKvPNk+LLnMNgM0ynZgOkO/V8IDgmtCr8WHiWoJbkXGQ5zGMwvWj7vNuEfrwmMAB4GuRLVGQQSbP126aXik+gj8MTwD+xE6KPnR+gx6eHq3evd6ZLnTOwN+kgHCQg0/Xz1/PxfD2EdmR0uFF4LJAkTDbITjxhSFwIPkQQg/5QApgNgAvj8h/gs+LH5Oflg9nX0Y/aC+1UAzAHQ/2L9a/6QBE8NZRMlExMO4AkRC5oQKhW2FA8Q+wrwB5MGkwVKBH8C8/8K/ef6D/qe+bX4Ffgo+bf7yv34/eT8bfwV/v0BdgbDCNYHHAbABkYJtgpuC1AP2RW/F5YSbhEPHtYp2RVW3QasarV19NAmhhPnymGSh5dMxwLw9/eL6QLZB9Ek1YjlXvp5BlMG9gWgEI0fVCKlFqwNzRY/LP056DPSH48M4gRLCvUVVxyDFFwAiexm5b/rW/W/9xnxwucj40/lNerl7HztIvBH9UL2Hu455GXnovv1EaQXJwug/L/6OgVvEk0buh3oGGIOHwW6BBoMsRH4DqkH3QIDAVT9M/dc9Jb4o/8WAsL92vak8q7zEvq6A8oLDQ1dB0MBCgJgChEUyBhqF/4Sfw44C9gJ0woIDZQNQwr7A/L9lPrk+bP6MPyU/WT9rvr29oP1Efj4/BABnALhATYAjv/GAagGJwtWDLcK+ghGCHsIEAsTESAW4BPFDfgQpB/DIkABdcjeqwrNIAytIwD2xK5TkNKsut1C91bx7t5g0SHPLtqh71UDBgkdBOAEWRKfH7IdnRFPD6UflTTDOb8q+BQyCOsJ2xRwHrgcCQ3t9zjrC+0H9jn6mvVb7XrnduWC5tPpb+357p3vIPMt+Iv2/uqt4YjrZgf1HWwazAL28N71fApuHE8huRrBDpgDi/9XBVkPWhNrDaoDrv3S++v5afcQ+AL9dQEYAFv5yfKr8Yf3BAICDMAPGQuiAs3+SwSUD4AYxhlmFAkN6wchB4QKhQ/uEdsOlQelAJP9C/53/ysAGwAo/4/8gvg79Wf1hfkk/7QCOgLS/tf7QvxeAPAFGwryCjAIFwQCA3YHGw5zEBsN6wlYCw0OZw6CEcIbKR/LA6PMvqbMvVEBrCp8CWe8VI5QoyDaNf10+3/oJdlZ0/TY6uvJA3AP6QlMAygL/Bk+HBQQ/AnNGG8wKjjdJ/YOPgHVBGkSoh7/H1ESSPux6bfpFPhtBCcCnfT96PPm6epW7lDwW/OZ9oT27vOT9Bz6Zf0g+MXwNvV/B/IWdxJm/tDwGvjCC6gYSxZBC2gBEf3H/tkFxg2hDlsFgPnF9YP70AGIAZP9+PxvACoCzv5V+uP6iQHfCd0OYw57CdkDqwLwCF0TrxkrFr4LWQMLA78Ipw1DDUII6QHW/Er6rPod/UT/+f5P/Ef5e/cR9973Rfry/dYA+AD//rH92v7YAVMFtwhKC3ULnAjuBMYDOgZGCu0MHgysB04CzgBYBcAL8g10DEANoA/wB4TvaNUz0wftewaDALvdO797voTU6+h/7tDpO+Na3hzeQuaD9Fj/AQFe/0QDbQvCDuAK6AgMEZweOCVwH+QTmwxgDRYThhh1GagTpghf/g37//66A7oCL/yu9Qvz1PJV8iXyF/SF9rb1Q/Kd8Zb1ifc68a7os+s8/ZwNfguV+XTsv/LGBQoU2xQODdsEcQCjAQ4JeBJWFeINMgOq/28EAwlHB/ECsQIgBtYG9QEk/FP7/P/jBSgJewhQBPD+tfwSAfoJPxByDsIGnwDyAPcFegpEC7AIkAR/AOr93/3r/+gB/AFgAIr+B/11+4P6Rfw0Ae0F4AWqADH7nvop/50EAQeMBfcB0v5W/goB6wQkBxEHLAYrBW8D/wHXA/YIVwzZCmAJmA1JEVMGB+wx2FbgTfw9CzX5n9b9wy3Ns+E67Qns6+VU4PjcRN+A6ff1VPsM+af4HAAECTIKyQXUBsQR5B1NIK0Y9g+ADUYRLBdCG4EamhN5CaECHAOuB1oJLwWH/pL5xPaw9MjzQvWC9wz3b/Ni8MbwDPOv9L/2W/u8/6D9gvSF7SnyZQDeC1cL7wEs+rX68gFYCn4PfQ/zCkgF+AKXBQ0KAgyDCvoHMwZVBFwBxv4x/7UCFwb1BSQCmv23++f9/wIFCMcJIwdcAr//4QElByoL5QoOB9cCzQA7AcoC5AOSA8QBSv9E/Wb8sPzX/Yb/GwGRAT8A7f2t/FD+gQKBBjsHOgSVACUAgwNrB3wI1QYdBc8EBAWrBBAEsgNrA4EDtQQqBpoFvwOJBWEMJA93Am7qR9wj59T+Awck9M3Ywc4D2mrpZu5+6gjm+eNu4wTmXu169Xz4ifel+eQAowZ/BUoCEwZbEaoaNhqmErkMaQ2rErcXJRm8FZYOjwcwBRoIcAu6CSADAf04+9b7x/rg94f20fdt+M71gfKK8mX1R/eU92b5Ev1W/tz7a/v9AHsF7P6+8cnv3gBxFNkTev8c73f0MAeqElIPPgbpAMn/pgBYBPEJcQtoBeX9YP28AvMEkAC0/AsAkQY6B7UA5/o8/KAC+wdTCU8HIQOi/n79HQIkCZcL0wby/5b9XACSAwcE/gKCAvoBAACl/Xv93P9NAroCpwGwAE0ALwCxAHQCwQTOBdsEKwORAq8DxgVuBzwH4QQmAsQBPQTZBvgGVgV0BNwEjQUsB4UKXgtaAlnweOMe6VL78wMh9j3eKNOu2+npHu8565Dm0uRz5P/l0uuS81D3fvad9yj+YATWA0UAXAOyDoMYKBivEMILxw08E4AXDRlYF7IRWAqvBi8JHw3MC/wExv40/bH9BPyP+NT2nff199r19fLE8U/yFvPN8zX1APfU94L3oPdv+Ur8zv6jADsChwMmBJEE5QVBCEMKpAq8CeIIsgitCEEIegeKBlQFzQNSAkIBbABj/zH+XP0b/Qb9rfxA/Ej87vzV/Z3+N/+4/yYAoABnAY0CtANkBJQEqQTqBCcFIAX6BBgFkgX8BeIFRQWVBDEEHwQnBCAE7gNoA38CiwEgAVkBmwFiAf0ABwFdAV0BIgGQAaoCGQMuAmIBUAL+AzUEVQMhBAoH2AjxB8oH3QqcCwoCaPEe6YnyVwLIA9vxwN3R2eDkUu+Q7+bp++Ui5YPlA+i47UTzgPRi86313fvW/3X+Z/11AxoO2BNuEPQJzAgrDsEU5xcCF2cTnA7uCrQKWA3gDiEMgwYfAr8AbgDo/qL8dftf+xr6KPY98fnuK/Gu9UH4nvav8pnwvfLE91D8Hf58/Yn8U/1pAH0EcwdRCBsIcQh+CQMKaQnWCI8J2AqLCtcHbgSwAhwDGwTiAwACVf8q/Wz8Hf05/nT+cv0m/Mn7j/yn/Vv+y/5o/yIAeABAABYA0gCdAp8EsAVrBZ0EhgSdBSYHBwjbBxEHNgaTBV4FuQU/BgkGqATiAu4BCwJtAmICAQKKAecAKQDV/zAAzwBJAdoBlQLFAkEChQLFBF0HoAdOBucG9ggSBtP6SO/L7zT8yQRm/Grpad7C423vvvNA7+fpUeiA6AnpAOyB8Tf1jvRN8x32UvvJ/Xn92v8AB1kNGQ1/COsGPwszEekTTBO3EcwPNg15C5QMIg/3DosKXQVgA8wD0QKC/xf9kP3m/Qv6WvPf77Lyqfd5+Gr0e/CS8GbzyvU59yD5VfsZ/Hn7/Psl/ykDeAUOBrAGwQcNCIIH9gdGCmYMxgvMCFcGEwbYBtcG5wXSBJIDnQF+/6X+Wf/8/w//Jv0F/Er86vwH/RT9vP2F/nb+xf3N/UH/OQF3AuECOAPTA20E/wTkBfoGdQf0Bh8GvQXFBdgFGQafBowG+wTMAhoCeAPYBCYEAgK0ABcB6AHZARABZgBQAL0AKAHbABYAmQBVA90F7QTtASMCFwbnBZn7x+4c7mz7Dgau/oTr7uDQ50L0OPe+8Ffrw+um7c/t++7m8uj1N/VX9Hb3/Pt7/ED6cvzlBO0LiApTBKcCPgjHDlsQNQ57DOILzgrlCSkLUw1qDNkHMwTSBKgGuATl/+L9UAB9AXL85PTp8uf3h/yA+mn0QvEe8wr29fZB98T4IfqT+cj4tfrK/nsBlQHEAQIEUAYXBrYEwwWCCQ8MoQosB4UFoAZOCKcItAcYBhIERgLQAbMCMAPXAZD/Yf6r/uv+Nf6H/f/93v6S/ib9Wfw8/d7+xf/E/7j/BwB1AAgBJwKaA2sELgTNA2EEvQXHBvkG0wbSBssGcAb9BegFQwafBm8GbAXpA70CfQLGArkCJQJ+AdsABAC3/x0BTwNSA6wAs/+QAysHrgEB9LrrIvPEAa4EJ/Zu5YPjuu6O93v1vu4b7KTt7+6q7x/yB/U59SL0U/Zk+1n9PPq0+Mf+EAjhCo4FsQBnA7AK+w4UDqoLoApcCiwK7gpoDEgMnQnbBnYGIwfmBbQChQADAVIClAH1/f/4bPXA9fD5xv3/+8z0Re+m8Uv5pP3h+jj2Rva1+jP+Yv4F/sf/jQIYBFQEdQSpBOQESAZhCbsLLwrDBYYDQgaMCgMLFwcoA4AC0QMnBPgCwQEiAWkAY//K/rr+Xf6M/WP9WP7s/qv9t/u9+03+3wAAAVj/jv7v/0kC1gMaBMQDmwMFBAAFFQahBpYGjgbqBiMHkAaJBS0F7gXYBpAG2ATnAjYC/QL5A78DPgKjAOX/+f+OAIoBPwJqAWL/+f7RASME6P/J9Tvvt/PS/UcAYvY76hPok+8v9mX14PCf7irv/e8M8ZbzJPZI9l/1HvdG+zz9YPuR+lz/oAY2CaoFBwKbA7wIWwyoDI4LnAqnCfYIsAl/C/8L2wnlBrsFNwbdBZ8DdgGJAckCvQHe/D33wvWO+Q7+pP3393fyRvK99uz6d/t4+eT3Hfiw+eH7Gv6W/wgAaADMAaMDWgTwA28E+QaUCWUJkgZjBEEF8wdtCVwI+QUHBC4DOgPFAyUEfgOwAdf/K/+P/8P/Gv9F/if+bv4N/uf8M/wC/cz+8/+b/4L+Hf4Y/+AAUgK2AjkCvAEbAm4D7gSsBXIF4QS5BB0FmwW+BYIFMwUIBeEEdQSoA8YCTwJ4AuACywLPAW8AyP9pAIQBqAGDAF7/Nf/h/mf8P/jQ9V73bPoa+jX1D/BY757ycPUN9enyqfHR8XPyYvMH9dj2wPcE+B75X/s8/bD9DP4ZAD4DIAXlBFcEXAWkB3gJ+gmJCb0IFghJCJYJ0wpSCg8I7QVKBV0FvgSKA9ICkQK9ARwAi/41/UX7//h5+KD60PyL+1f3rvR+9pj6wfzX+zb6DfpL+wX92/5tAP4AqwDeAGQCBgRIBN0DvATwBioIAwcXBc8EPAZwB0QHRgYwBQUEBwP/AtoDJQTnAikBjQDpAKwAZP9y/tf+kv8f/6j9uvwn/Uf+Kv+P/47/L//Q/kP/2wCoAlUDtwL/AU8ChQOhBP0EyASPBJEErQSuBHwEIQTEA4kDYQMCAzYCOQGOAGYAXADt/xH/LP6Q/V/9n/0S/gX+9fx/++/6d/uY+xL64/c593D4bvl0+Hv2zPX29lr4j/jx9673OfhA+WT6Uvuy+6j7FfyX/Wz/KQCn/2L/pgDhAlMEKgRGAxQDDgSBBVQG/QXiBAAECwTABDQFzgTdAxYD0QLTArMCPQKAAbYAHQCt/w//I/5s/Z/9kv4V/z/+uPwj/DL93f6u/2n///4x/9n/lABaATICxAK/AncCjAISA4MDqAPzA6oEMQW5BH0DswIcAx4EfAS8A2wCUgHCAKcAxADCAEwAav+b/lH+Yv5M/vv95P1F/qP+YP6j/UD9pf1U/pf+b/5d/oj+mv6D/r3+ev8dAPf/Xv9V/yAA3gDEAD0AOgDGAA0BpQAmADkAngCbABEAkv+B/6T/mf9g/0H/UP9f/0D/9/6w/pb+tf7l/uX+nf5D/iT+Uv6k/uf+A//2/tj+zP7j/gj/JP9O/57/7P/r/6X/hv/T/0UAbwBRAEQAYABiACsAAAAYAEgARwAhABIAGgALAPb/FgBxAK0AnAB8AI0AqwCPAFEARwB+AKMAfQBEAEgAfwCdAIEAYAB2ALsA9wAHAfoA5ADNALMApgC1AMsAwQCQAFkAPgA2AC0AKQA3AEYAOgAlADcAdgCiAIMALwDt/+D//P8dACcADADi/9P/6f/t/7T/af9c/43/qf+C/1D/Tv9d/0j/Iv8i/zX/EP+7/pn+4v5J/2X/OP8T/x//Pv9Y/3z/sv/e/9//w/+2/9n/HwBVAEEA7P+i/6j/5/8KAPv/9v8sAHgAmQCOAIAAeQBjAEoAVgB8AHIAHADD/7n/7/8PAPb/0v/Q/+L/5P/e/+z/AAD6/9T/tf+0/7j/qf+Z/6j/0v/r/+D/yP/H/+H/BQAeACAADgAAAAYAFQARAAIAGQBbAIIAUAD1/97/IwBeADEAx/+P/7L/+P8iACsAIgAVABYAOABkAGsAQwAYAAoACAAFABcASwBsAFAAIAAoAFkAUwD9/73/8P9YAHEAIQDd/wEAWABkAAwAr/+m/9//BADs/7n/ov+w/7//t/+g/5H/kv+f/7H/vv+8/6j/mP+f/67/pv+D/2r/ff+w/9H/xP+Z/3f/bv95/43/of+j/4X/W/9T/4L/vf/H/6r/rv/p/xAA4f+S/5D/2v/5/67/V/9n/8X/AAACABkAYQCQAG0AMwAuAEkASQA8AFwAkQCJAEMAJgBhAJQAYAAFAP//SABqADoAGABKAIcAbgAnACEAYQCCAE8ADQAAAAgA8//Y/+7/HQAcAOL/v//p/zEATQAxAAsA/f///wcAGQAwADwANAAcAAIA+P8LADUASwAsAOr/v//L//T/EgAjADUASgBSAE8AVgBqAHEAWgA7ADMAQwBEACcACAAPADkAWQBJABwAAwASACgAFwDk/7v/uv/F/67/gP93/6//8f/w/63/b/9j/2n/X/9d/4T/uP+3/4b/bf+W/8//5P/w/xsASAAzAO3/2f8fAHAAbQAvABgARAB1AHQAXQBfAHEAaQA/ABoAFwApADYANwA2ADAAFgDu/9P/5P8LABcA9f/U/9//+f/h/57/hf+7//r/8f/E/9H/KAB4AJAAoADQAO4AuABbADoAYwB+AFcAJwAvAFsAawBfAG4AnACqAGoADQDj////KAAeANn/hv9h/3v/r//J/7f/lf+R/7f/6v8FAAEA+/8HABkAEADu/+P/FwBsAJsAjgBvAGUAYgBUAE0AZwCGAH0AVwBIAF8AcQBnAF4AbwB9AGoARwAxABwA9P/M/8v/3//U/6f/jf+W/5f/d/9i/3r/lf99/1P/Xf+T/6X/ff9s/6z/+v/s/5D/Xv+U/+v/AADg/9//FgBDADIACAAHACQAIADy/9T/7/8VABAA9v/7/xwAGgDh/6//xP8EACMABgDU/63/kf94/3H/jv+3/8L/of96/4P/v//x/+H/p/+a/9z/JgAhANf/ov+0/+L/8//p/+T/7v8EADAAawCEAGMAPgBYAJUAowB8AHkAwgD7AM4AbgBLAG4AcwA1AAIAGQA9ABwA0v+6/9z/4/+l/2X/b/+p/7z/iP9D/y//VP+J/6r/sv+4/9b/CQAqABQA4f/O//T/IwAuAB8AKQBVAHsAgAB0AGsAXABJAFEAfgChAIsAWABOAG4AcgA+ABAAGgA1ACUAAQAIACkAFwDI/5P/sv/q/+n/v/+4/9//9f/V/6T/k/+b/5z/kv+W/7D/z//j/+f/4v/h/+7/AAAOAB8APgBbAE8AGwD2/wYANABEADoASgCBAKUAigBXAE4AbQB3AFgAQQBWAG8ATgACANP/3f/t/9H/pv+p/9f/6/+8/3b/X/99/6X/u//C/7v/mv90/4D/0/8zAFMALgAJABMALwAuABcAEwAtAEQAPwApABcADQAJABMAKgA6ACoABwD0//r/BwARABoAJgAnABoAEwAdAB4A+f+4/5D/mP+2/8f/x//F/8H/tf+l/6T/uP/b//v/CAAHAA0ALQBPAEIADQD9/z4AlACiAHAAXQCDAI4ASgAAAAQAKgAQAMH/pP/U/+7/vv+P/6r/2f/C/4H/fv+8/9f/qf+E/6v/5//l/7L/nP+2/8f/rf+D/3b/lP/O/wEADgDx/9X/5/8UACIAAwDr//r/FAARAPj/6v/z/wIADQAQAAkA/P/2//z/AQAAAAgAHAAaAPv/7/8YADQA8v+T/7f/QwAgAJP+n/xK/Cr+cQD5AN3/RP+EAF0CqgI9ARIAngDoAfwBkgBX/53/tAARAV0Arf/M/zsAFABl/xb/nP9PAEYAgv/m/hj/s//l/5H/Yv/O/1oARgCS/wz/SP/3/10ANQDb/8D/6P/z/6j/X/+v/4kA+QA0ANr+df5+/5MAPQD7/pX+lf99APr/xf6X/rT/qgBwAL7/0P+rAEABBAGfAM8AWQF6AQwBpwCuAMUAfQAeAEAAvgDBAPz/RP93/ykAPQB9/+b+LP++/7j/Of8P/2z/tf+U/3b/t/8EAO7/ov+q/x4AkwCvAHgAKQAHAEUAwQD0AJAADQAgAK4A2wBLAL7/8P96AHYA5/+m//v/IACK/9/+G/8HAHMA2P8N/xz/3v9MAPD/bv+V/0QAmQAjAHr/fP8vAMsAwQBnAFEAdABeABAADgB1AK4ASgC+/7j/DQD//23/G/+E/xgAFwCk/3L/pv+9/4b/f//y/1QAEQCA/3r/HQCZAE8AsP+S/xIAgwBYAMz/fP+v/x4AXgBLABcABAAWACEACADk/9j/7f8RADcAUgA9AOT/fv9t/9D/UQCFAFIA9v+v/5j/t////z8ATgA4ACQACgC7/0b/Ff9y/xAAYQBAAAAA4P++/4j/iP/7/48AsABAALv/iv+e/8b/DQB9AMQAiAAAALv/2f/j/47/Tv+3/4UA1AA1AEj/+/6B/z8AogCcAGgAHQC+/3b/i//w/zUAEgDC/7b/9v8WANj/kP+8/1EAyAC+AFYA9P/P/97//v8OAAsAEAAzAEkABAB0/yP/fP80AKUAlABMAAAAlP8c/xj/wv+GAKcAMgDS/8T/pf9V/1//HQDxAPQAMgCF/17/af9x/9L/oQAWAX8AeP82/9v/SQDu/6T/SgA4ARQB3f8D/17/IgBHAAkAOQCyAIYAmf/2/kz/9v8NAMb/6/9uAGoAkP/I/gP/9/+YAHkAFwDy/+j/rv9w/5f/GgB1AFkADQD5/wkA3/9+/3L/CQDGAN0AMwB6/1X/rP8CACYAQgBeAEQA4v+J/5L/7/9AAEcAGQDy/+X/3P/G/8H/9/9SAHkAKgCb/0n/bP+///r/KgBqAHwADQBR//f+Xf8XAIAAdwBOAC0A8/+c/3L/q/8bAHUAoACeAE0AmP/a/r7+f/+GAP0AowDt/2f/N/9H/5n/KQCpALMATQDw/+X/5v+k/2r/1f/ZAI0BKQH//xr/Gf+z/04ApQCzAGwA3/9o/2j/yf8WABYAAwA=\" type=\"audio/wav\" />\n",
+              "                    Your browser does not support the audio element.\n",
+              "                </audio>\n",
+              "              "
+            ],
+            "text/plain": [
+              "<IPython.lib.display.Audio object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "wav_file_name_example = \"spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_yweweler_14.wav\"\n",
+        "display_example(wav_file_name_example)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "HwokyN0bfVsn"
+      },
+      "source": [
+        "In the three examples below, the given label is **6** but they sound quite ambiguous.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 103,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 92
+        },
+        "id": "GZgovGkdiaiP",
+        "outputId": "d76b2ccf-8be2-4f3a-df4c-2c5c99150db7"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Given label for this example: 6\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "                <audio controls=\"controls\" >\n",
+              "                    <source src=\"data:audio/wav;base64,UklGRjQjAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YRAjAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAA//8AAAIAAQD+//7/AgADAP7/+/8CAAYA///4/wAACgACAPT/+/8OAAkA8f/y/w8AFADy/+X/CwAjAPv/1f/+/zMADQDF/+P/QwA0ALb/q/9QAJEAq/+j/uH+4f/x/w//Lv8GAXECSwG5/sT9Pf/xAAoBRQAnAJAAaQCx/1D/b/9a/wX/M//S/57/J/4D/cj9mv9AAGD/6f4JAEQBswAB/5H+FgC7AdkBDgHGAAEBygAoABsAuwDXANj/0f4A//T/PwB//5j+OP4D/pD9Tv3a/QP/BwCPANQADQEsAU0ByAGrAmIDNAP8AVUAGv/F/jP/yP/p/3f/5f7M/k7/3P+5/9j+NP7J/iIAgAAE/0j9q/0WALYBowCQ/nz+hADQAbcAEP9d/z4BSAKJAW0APwCRAJ4ApwAEAQIB/v/7/pb/dgFPAuAAvP4z/ln/OwCj/1f+kf1l/U39ZP0j/kn/+P/k/5T/bf9H/wr/FP+P/xUAXACYAOcA7wCqAMEAWwFiASEA+P7B/9wBrQJHAa//sv97AIMAHQBMAH0ApP+g/hj/RgDZ//f9hv18/90ATP/p/CX9dv9rACn/c/4JAAgCFAK9ABMAhgD9ABEBUwHJAaYBhQAN/zv+pf4XAHUBaAHt/6T+1v6m/3v/o/73/skABAIRATL/uv7n/+EAjQDe/y0AVQEFAoYBfgD6/xMA3//H/rn9Qv5QAMYB9QDt/jf+fv/aAJ8Ah/9E/wAAkACCAH0AuwCEALL/Wv8/AGABNgH0/1b/MwBRAR0B0f8M/67/ygDqANL/mf4//pj+2f7T/hH/tP/w/zP/Rf50/rX/igAdAG3/xP/KABgBZQD1/6QApgGUAUUA7P6z/q3/2wAXAS4APP+D/7cAGAG5/wD+9/2H/5UA3P9j/tL9UP7s/kv/yf9VAFYA1P+w/1kABwHXACoAEACzACAByQBRAIUAEAH2ABAAUf+G/2gAHwEwAaMAt//r/vH+7P/wAO8ADwBx/4f/gP+v/sH90v3J/oP/af8L/xj/ef+2/6n/hv+b/yAA+gCAARYBIwDH/1QA1gCNACkAmgBXARQB8v96/z4A1AACAMD+2v5NAEIBiADs/uL9+P3Q/tv/gABGAF//tv7Z/jj/Hf/i/lT/FADX/3b+sP3i/ucAbQEgACb/DwDBASICAwETAFUA/gD2AEMAgv/5/tv+d/9vAH0AHP+//R3+kv/T/1X+Pf09/iAArwDc/1//4P9GAPT/zf+GAFIBMwGUAHUAsgBhAI//X/9KAFMBXwGgAAkA7v/U/4T/df8EALMAlgCK/4T+kf6W/3EAaQD8/wcAfwCRAPj/bf+P/wAAHQD8/xYAVAAyAM3/yP8RAML/mP7T/aH+VwA3Aa4A0f+Q/5r/av9d//z/zADaAA8AP//w/vf+H/+D/wkARAARANX/1f/e/9b/BgCBANEAxwDgAFEBRwEeAND+4f4dAKkAqP94/pr+ef93/3j++v3A/sv/6v9k/2D/NwAKAeMA3/8f/6j/TQG7Ar4CfQEzALr/vf+B//L+of74/rf/PQAIABz/Kv4l/mH/GgENAqQBewDK/zcAOgGUAbYAkf+K/5sAKAEaAIz+c/4IAIkBiwGHAMD/nf/N/z4A9QBhAdAApf8X/6T/SwDo/6/+6v1V/kX/jf/a/gT+Cf7t/sv/+P+9/8X/JgBdAB0Apv9V/1T/w/+jAHIBWAFKAGr/vf/OAEQBtQAUADQAoQB5ANb/m/8lANQADQH2ANYAXAAw//P92/0K/xoA6f8m/0r/RwCPAJL/1P60/zABVAExALH/eADqAOT/xf5W/9EA9QBy/2L+IP91ALAABwDL/zkAdQAnAOH/9v8VACAAZQDBAHMAU/9o/qP+g//Q/1f/F/+d/ykA0//m/oz+Of8lAG8AIgDg/+H/5P/S/+L/CgD9/87/EgDKAO4AzP9w/pb+PgBrAbwATv8k/2sAWQGVAN7++v25/jkA6wAcAK/+Of5I/6cA3wAHAHH/vP83ADUAAQD+/9j/YP9N/zsAZAF9AZoAAwBBAI0AUgANACwAOwDm/8X/QwCJALD/kf7p/rkA8gEoAXb/4f63/34AMQBn/z7/0/88AMn/wP74/dr9HP5i/sP+Y//Q/3D/iv4w/tv+s//M/33/y//CAFwBAAFGAPj/JwCWAFMBSgLJAjQCCAFkAJYAywBIAHn/Sv/m/2YA6P+Y/qv9J/7F/yMBLgEoADT//f5D/4X/nf+g/6H/xP8zALIAmgC6/+b+Hv89ACoBNQHAAGYAHwCr/0z/ev8dAKwA6gD6ALMAsP9G/rL9pP4UAFYALf8L/hP+vf7x/sL+IP87AA4BxwDY/z7/VP+2/woAUACSALEAiQARAGv/CP92/7IA0AHIAakAjv9Q/7X/+//d/6f/tP8EAEoAKQCT/wX/Fv+u/w4A1P96/4b/rf91/0T/6f81AQkC1wFIAfwAngDe/2z/BAD0ANYAr/8K/7j/gADu/33+EP5z/1oBCAISAXD/Uf5d/n7/5gB/AdwA2f+7/60AcgHhAHH/t/6J/+sANAHf/xD+Tv35/RH/Y/+5/vj9Gf4Y/wkALACz/2P/mv8HAFMAjwDGAJ4A4/89/6D/6QCyAQABp/9K/zUAAwGSAJL/ff+XAJ8BcwFSAE7/CP9b/8r/8P+k/wP/ZP4U/h7+X/6p/t7+Bv9Z/+j/PADA/7f+U/4//48A5ABFAP//rgB6AYABKQFTAfABQQICAokB9AAmAHb/hf9IAOcA2wCFAFoAJQCc/xb/G/+L/9b/xP93/9T+uf2y/Lf89/1z/yoAHwDs/9///P9sAEkBEwIdAnIBzwCeAIkAQAAcAH0A+wDSAPj/Mf8E/zD/T/+A/wgApAC2ABgAUP/g/sf+x/7M/uD+8P7t/gD/UP+Y/17/r/5I/sj+0P9cAOX/7P5a/oL+AP9b/4r/2v91ABMBKgF4AGz/1P4e/+7/lwDSALsAVgCR/7r+hv5B/08A2QC1AGIALwDx/4L/MP9W/+D/WwBuABoAr/+W/wwA3wCNAcEBjwEzAcYAZgBWAKQA3ACGAN3/ov8UAIIANwB//0D/xf9aADsAiP8J/zv/y/8LAMb/cv+k/1MAzgB1AHz/w/7o/p3/EADb/1v/I/9T/4//gf83/wf/Mf+n/xAADgCD/8T+cP7k/tf/hQBiAKL/Ef9W/0kAHAEqAaYATQCGAPoAFwHMAIYAmwDzAD0BPgHwAIcAWwB7AGwAsP+U/hb+ov5z/4v/6P4w/pr98fx8/OX89/2P/i/+zP1T/iH/Av83/jn+jP8IAYQBLQHAAHEAPgCTAJoBiAJvAo4B6gDUAMAAcwBdAJ8AvACBAFUARgC5/6b+R/58/0EBzAHpAAAA5//6/6H/df8rAEUBrgE7AZQAGAC5/8D/qwAuAiEDzAKpAZsA/P/Q/z4APgEfAh0CSwFnANv/b/8H//f+bv8AAA8Aa/9O/jX9z/yl/Vn/mQBxAGT/rP6R/kr+mv2J/eL+xACMAcoAff+J/gT+Df4y/z0BkgLAAXv/9f1T/qz/owAIAUgBPgF5AE//p/7B/v7+Df9l/zMAmwC1/+v9qvzO/Oz9EP+b/1j/df6L/VT97/26/hj/G/8v/2r/dv8E/zz+qv3o/QT/OQCOAOP/EP/V/gj/Ov+H/zcA6wDvAFAA0v/N/9//4P9JAEgBEALKAboA2/+5/zcAJQFJAv0CkQI/AScAGwDIAFQBYQE1ASIBGgHTAEMA5P9HAFMBHgL5AV4BPAGdAb8BlQERAnIDVARvA50B2ACGARQCbgFsADYAdQAtAIn/df/l/87/6v5H/p3+K//d/uX9WP2v/V/+uf6S/hn+vP0R/jP/PwA0AFn/Ev8IADoBWwGIAN//7P9QAKYA4gDXAC0AI/+I/rD+4f5Z/ln9r/yJ/GL85PtE+7L6Ifqn+Yv5u/mn+Q/5i/jY+Mf5bPpT+hH6gPqs+9T8XP1x/cL9vf4fAEQBxAHRAfgBmQKSA3QE5wT2BPQELQWVBdsFxAV1BUkFbgWqBZcFCgVEBLwDqQPFA4wD1AIIArABywHbAZUBPQE2AXEBlAGAAVsBPQElAUIBygFnAlQCcAHAAEsBoQJKA6gCwAHAAXYCzwJqAuMBogFaAeMAsQD7ABQBagCl/9P/qAC2AH3/PP4p/tf+Nf9E/5v/3v9A/1X+qP4tAPIAGwBx/4kAFgIsAtEBOgPbBCsCpvqY9Pj1cPwAAKX8CPae8dLw//HV82P1QvVo83LyTfSs9uT16/L18kf4qf68AIT+QPzG/JH/QwP3BjAJkQhXBroFwgexCfsI7AZoBn8HjwdDBRICx/+u/pD+U//h/0v+e/pU93f33fln+xP7pvpo+4H88vxZ/ZX+SgDeAawD4wU4B5MGZgVcBqAJYgyJDC0LcQqGCj4KhwlaCacJIglfB5oFwgQRBIkCzgBCAMsAyQBd/4T9q/zo/E39Zf2R/Rz+mP6I/jT+Xv5F/0gAxADtAGYBHgJRAsABUAHfAf0CjQNLA9UCeQIRAg8CLQO4BMcENgOvArgEGAY2AgP6WfTy9Yj7//2R+lz0Tu+/7MDsEe/P8RTyr+8L7nbvjvED8TjvwvCY9jz8k/23+4f65Ps3/6sDTggLC3cKfQiqCIkL8g23DagMYA0MD6sOjQsoCJEGXQZmBnQG+wUUA9n8CfYK8+z0Ffhu+IT1yfFM76Xu/O8G8yb2kvey96D45fqV/Mf8vP2yARMHQQpOClwJ7Aj5CGAKQQ5AErARrwyyCToMZA7HCSwEhwrZHTQtEiiKEXn7NPKR84H3EfmC9ZfqKNsR0bvUfeMy8tT4h/ga95T49P27BkcRCxtbInAntioKK4gnKSNJJAwuMTp1PBsvAhuGD/IRTxncG5UaaBpqGPEO1wPyA08M3gVK4+S5u6ycwMPU8crXqKSK3IAQhxGT7Z3joOyYoo/mk1qlqLJFssKxbcIH3/rxO/Lq7ATyfgMhGnAvIT0gPSEzIi8VPPFPXFf+Ts5F7kWwR5JA3TOFK1Eo8SPvHZcZlhCJ9kfPnrROusHSDNzXxrqlsJSum8Otbrx6w3jGIMul1YLkOPDF9Fr6VQ3cKzVDeUT+Nh0wsjtRUqRkjml2YSVTSEhKR5lMV01DREo4RTK3L1gmiRMjART58/kI+yj3We8k5qXdTtlZ3E7lVO4b83z0yvUc+fH+4AZCDyUWzxsQIiMoPipKJxckrSWhKmwtdSvhJbEdhBSID2US4BYQEqAExfw5AsYJkQac//sDygxa/77URa2srI/M5OMt2Bq2MZlzjduPA5yyq+SytavuoRilirEWtqawnbTtzUDszfZK7DPiNOn+/vkY9C67Ofk01CgqJ/w2JkqcTwpJW0RKRXhCVDeaKzAmWiQ/ImogwBnEAIfU+a+xsbHT7+td2xqw9pDskeCn8L5kzW3SQdGu0TXbtupi9Xz6IAgIJslDTEmYNqwmeDC5Tgpq0XHnZTRQ2T3+OQtFGlHcTrw+ii7WJWEdvw27/dD5hAFZBkr9Zeri2fDTdNmD5nXzsPdr8WXpVeo59RACRAvXElwbyiErIrwetB2OIZQnwiy4L1EuiyZJG7gTXxP9FZ4VVhEGC8MCkfkP9SP5rf8t///52Pu5A/f8odpwsoSqJsop7H3op8DtmKyNV5zIsV6/j78HtC6ntaYbtN/ABcIJwXHOUefz9RPvCOJu5ZX8DRilKWIubSm6II0e8yrTP+5LzUbtOlM2nzcHM/0l5Bq6GNkYEhGrACruC94O0lTN/dDX1Y3R8MPnuGa6hcWs0LLXCN2h4vbn/O0v9xcDew7lGBElDDJPOdk3LjWKO1JK6VWaVc9M1UTfQWhBLUBAPQs4nC/rJAQbhBPsDKMF1/5c+hn3FvIe6+7lyuWO6WXtVe+I8LDyEfZT+qz/TAaFDUQUxhkwHYQdgBvqGtIfTCk+MHAtbSEhFWQRGxboGsAYCBEGCnwGLATHAVQB3AIZAvr9tv0oBgsMW/wr1y64Nbpf1lPqut6qvbehfJkmoUSu3LfUtzuvZ6g0rD+13LaFsYm198ti5vfu3OPl2Nvf0/d5E5UmhCuAJJocySD+MXpCWkYKQkNB5UMLPnArixh5E2EadR5rFDP9K+LXzpvLBNd245zh+8+0vEO2Er6Yy6rXmeCR5sDpCuyY8Ov42wTNFO4nLjgoPVQ2Gy9INDJGgVg5XwVZGU0kQ90+2j8YQgZADDc1KmIephTJCvMA7/pG+jj6pPSq6aHfK9zL333nR+8Y8y3xqe1O8Hz7zQesDM8LMA/hGkMmzCYoHrMYYh6zKR8vTioDIaAadBgzF+EURxKpD6sLfAavApkARPyC9I3xDvyTC30Hq+KAsrye0LbS3vTrls/PoQGGg4tGprK97sDdss6lrKg9t77Au76cvmrPaOtk/EL25uUA4633zBg8MiM36ynrGV8YHSoPQrpMPEMUMSgmlCX8JDAbWws9ALT+0f+O+B/mudEqyJ3Nbdnv3SLVX8aIvwDI/dng6NztkO0y8e/7zAgcEkEYBCDaK8k4gEFpQ/VA+j8XRf5OX1ZuVCJKlj9GO4472zm9MmkoPx7bFIgLJwNy/Sv63Pa58a7rJ+ds5dblaeeI6i7wT/dB/GL8Ofo2/BcGVRQrH/ghFR8UHcEgECn1Lw0wUipZJaMlBijgJesdAhbQE4kWahhtFEoKpv+l/FsCvgPV77/I6qnBrIjIhdgoxcSdJoQmh5OZmaeUqZ2j7Z1BoAas7bcMue+zebvW13P2E/5Q70Tl2/QQFg4xhDhLMegn+SbwMolFFk97RTky2SiVLRsvoB5sBf/4XP5HBDT6OuPzznfHkMuQ1MLazterzJvEBss53XvsRPAX8JL3bQbIEvEXdhu2Iw0w+DtuRL5HL0WEQHlBpEpfU6JQ+EIVNikyLDOLMAsofR3WE24L2gRrAN/7OfVq7wjvHfIP8f7pmuXu63/4x/+Y/kP9/gLPDM0THhf0GqQg/yT4JYslLCZeJzcneyX6I0MkRyVdIyMc6RJ2DgMQ5g83CGz/a/8bAkDzJs1vqS2nCcOJ10nI46DyggGAHI+rn/GoAKk+okydYqNHsvi9dMLiyrTfAfYo/FrzH/B9ACMcSDEKOEA05iwvKXcvzT27Rtg+RCyxHxsedRsqDpf9NfYW95T0j+kw3L3SRs2sy3rQc9kY3ZTWEM+N097ja/M++mj9vwS9DwcZ0B+tJ5wx4jr2QYBHeUqlSBpEYkPQSIlNREkCPZQxRyyCKXEj5hkpEYkLLwdxAd/5LvLi7Ljr5e367zrvJ+3j7bPyJfgn+/j9OQVPEPAXgxZ0EMoQaxwcK9wvqSfrHEgb2iKzKb4n2h2PEv4L2gwmEscSXgcQ9r/vKPq2AWLth8Eoop6qkMu022vG3Z4ehgqKNqD5tR++h7bzqf2oMbkQzUrUnNH31pzrAgFbBoj+J/siB3UdfzG9OEUv3BtPDxIWDSjYLg0gvgla/6gBWAI7+sPw1e3j7pLtF+kp5Nzf8N0A433vCPrQ+NvvPu6o+zEPURtCHWIc+B41JfcsdDR1Ob067jrFPaxBdkCROBcx6DChNH8yHyenGWASfBEJEeQMxwWe/uj59/jy+rv8FPyv+tj7Q/9eAXMBnwNaCmoRUBO2EUQTXhnWHb4c2RrAHQYivx8XFwIRXBJyFUgT3Qw3Bmz+ZPQW7331Ef4382XPjasOpmy+9NT5zvKxDJgCkyug9rFjvAu7lbNzsrG+OtB12NXVctcD6ZIBmQ2QB7z+lwSOGXsu6jTrKj4a0g86EmEceiE2GZkIofzO+7D/3v2/9IvshOwz8q30He9w5kzk/Oyr+t8C4gCK+nL6dQUkFngibSXdIpoimSjMMSI48jgzN4c3ozpZPEE40i5UJeQgoyGSIh0eRBPoBq3/xv/aAosCIP3n9u70hvfj+jv8vvxG/0oEAwlnCrgI/Qd8DPoVuR50IOIaSxToEqwWbRr1GSkVNQ5nB/kC7gG9Adn9vfW87hrssueJ2I3BHLPsuPTJf9D1wb6pz5sVoaKyT8Mqyn7GGL+2vT7HL9eY5MXrq/Dh93UASAbrBzAINwstE+cdQiTiHkYPQwJnBEwTqh7iGS8JQPv2+Ov+rQSWBU8C3P0g+yj7T/xq/JX8rQB/CYkRcxIwDR8KYRCVHnYsZTJRLwIpZCf8LYM4ij6bO04zqiybKlwqZChPJHsfLhrjEzYNzgeYBE0DLAPxAqsAmftZ9jn1WPkU/0ECTAL0ACP/n/0V/2gFFA2ND7AL4QczCV4MZwsTB9cEFgWOAiT8L/eC9PvqCtVYvjC5FsYs0NnFX606mzCaIqSArp+0O7aUtO6zvbm2xUDRyNjm4DLuoPzdBDAHZgpjEcsY4R7lJV8sGisiIN0VtBenIpwoOCIOFocNGAqNCDkIXgmzCAEDePuO+An7pv0G/hMAYQaEDFoNUwuKDTIWmyAgKE0s7C0MLQQsuC8LOeFAVD+yNRItHSuXLNQr9ycxI5Ud/xVbDnQKYAr/CccGvwIvALz9lfkp9sf3+f27AisB0PqB9d/1YPyWBeEL4gqfA5n8uftaAG0EHwPf/HH1J/DT7R7sb+YJ2rDK48DuwA/FN8NSuGyrdKVfqCWvAbT/tBy0GrWfuprD9MtC0TjWQN/r61/2d/pT+9j/rQqlF4IgnCIeIMMdqB9UJoktYS8ZKjgi3R1VHr4fXx6aGisXWxUtFHISURD2Do8PQhKFFeMWhxX0E94VAhwEI+0m8yZAJQckJCTsJZAp5S0NMNYtdygVJNUjlCYDKC0lch+ZGkkYixYaE+gO5AyBDUgNzwgvAXz7tPurAMQElQLF+Qbwj+wd8Zr39Pdi8IbmGOB33A7XZs4WxpPBo79MvKO1S61lppijJ6aOrAeyKrJErkStgbSjwXvNL9RC2MXdZOVr7Xf1nf6tCIkRbhdxGrkbrRwWHwUknCmGK1gn5B+nGjMaTxw0HQ0bSRZ6EMoLIgpUC8AMAwypCSoIqAguCi4M3g8IFqgcliBnIT4iCybaK9MvxC+wLWAt0C8GMqYwByy0JyUmFyabJMMgHBwmGN4U4xFlDyQN2QkUBe4A7v85AfIAN/0J+Xv4DPs0/ID5l/Ub9LT0ZfRa8mLwk+7d6bTg49a60V/RltBaywrDYbsQtgqzyrJktVu4m7jGtgO3ubvpws3Jj9Bj2BXggOWg6e7vdvlPA8EKRRA0FeoYrRqMHDYhayedKqAoOiQtIfgfBx/yHR8dYhv4Ft8QpwzyC1YM+wqRCLIHqghZCSoJXAp7DqET/BahGLMaeR3yHqkeZB9aI1Io1ynUJuciyiE8I10keSMjIWkepRsAGbAWdBSwEV0OJAtNCH8FsgJgAFv+t/up+B/37PdT+M/0Te4d6pHrhO8F8CPr4+Nz3SnYu9NS0WzRWdGHzRTGOL+hvBC+2cAQwyvEFMR4w4nEcsmb0dPZu9/+44/o6+1q81X51QCLCcwQXRQkFT4WwRkEH7UjwCV8JAkh+B2LHX4f6yAiH4Ea9BWuEzQTxhLbEVwRtRHqEQARsA/FD/cRJhXnFwYaCRy4HTgepx3THWsgliQBJ/ckmx95GzIcciDrItofBxmJExcSyhJVEswPbQwqCewFwgIfAPj95vsr+jn5HfgB9fXvzev76mTsx+yL6ubmq+Nr4Y7f09zg1/3QS8sSyhTMtcuaxXa977nCvJHBC8RFxGzEX8Vox+jLgdPB23Th/uTO6UzxBvnI/u0DrgoBEsoWchjGGSYd4CHQJdIntSd8JTAiOiArIWUjdSPyH+waVxcpFmAWqBYwFpYUORJxEH4QIxLyE0IVAhcBGgQdsR2cG5gZEBseIOokYiVZIbAcixtxHgsiWyJgHs0YWxU8FS8WIBVXEdQMvQkhCGgGTwMQ//n6Y/is9533AfaT8bfroudD5wPp9+i45ATeQ9nw2G/aRdhN0AbHecNyxxvNAc3rxcW9Ybs2wObHw8yszH7KL8sE0WrZDuDJ41rnNu1Y9DL6bf7mApgIbA4fE6UWLBlzGgIbiRyuH2YiGCICHx8crxsMHRAeSx2VGscWsBMuEzoVZRdGFzMVjhO+E/sULRabF+oZQhy4HMMaexjQGIYcIyERI9wgfhyHGQMaAh2nH20f3RvSFjATpBIbFJ4UIhJ8DUgJGwcpBqQE4wHo/tj8fft3+fz1//E87zPuqe0n7HDpHeax4t7f8d5K4G3hZt6C1n3OTMyp0AnWHtazzzDHnsJMxaLNDNb92NTV3tFW0zzb1eQb63Tt2O758UL3m/2fA0QIfwt2DhESfBUWFw8X0BcNG1MfhyFTIEYd8hrPGpocnx6JHj8bgRbNE+gU7BdeGcMXsRTDEkMTaBUdF5cWFBQYEg0TaRbkGBoYSRXZE34VjBj+GZQYzRUqFKwU7xWxFUATERDqDewM8QtHCjMI7AVDA4QAmP5z/WP7EvfL8XvuPO737srtEuqv5e3inOKR45PjW+Ev3r7cpd0N3hTbMNYn1DvX+dsB3fHYgNNm0WTUidrt31fh6t6r3BjfiebC7onzufRP9br3Tvw8AkkIxwyvDkgPUhHKFY0aDh1/HRMeuR8fIf4gCSDIH30gEiGpIGIfqR3RG4QapBoFHMEc1Rp7FkwSzhAtEmAUEhUpE0IPXgvfCboLSQ9UEd4P7wuNCAsIQAryDLsN8wsvCdcHxAhPCgkKZAc+BKMCgQLjAUb/Nfub98T1TPWi9HDys+7h6tToJ+lV6t/pwubP4gLhZOLR5CTleeIJ38HdYd/q4bziCOFU3tTcd91032ThgeLt4lDjduTs5nHq0O3q7xLx+/Lv9kP8AQEJBCEG5wjxDEQRdRQkFjUXwRj0GhEdUx6eHlAe0R16HZEdCh5IHpwdExyIGsAZjxn1GB4XMhRdEfQPTBAlEYQQkQ2vCXoHWggHC5gMMQvDBxsFRQXZB7EK1QuzCggIbgW/BL4G0gnJCvUHSANtAL0A7AHuAFj9N/l29j/1qPTU8zjyte/87EzrMeu061XruOn+52Pn6ueP6J7of+gz6RHrNu1O7gXuce357ervQ/K/897zMPPY8sDzyfWw90n43Pf795/5+vuH/f39cP6s/0gBhQJ4A7MEKgYxB44H9wdKCZILFg4VEDsRbBGyEIYP+g4SEKkSIxWuFQUU0BEJERASbBNUE1YRkg6oDGMMEQ0fDaMLXwnoB78HsAdhBg4EMwKxAfcB9gFUAWgAmP8i/zP/t/8xAB8AZv9H/hL9H/zl+4v8cP2R/Zn8Gfum+UH40/bR9bv1MPYo9j31LPTU8yH0W/RE9EX0nfTy9Ar1c/XT9sP46/mT+Zv4mvg++tP8Iv86ALX/Bv7K/Nr9OQFeBHEEWAH4/TP9S/8yAskDQQMiAcr+1f0F/2cBCAO7AhYBpf+B/74AjgKoAy8DsQHsAOwBpQMZBM8CVQErASACFQOYA9YDmAN5AioBNQH/AtAEqQSvAuwA1wDbAWUCmAHQ/xH+jf3l/kUBigI8AXn+/vwH/vD/VgDf/h/9c/zb/Mz94/6W/z3/Cv5F/eD9Ov8LAAgA1P+w/0f/sf6t/oH/cQC9AG4A4P8k/47+7/5vAK4BIwEs/7H9x/3C/rL/hQA6ARoB6//x/oj/EAGdAacAvP8jACABUQHNAK4AGAEKATwA2v/KAB4CJgLCAJ7/AwBCAboB9AABAOz/eQDTAMQAxwD/ANgAAQAl/z3/RwA3AS8BVgBp/9r+rf7J/vr+5f5i/t798f2M/vz+0v5d/hn+IP5r/hL/3/8RAEz/cf7H/hwA0gADAMn+r/6h/0UADgC//+T/9P9j/7z+6P7M/1sA6f/N/ub9z/2R/pX//P9w/63+yf7i//QAHwGEAMr/SP8o/9T/dQE8A88D0wKBAWcBvQIyBFQEFAPWAfgBUANRBOQDrgIhApECBgPoAtcCVwM=\" type=\"audio/wav\" />\n",
+              "                    Your browser does not support the audio element.\n",
+              "                </audio>\n",
+              "              "
+            ],
+            "text/plain": [
+              "<IPython.lib.display.Audio object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "wav_file_name_example = \"spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_yweweler_36.wav\"\n",
+        "display_example(wav_file_name_example)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 104,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 92
+        },
+        "id": "lfa2eHbMwG8R",
+        "outputId": "6627ebe2-d439-4bf5-e2cb-44f6278ae86c"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Given label for this example: 6\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "                <audio controls=\"controls\" >\n",
+              "                    <source src=\"data:audio/wav;base64,UklGRqQfAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YYAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAQD/////AAACAAAA/f8AAAMAAAD8////BQADAPv//P8FAAcA+//3/wQADAD+//H/AAARAAQA7P/3/xcAEADn/+b/GwAoAOT/wf8dAHAA4/+1/jj+G/9YAHsAeP+P/qf+Y//9/zAAHgDM/1X/Kv+b/1IAvwDLAMsAyAB0AOP/pf/x/ysAxP8e/xH/n//m/33/Ff9u/zAAfQA2AAoARgBqADAAHQCRAOMASgBI/yj/GgDXAIMA+v9PAPYAfQDx/hT++f55ANkAEQB+/6n/uf8U/4P+Cf9MAPUAgADe/w4AwADLAOb/If+M/78AYAHiACIAEwBtAEoApf9j/+7/jACAABwADgAeAHr/OP6o/bz+tgDlAXUBGwAU/+H+IP9M/3D//P8DAdUBmwFiADP/7v52/x0AngAaAV8B7wDi/xf/I/+G/4L/WP/e//kAZQFMAIT+k/36/fj+xf9DAIIAUACr/w3/5v4Y/2T/+P/4AM0BjgFLACn/AP+A//b/TgDKACYB7ABFAM3/kv8q/8n+Vv/gAAACcgHX/9j++f5B/wT/3/54/1AAewD2/33/a/98/5f/7/9sAJ4AdgB8AOgAIgGbAL3/av/Q/0wAZABCAC0A//+B//D+yv4p/67/9P/l/6//hf+D/5//rv+V/4P/zP9+AC4BTgG+APf/lf/D/xgAEACg/zX/Nv+K/9T/6//3/xYANwBFAEsARQAQALz/of/n/yUA7v+V/+L/0wBkAeEA8v+t/xIANQC7/1P/e/+r/1X/9v5W/yQASgCR/wD/Y/8uAGEA6/+M/7r/MACLAKoAiwAuAM//xv8dAHEAaAARALT/fP94/6T/1v/J/2z/D/8S/3n/6v8YAAUA6//1/xUAEQDO/43/uP9KALkAlwAfAOD/AgA0AC0A/f/O/77/1//+/+3/kf9k/+P/rADCAO7/Ov+O/1gAZQCi/yj/lv9RAKgAxwD+AOUADwAN/+L+nP9HAFsASABuAFMAff+F/o/+wf8EAVcB3ABcACIA0/9C/+r+Wf9eAC8BQQHCABYAXP+p/nL+FP8bAJQAOQDE/8T/0P9M/6L+1f4LAEEBiwEKAWEA6f+t/8L/FgBWAFMAUQCEAI0A//8b/5j+vP45/8//bwDNAHMAk/8E/0H/0f8RABYARwCOAIcAPAAIAPj/1//T/1YAMwGZARsBPQC//7v/3P/t/+r/zP+x/93/QABPALf/DP8l//D/kACKACwA2v+M/0f/Yf/s/1oAOwDq//j/SABFAOL/qf/f/ygAMgATAOv/pv9W/1z/y/8YANL/Vf9P/7//CgDo/7f/0v8XAD4ASQBPAD4AEgAJAEoAfwAzAIL/Df88/8L/CwDo/5n/a/9p/3j/hP+T/6z/z//7/y8AYABnACsAz/+k/+P/XgCqAIYAEQCr/5D/sf/O/8j/z/8dAJEAtgBaAOj/6f9iAN0ACgELAQ0B9QCjAEUAGQAXAA8AAAANAC8AMwADALv/e/9b/3b/w//s/5r/9f6c/vX+rP8ZAPn/ov+U//P/bACIADYA7f8jALEA9ACnADMADAAWAP3/zf/L/93/tv99/6D/AADf//3+Lv5W/jX/wf99/+v+uP7//nP/w/+0/z3/1P4n/0AAMwEbAT4Ax/9KADABgwEYAY8AeADKAB4BGgGkAPv/nv/v/6wADgGcAMH/Wv+2/0MASQC7/y7/Kf+l/zAAXQAIAHP/Ef82/8H/JgD+/4H/Xv/z/8QA9wBQAJH/kv9EANIAtwBJABoAMwA/ACUABgDV/27/GP9Q/wEAawAbAJT/mP8RAEAA1v9W/0b/g/+k/5n/kP+H/1n/K/9Q/8T/CwDR/1b/Lf98/93/5v+v/6X/+v9dAGMA/v+C/0z/bf+2/+3/8P++/4b/gP+r/8L/nf9+/8H/TQCdAGIA7P+u/7v/0P/P/9b/8P////b/5f/K/5n/ev+x/y4AggBuAD8ATQB1AGcAPgBTAJoAqABqAD8ATAAzAL7/Wf93/9n/7/+y/5v/x//P/37/Nf9b/8j/FwAwADIAFQDK/5D/x/9XAKgAYADm/+X/cwD4AOoAdQA/AJoANQF5ATcBzACvAPwAYAF3ASgBtAB0AH8AogClAIYAZAA0ANr/bv9A/2n/nv+Z/3T/bP9j/wz/ef4p/mX+3v4n/z7/WP9q/zz/3/6q/rX+wP6t/rz+Ff9j/zP/o/5K/nz+6f4W/+/+v/64/sP+rf5t/iv+F/47/nb+nv6r/q/+tP61/sP+C/+U/w4AJADy//H/UwC5AMIApADbAGMBrAFuARwBOwGZAa4BdAFpAbYB4wGcAT8BSAGQAZcBVAE1AVwBZgEXAcQAywAJASMBHwFGAZYBvwGmAYwBsgEOAnACtQLOAsUCxQLkAu0CpAJJAm8CIwOgAz8DVgK5AYgBJgFbANv/PADyANkAsf9r/vb9Nf5x/m3+f/7E/s7+Tf6u/aH9Lf6t/sT+xv7k/mj+b/xf+Qj35vaS+DP6Qvq0+Jz2OvVH9Zf2Qvho+Qj6xfrM+2/8Lfy2+1v8ff4dAfUCewP1AgQCfQEgAtoDiwUOBnIFuAR8BF8E4QNCAysDxAN5BH0EYwN7AcD/Nf8AACwBmwEdAUsArf9Y/1v/2P+uAIUBSgIkA9cD1QM4A/kCqwOnBA4FBQUWBfcEGwQrA00DHAT+A9wChwJ+A4YDQgFq/7YBegccDOUMWQuYCYIHzwQqAz4EpwczDNUQDhP0D6cJxQfvDYYV+harFYwYAhhsAZfTo6s6qJLEO91c2Ky8DqB9jsyI245OnqitGrVmuU7Dms6Zzs/En8Wq38IHeiVLLbImgR4fHQ8ndDtWUE9ZHlU+TqdLKUhOPQcwMStnMBQ1EC5gGab9GOXC2Ifan+EO4RbU/8HBtH6v3693tKi9JMqV1mHgceat6MvpSvD6ANgX6ykTMIUtkireK5swVTYHO7c8azp9NcQvxShZH9UVJxFwEhsUfA8WBJ33/O8W7/zyo/er+H30iO6J7GLwUvZk+rb9/QMYDSsUzRWVFAEWchyYJY4tkzG4MEos0CdHJqYm7iS2H24aTRj9FqoRRwgWAFT8k/o5+A33uvfa8hff67/Np4Kmqrdcx9TGVLj6p/me35+GqWW4zMak0ArXLd1x4vXjLuTT67X/gBjHKHkqmCNmHnMgJimsNPM9gkDMOxs0BC5nKfkiRhpFE8MQSw/aB4X3SeMn1K7PzNPh2PvXDtA2xhXBxcOFzFbXSOGo6QLxlfcN/a0BhgdSEUEfFy3kNFk0KC/IKxYu2DSMO8Q9wzlKMUcoxCG2HRQa9BV5EhgQQAyZA9T2v+tZ6OXsmPMY9tHyF+126ZnqzvB9+pcEFQxoEK4ThRfDGiwcIR5qJAEujDS/M0cuNinUJWgjkyP4JsQnnB8qE+8NjQ4HAgfd5bKqpJ64XdA1zFqttI0BgHCD5Y9dnyirlK0aq8+var7kyh7NRNCx5OYG3CCaJEcbYRcqIZg020nOWC9amE4QQptApkfCSQtBEDbVMWIw8SbyErf8Bu3F5dPjR+Ij29rKSLYiqXKqm7QmvP28GL3KwuTME9ar3EDkoPBmASMSjh1lIeMgJCP0LHY7JUYYR2VADTmyNXU1yjSYMU8scCatICYaYBHEBu795/ok/XH+vPj07MniCeEv59bun/KR8mbyGPWa+gYBAwfGDE8T2xr9IT0mMiaWI+MiVifQLs4y3i52JTMdBBq+Gj4c1Rv6FkINIgT8AsEG5P7t3we42aXetf/QddX2u56brYwykpag7q0Ltpq3ArZ8uUXFAtEG1MDUkeIv/2cYdB01E/UMSBa6KiE/8kokSgI/uTPoMmI7wkAyO/ww6Cs9KqQh/Q6l++DxpPHR8g/uG+HVzsS+ZbkmwCHKy8yux/TDoshN03jdFOXt7Er3OgMgDokVkhjvGWAf3is0OttAYDyUM7MvtzIxN7g3cDNeLJckpB0gGAET/QwxBz4EogNwACf3dOsy5cDnxe668zD03vFh7x7vZ/OY/DsHmQ6cEUYTMhbtGXAdciFSJt8pCipRKF0nUyaMIo4dGRzYHQ4caRTeDu8QYA/P+MTQILSMuUvUSOGvziusKZS9kN2a9qittMa4trQFsei2b8Ozy7LO09je8FYKZhOyC5MEYgxbIUU4o0e2SgJCwzUIMoA6PEWARrI+ADe6MnYrdhzzCtP/PP2q/Rr6Y+7z2mLGILtcvjXJ184DymzBbb48w+vLZNW13wjr0vU3/oUDjgYuCpYSRCE6Meg5ijdzL8wq6y2wNdo7RDylNrItHyUuH0cbfxdjExsQeA2aCBz/GvOU6gPq4O+59aj1Ve8+6ODmCu209oD+wwKhBR0J4gwAEBITiRevHRkkeCiiKFkk5h5HHdQg0iSTIxMd8hXQEKcMWQlACNoFJPmc34vGqL+My8vW389EunqnRKIvp16uS7ROuOq57Lo9v0THdM4V0zPbUeyvANALGAohBj8MDB3+Low5QjusN80z4TN0OB494jzxN3YypC26JZkY5ApBA+MB//9o94/oCdmFzmTLvc1y0PPOqsnkxTrIy88Q2HLeS+S96330c/x1AooH7w0tF1AiqCtyL8EtQSvgLMAyRDgLOe00Ci8wKtgm4yMoIGkbZBbWESANgwbE/fb1DfML9SL3x/TR7lDq6eq+75T1J/ru/Hv+VAAzBN8Jww4YEb4SuhYqHHweiBsNFz8WhxnIHJ0c2RjUEmkMZAjVB+EFp/rk5W7Tos8U2Abdd9MUweSzQ7Ixt4W7OL2+vZG+EcFnxkrNodJ01pPdKuub+q8DtwTuBPALcxnUJowuWzCJL0svjTDoMZkxui+iLeIquyQwGhMPfwiXBkEEXf0I8x/p3eFp3Znb0ds13Dvb1NlE2gPdteAA5SXrIPNZ+sH+ugFCBkANLxWeHO8iNSeWKEwoNSlTLFIvnC+KLQgrTigWJIkeqBlqFlETyQ5SCUUEwv9X+8T3RPZ19pv2/vVj9Tz1KfXq9Zv5ZwCbBkIIPwaCBQoJmg4hEosS5xH9EV0SrxGXDwcNxAqiB4sA+PPS5cbdPd/+477hgNXixlK/bsCxxBPHBsc2xv/Ffsdxy/3Qg9Zy3APl9+8D+d78Vv6LA5EOQhsqJEonHiboI5Mk9yldMJgwYCiBHiMbPx0FHNISFQeNAIH/Bf5t+JDw2enp5Q7leuZZ5/DkCOEy4a7nq+9C8zDzPPUB/B4EzQmDDa0RvBawG2Ig2iTHJz8oMihSKoctbi05KLIhmx7PHgIeexnlEnENFQp8B14E5AAd/sL8ffz2+/v5Cvdo9SX3vPsqAKQBJABB/o3+hQG8BVIJzApLCTUFowCg/Vf7iPYY7v7lHONo5CzjSNvJ0CHLY8z6zzDR1M8zzr3NFM/w0rvYCd6q4d7l/uwk9W/6Rf17AhYMcRVBGdYY7RmIHsciCyO1IFwfzx/fH5wd5hjKEh4N3wkVCaIHRAL3+WbzbfHh8cnwYe1i6j7qpeyo78Tx1fIP9EL3Af1ZA30HNwmKC/gQKRiIHaMfcyBgImglzSdYKDUnLSUMI10h+R/2Ha8avhZUE6wQ6A2TCnwHqAXYBLADNAHo/XX7Uftq/f3/5ABd/6X8/frq++v+PgGm/5b5q/Iv76vu7OsJ5HzbMdkX3UPfvNkN0LjKMc090ynXO9dC1QPUEdZg3Gjk3Onh657uefXI/VsCJgOBBYMMuxQCGZkYYxavFHYUyBZIGwAelxpoEgUMVwsIDcMLPgczAxIBnP55+sr25fUi90v4aPij9xr2vfT19Rn7twGoBfQFvwULCIMMOxGAFX8ZhRyrHaMdEh5RH1AgriAtIZwhKSAHHH8XrRWUFgEXjhRWEB0N2AsgC3YJ/wbYBKMDNAMMA4sCBAF2/iT8ffvt+5r6fvVp7nTp8OdQ5ojgwteo0ZjRYtQP1O3OHcmEx9TK+8/j08nV6NYp2czdUOSq6oPv+/Mh+rAB3gf/CgkN+RCvFvcasBtFGocZYxqLG3AbfhkCFu8Rgw4zDPcJiAZNAvz+Iv0+++r3FvQB8mjyyPNZ9PHzx/Mc9WD4+PyDAd0ETgdXCuQODxQ5GPUaKR1jHwohcCH1IJAgriD0IMQgiR/pHF0ZYBYhFeoUmhMgENALxQhwB40GDAUvA7ABmwBU/0/9q/pD+O32Ifa982nuI+iP5PHjyeGe2s/Rbs4Y0jnWKtRozSTJSMsP0QfW8Njw2g/dRuDK5TLtwfPY97P7OwILCtgO2g9KESwWzBvHHVYcchvgHGEeqx0uG0AYHRXwEZcP2g28CnUFgwCI/iz+3Ps99+zzRPQd9jf2zvSr9A73r/o9/q8BIQVECGYLZg/7E2sX7RgaGtYckyDxIsciPSEIIKsfsh+TH80e3xzLGVsWfROCERkQkw4ODPsHEAMV//X8dfup+Hf0dvAs7QfpLOPs3U/cRd2n22fUVsuYx3TLp9F/0xzQZMztzMvR/tcV3bngBORa6D7umvTO+Qz+gAMSC/4RwRT9E0IUURi0HT4gNx8pHccbcxqQGL8WMBXCEusO8woGCFgF2AGk/pD9zP1H/BT4V/R29Of3M/tl/KD8v/0kAFUDLAeNC7EP0RIfFWQX7BluHMEe5SBTIkIi3iCRH4ofQiALIPMdrRqcF14VYBOxEAIN9ghaBTwC6v73+sb24/If7+bqNOal4eHdbdua2mja+9c+0fzIAsbTyzXV8dhD1PjNLc531RjeuuMD5zHqve1A8Tn1QPrN/xEF7QnqDaMP+g7jDpoSAxkPHYEbnxYfE+0SURQDFTIU8RGPDvoKcQhCB5EGsAXGBLkDswGs/o38fv0uAegEeQY3BgYGSAcACmINihD5Eq0UyBVFFmYWKxdfGRUcMR0WHK4auBoVG4kZphabFV8XNxghFJgMgAcFCJMK/gh2Ac/3m/Dx7DPr8+ki6Hvj4tmJzYXFTMetz+DUu9A8x5HBOMQEzK3TMtlB3VDgiuI/5VDqOPKx+9AEggv9DbUMpQtnDx8YoSB+Iwgg4RkbFawTKhUgF0QWTBGKCncFzwKgAAD+bvyX/P377/f98RrvEvJe+Pj8TP3y+ob5p/tUAUIIuw2uEAgSPBPsFDEXWxp6HmMiICS+ImwfpxxuHMUeVSHEIIYb3hNNDkUNvA6dDgoLcwUOALL7R/iw9VvzB/BK67Hm7uNf4gvg/tyx2y3dvN5E3b7ZJNgz2o/did9q4MDhX+Mp5NfkfOdP7OzwXfNR9I71w/fL+sT+XAPuBg4IvAd/CDsLYg5oEH0RQRJOEjgRARAXEFcRThInEikRlQ91DbQLzgu1DToPhg5dDNUKogrcChML6wt5DWMOiA3KCzgLsQwMD54Q7hC/EOYQkxHHEsUUQRd9GJsWvRJHEQsVlRrUGjATsggDAmYAgwCB/8b7pPLp4qLScMwX03XbCNj1yGK7RLmNv6LFuMiOyxnPYdGm0lbWHd7k56XxYvv9AzUIGwhFCtAULiSCLfEqESLHHNQeWSTWJ4smYCAnF1sOFwk2B7sFcwK+/Xb4XPLm6+Pn5ehf7Wjw1u6A6hLonOqY8QD6jgCwA4wEGAaLCoARwhh8HiYi4yMNJJsjGSRnJoEp8Cq7KDAj8xwSGVUYZxgDFjIQ/gj3Asb+ofsa+Tf3EfX58L3qweTj4YbiZ+QJ5Z7j/uDm3jHfn+Kt53HrbuwR7MXsK+8i8vX0Cfgz+/n8ZvzF+m/6IvyF/u3/s////YT7tPkK+k/8Tf4S/hz8k/q1+u/7Qv2B/sr/uADRAHcA1AC9AucFGAkTC4QLVwsDDDMOMBGqE+sUHRW+FD0UCBRzFFgV/BWZFQ4UEBKzEJIQOhGKEdMQdQ8fDssMGgu1CUgKHQ04D3MMhwT9/Bz8RwFTBIn+UfOY7NDthu6F5eTW29BP2WLkCeL70SbEssUh0//eUuHr3PnYXNob4oftK/cu+/L7b/8SB7kNuA8BEScXhh8BIVUY9Q3GDHIV5x1eHK4QTQM7/acAhAfxCIkBvPb98L/y0vay9+r1pPX195b5LvhB9mr43v/VCCUO0A22CjsKvA9QGSMhzSJjH/gbVRzhH18jeCQNIwsgORwgGFIUWBFpD9gNxgowBH/6tvFh7l3w8PGQ7TDkWNzw2oTeEeLQ4t3hQOGf4fXireXc6U/ubfG98uzy6fKj8wT2//mx/cj+M/2O+1L8Nv/1AfQCXwIxATYADwAiAQMDgAS5BPYDIgPOAhED7AM+BXIG0QZhBhcG4AatCJoK5Qt8DMoMOQ0ADiAPXRBEEXURAhFsEEAQrhB8ETESZBISErsR+RG8EkgTORMaE1YTyBKdDyQKsAVKBZwHfwdzAeL3DfGV8GvzkvI16gPeHdYQ1wPdkd+U2ljSks4q0hXZqt1x3kveXOAa5dXq7O8s9J74NP5uBHAJxwsnDNoMWA/eEoIVKhYSFQYT4hCbD78PexDTD40M2AdMBEIDjAMEA90AC/7O+6P6dfok+1r8cv0P/qr+DgBJArgEFwfjCUUNQBCxEQISFhMbFu4ZHRxxGxMZNBf7Fr4XzxeuFfIQmwqxBOMAGf9m/cn5DPTg7UbpCeeG5mLmeeWI42LhVOAH4QPjTuVW5wDpQOoe6xXs5O2v8MLzPfbe9+342vkp+1j9QgDaAg0ECgQqBHwFuQfQCQkLXAsKC3QKJgqMCmUL2AtTCyoKOwn9CCcJNAn5CKIIUwgLCOoHMwjWCEEJCAmUCLUIdgn5CbsJYgm8CWEKUAqdCXMJPArcCmQKlQmLCagJNggMBSgCDQG7ACP/1vsw+E71DvP98BLvOu0P64/obuYo5WLkpuNF46vjUuRV5O7ja+R45kXpwuvl7T3w6vLI9RL5Af39AB8EegYfCXcMlw+iERATyRSPFkkXzhZBFnAWuRYQFncUsxIIESsPQw38C1gLQQryB0YF3AMbBMsEqgTEA/MCuQITA/EDMgU+BnkGMgZ9BscHGglDCUQIDAcZBiEF+QPiArABkf8y/JP45vUQ9CTy+O817s7svurQ54blRuVH5oPmZuVm5PLk2+Yh6ULrMe3i7pnwFvOb9i/6vfyt/k0B3gQzCIUKbwyqDsEQ8RGEElITRhSAFOATRxMhE6kSLRFAD+sNOw1mDBwL0gnRCMkHlwazBYAFiAUIBfoDLwNTAzEE8ATtBEwEzgMCBJYErQT4AzUDJwNjA7QCyAC9/p/9Cf3D+3/5JPd69Vb0QfM08izxqu937YfrPOuY7OftsO1r7OHrFu1Z70nxSPLG8pLzJ/Vo99H5+fvj/c7/wwGNAywF6AbOCF0KHQtcC+EL4gzQDTUOTw6JDrkObQ7CDVcNYg1hDdgM8QslC4oK8QldCf8ItwggCCUHNwa0BYAFTAUMBdEEagSbA50CCQITAiACWAGJ/2f99vu/+1L8gvxJ+8P4TvZm9SP2Cvdr9g30aPFF8BjxnfIJ87bxye8x79DwmvOc9fX1k/UH9tT3HfrW+8f8a/0v/i//XQCbAbYCjwNOBCEF5QVLBlkGfgYCB64HHgg2CAgIrQdfB3MH4Af3BysH+gWMBUAGKQc1B3QGyAW4BQAGLQYUBroFOgXnBBgFpgXhBVcFYwSuA1QD5AIlAloBtwD//93+Zf35+9r6IPri+Qf68/n9+Fz3PPaG9qz3K/hE98/1M/Xo9Sv3+vf/9573evcS+Gz58/rY+9z7t/tj/Ab+vv+fALUAwABGAR0C3wJUA3ADMQPfAg8D+gPpBNsEzwP7AmoDrwRqBfUEBAScA94DIwTzA4cDYwPEA2sEzQRtBE8DGgKnATQCHwN8A+sC0AHdAIYAwQAXAfUAKwA5/+T+V//Q/2b/I/4Y/TL9If6h/tP9L/wO+0/7e/xG/dn8mPuv+uj68fvA/K38AvyS+8v7Uvyi/L78Fv3E/Tz+Af5m/U/9Ov65/+sALAFeAAT/L/7o/hQBLgODA/IBFQCx/ykBcwMXBSAFmgOfAa8AdAEPA/EDZAMbAkABTwHyAZMCugIyAjIBawCLAI8BuAI3A98CGgJnAQwBHgGQASYCZQLeAZQANf+z/nj/2gCHAa0A0v5Y/S79+f2g/oP+AP7M/Qz+Pf7g/RT9ffyd/Fj9E/42/rH9Cf3o/I79l/5I/yn/ef4N/o7+sf9iAN7/n/73/aP+EAAUARgBXQB3/9z+5v6r/8MAbgEzAT4AL/+u/i3/iwDtAVACkQGhAG0A9AChAS4ChgJAAhMB0//r/4wBEAPRAikB3f/v/+IA2gGHAsQCLQK6ADr/q/4v/wwAdgAQAPn+wP1F/fH9JP+0/yP/+P3//J789Pz7/S//l/+//m79+PzO/TX/MwBkAOj/If+6/lb/2AAxAkoCGQGg//H+df/WAEYC2wI3AuMA3/+y/x8ApgD3AN0AHQDS/rn9vP0K/8sAxAFCAa//ZP6w/qEAxAJnAy4CPwAA///+AAB0AYYCXgLlADb/qP5z/7gAvgFuAoICRQHs/l79fv6QAZkDqgL3/xL+8v2u/nj/bQBcATEBbv91/UD9CP//AGoBSwD1/or+PP9zAFIBRAF3ALP/jf/l/0AAbgB8AEsAr//s/rf+Zf92AB0BFAG4AHAAXwCPABIBrwHDAdgAZf+b/kH/xQDAAUsBzv9x/hz+2f4LAOQA1ADp/9L+ZP7p/uT/jgCSADgA9v/n/+D/zP/a/xoAPwD6/5H/r/9wAB8BGAGhAG8AmACmAKAAJQElAmAC8QA=\" type=\"audio/wav\" />\n",
+              "                    Your browser does not support the audio element.\n",
+              "                </audio>\n",
+              "              "
+            ],
+            "text/plain": [
+              "<IPython.lib.display.Audio object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "wav_file_name_example = \"spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_yweweler_35.wav\"\n",
+        "display_example(wav_file_name_example)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 105,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 92
+        },
+        "id": "qeIrpgYj6zIQ",
+        "outputId": "2dde7439-9493-4dee-bb8f-dc5bc337378c"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Given label for this example: 6\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "                <audio controls=\"controls\" >\n",
+              "                    <source src=\"data:audio/wav;base64,UklGRkwZAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YSgZAAAAAAAAAAD/////AgACAP3/+/8DAAgA/f/0/wEAEgABAOj/+P8eABEA3P/h/ycAMADZ/7v/IwBeAOn/h/8CAJQAGwBS/7r/xAB9ADD/Pv/QABMBQf+R/pgA1AGs/8H97/+tAqIA5vyX/oEDeAIj/BD8LAQaBpj7RvaQBLURXftrxj6h1aarukS2SaVxs03mTQ4fCGbu4/OBHvBDukVlNaI15kt2X+tcOUtfPuo/ykfHRlk14RpCBwMDoQW8/h/p5tDHxFnFjcZ2v4az/quXrAaxjLN2szu1Db0eySXSj9O20kbarezv/v4E9ACqACEM5BtEI6UfWxnmF1walxudGc8WyxVAFocVwxHvDMAMuhWMJaIzOjl6OEM6vUSmVItf71vfSJIwPyM0KrQ77j54I0j2F9iv2Tnnnt/rvZ2fBJ4UrWOs3ZMBgOCMfbCBxV+4854Ln27Dq/BCBLT54exY+VkciTo1QME1NDL+Pr9Oe09nQEoySjPhPWw+BCqkDKj8tQDlB73+k+bO0ebLAc4nzAPFbb9xvrq+cb2Iux27WL6qx8jVj+Cn4Dbbnd4d8BkDVgg6AbD8HwO1DW0SGBE4EPsRPxL/DcoHRgQOBbAHBwh/Ay385vie/xUONRqKHLsZTB6mLytEt00NS3dJKFLDWo9QzDN4HvUmuj+6QEkWid3DxlHdX/nb7iHBdpwLn762DLwHpYePlpjztn3H+LmrpSmtU9S7+ogAqerY3PfwkRqGNiszwyHzHhIxbUTrRdw4Zi80M247wTjVJskQuQUICdkNCwQb6/LUFNJo3fHhs9SfwRG7C8Pcy/fLL8hsyRTQO9aE2XvdseVf8QX8JABp+0/zOvOAADAR8xSkCDj7xfvkByARuA/ZCIUDx/83+5L3AfiG+53+EgCaAAsAiP8hBJ8R6yLALQAvcC6ONMJBN1HGXRhgQ1CvMlUeJyisRcNQhzEL/VrfC+nu/az4I9ZPtbyvArwMvD2kq4uPkJuwDse/t6KUMYyuscXjf/NK3HLHf9inBP0kliaPG4geijLZRLdGyDx1NjI8gEfASbE6SCLXEtwVYh+3GQr/5OEl2LjhKuqr4bHNbL+Iv2/HoctnyCLEFMdp0QvaONmx09nWVedt+Ev6jO6S51fyEwdBE5IOkwER+mP96QVxChsHTwAj/Zr+pf5q+Un05/bg/vQAXvgJ7yTy6AEUEgwZNRkbGzgjiy/gO+dFYE4wV3ReFFwXSv8xhypTPilXO09uHRfnAtpH908QxfzhyFWkd6hVvQu8KaAeisCS1KoXsF6bZovdnaDI3eTg3f/I8sqe7fgXOizYJf8YRxtbMMFJs1UiT2tBuTtSQM9CjDg3J/sdGSG5IpwTTvcD4rjhd+3Y7gPb+76bsSW7ds1y1FvLmL/Dv7HLG9ef2R/Y4txV6aDzgPMb7uPwogDTEfQUywhW/Av+TwxUGD4WTwgR+8L4lQCrCBoIkf/a93D3P/u4+7z3KvZe+5oBQADR+Cr3EAO/FaEhdyIcIfUmoDJxPIFCgEnRULlNwjmjIqYgEzhNTJ887gzp5dTmMwAwByrq6sPNtgHCkMfhtjSh1J/8sRK/wLZzpMugv7Xg1LTmwOHA07fUoO5zEZcirBk3CkoNDyUYPMk/TjS4KwkvCTZfNOcotR1eG8keMxxsDKn27upp8Cb7z/dK4tHLR8dq0wTeyNrXzy3K2MxN0QXU2Nie4hPtE/JL8cnvZPKC+sAFOw44DkkHaQMRCnYVcxiQD9MFwAV0CxALfQHA9+n1FvnB+M3xFOn+5FDnLuyT7erozeKT48btdPmG/J33nfaWAkAWESRUJiAlrCutO2VN5VgIW4tT7UTzN0s4zUYOUo1FhyKPAsv7/QZ3CIHxtdBFvum+cMHZtrykUJyvozGuoKyzoMObwanowWbQ0s3Gx5zQm+qxBjkVAhSHDckOex1JM8dBeT+wMn4r4DDTOKk26is2JGoj0SBFFSIGz/0r/kn/K/kr67Lba9Nr1r/eSeD61RzJr8ZpzzXY79lD2d7cFeNi5iHnWeoX8Sv3HfoZ/HL/tANGCL4NBhOxFLMR+A3ADTkQEhEIDpsIRgNS/6v8J/p49iTyfO8W7xruW+qF5r7mJOrO63PqfOrg7lr0/fYz+ZUASQ0gGbgfkSOdKacyiDsxQplHO0wYTdRGLjxZNhY7vkJQPd8kiAdw+ZH9NQIC9j7b7cLAuAK5orjUsY6nGaCTnu+gaKOnpVOrQbbowevHSMkxz3ngMvi8CT4OEQzZD+0etzEJPDA6EzQtMy44nTw+PLM4VTRqLi4mnR2GFqYPhweC/6T4WPCo5OLZUdZ62IXXBc8ixSPCNsZPy7nNXc76zuDQLtaP3yPpK+7V76nzufre/8wAPQNRDC4XbhpOFegQzBMyGq4cvBkiFWoRgQ7eDC0NCw2ACOv/6/h397L4OfeL8ubug+5+7mXrWuax48HlseoV71Xxo/Kk9R789AR/DBUQxBH5FhEiRy5bNJczWDOAOVBBB0BdM/kmWic8MWkz6SILCWT5U/sNAv37mOY40I/HWMxi0QbMNL+ctn24ML+ZwSG/or/yxwHT89ju2aTdyOgg9ycBlARSBV8IzA8yGmQjoCYdI34eux+pJkMrFicXHXAVGxNpEdgLOgTr/rz7qPa07hfoD+aw5c/hatq21MjT5tSv1KzULNiP3XXfUN3g3S7mjfFK95n2YvfT/q8ImA4pEQ0VJRrNG5cZbxm0Hggk+SFCGQQSmRG6FGoU+w0DBdj+O/34/HD5o/ET6ULjrt/a2/DXb9Zp13DXoNQq0ojUwNtu47znkejI6A7smPTLAHwLvRCtEkwXRCHjLA418zhiO2c+1EEvRYdI/UpNStlEtztNMu0rGik3Jrcdmg36+hfuiOm05u/cgcu9uueyxLPTtZWyXaqYohmgiqN/qmuy4rn8v5DEzcmu027jNPQa/x4DYQYvDscYWCEkJ2ksCTBdLhwp/if7LdEy/SwxH1IVwRRuFggSdQha/7z3R++y55nlyOd95uLdbdTu0nXZJuBp4Qrfzd0a4KrlAO2E86P2zfbH91b82ALhB9kK1Q2kEZ8UwxWwFmYZER1rHi4b3xT3D84PohKMEpkLpwC2+If3X/rK+5r4TvFA6R3lG+cW64Hp9eDb2XXcf+UY6n7mheLT5cbtI/Pb9Gf3HfzX/6QBlAR5CaMMdAxTDf8SjhlRGvMVShShGfYgySJnHswZFBpEHhAhVx4zFxIR/A+bEbgPNgj//zT8CfvC9ljuvuZD4wrhINyL1SbRss+rzvHMzctZy//Jo8iEy/rTX9xD3oTbmNw/5ZTvv/R69pf7OgVkDVkQ6BGPFgwcRR38GukawR6UIXsf5RqdF6kUWw+JCVwH0AfgBGz8Q/Rm8p30j/PN7LHl3+NQ5rvn/+VR5P/leemj6j7pAOoR8Oj3mPsA+8T7zAA1Br4HYwebCe8NRhBjEE4SxBbrGP0VPhKJErgUNhO+DT8J+wc2B9YELQKj/7v6PvML7q3uHfGa7knnBuK/4qvleOVK4iXgHOHw49Hm2OiV6Z/pRus/8HD2eflQ+ET3tvo2AUwFuwRYA28FmgnQCrMHlgQ6Ba0HxQesBSQFCQfgBwEGBAUjCFcMawwtCZIIhAyhD04N0AhmCOkLFw36CEwEpwSNCHMJhAQF/mH7WvwU/Oj3jvLR70jvkO3E6dfmxOZB51jlaOKG4k7mm+ks6eLmvOaW6RntiO8d8Try0/LZ88f24Pok/X38F/wv/+MDJwXwASX//QA2BV4GYQODAP4AAwNDA8kBIAEiAh8DrgJDAd3/rf6h/Q/9Xv2X/kwAbAHDAJb++vwO/eP8YPqS95H44Pzt/vL7R/iq+PP6Qvrj96D5sv8jAxQAnPvU+wv/o/89/T/8A/5C/yL+kvzh+676v/hu+DL6l/qA9x30N/Ra9mP28vMl8kXy5PKk82718/as9UDz9vSt+/0Az//T+w/8tADHA44CrAB7AYsDhwQpBa8GxgfhBi0FUwSBA7QBvQBMAq0DBwE1/E37mv/yAkQAbfo490/3YvfC9nD3rPgz96fzQ/PG92v70fhR83zyF/c7+pr3PPPY8s71f/fo9kv38Pms+wL6dPcQ+IL7ff3v+/f5WvsG/2YA3f02+478hwAYAmv/M/xQ/KX+Vf+W/WP8mv1F/73+b/zQ+uv6u/ty/IX9QP+rALsAz/9N/+P/qABlAGf/R/+HAEQBjv+w/An8N/7A/xv+0vvU/Pv/FgCV+0H3lfeb+lb7H/nT92X5Gvso+gz4Lvjl+hz9jvyv+rv6sf0DAXgB8P6M/Mn8gP7f/ov90/ze/dv+Ff7R/EX94/78/sT8lfqj+h/8rfys+7/6S/uM/Jz85frf+BH47/e/9oT0j/Mh9e/2BPZe8zbzIPdq+9T7BflK9974r/vA/Lz7t/qY+yv+GwAL/5T7lfnD+4v/9v/Z/Kn7n/9qBBwE0f/i/UkAGAKc/xD8LvzT/mb/Vf1j/AH+Nv/3/Yz8cf0V/5P+o/yM/An/PAH0AHD/Fv8iANoAOQA8/2n/pwAaAXv/C/0N/Fv8e/vR+GL3VfnZ+7z6Aven9eb3Ofml9n/z6vNF9lj2avQs9OP1JfZe9E/0h/dl+v35ofhO+Xf6hvl9+Of6/v6S/4z8ovtN/4cChQAf/Fv7cP4gAAr+wfvj/Lz/4v8j/M73uvZP+Xr8Af29+nT4cPjm+X36kPmm+AT5T/q++x/9Pv6D/tz9Nv1r/XH+7P+TAcUCvQLdAZQBTwLAAhUCjAFLAs0CxAAq/eL7kf7YAWABbf1g+vH66Pyr/I36Mvqz/B7+yvpN9crzh/cX+zr6yPeR+HH7P/tp9y31gPfb+lr7pPoy/Pn+Uf9O/Yb8Cv4G/+P9xfyS/dT+dv7q/Jj7a/oS+aD4qvlv+oD5k/iX+YT6EPgm9K30oPol/7D8LPdl9pr6n/xE+W32EfrxABcDB/84+7T8EQE8A1ECKAGXARYDrASgBQgF8wJNAWwBZAGM/jv60/iN+4/+if4U/Uf9rv6l/uf8YvuV+m35Ufjs+OD6CPxV/MD9f/+i/br34vMc9739KABu/Zb7yf0QAJn+nvvr+sj7o/uG+8H9PgDv/lb7hft0AFUDcP9c+Qn4j/rp+lr4NvhB/Bj/lvxO+Nj3uPqZ/KL8cf0T/7v+kfxw/Cv/GQB1/N749/oqAKgA/frB9u75jwDGAnv/Ofws/Kb8Nvsi+iP8O/+O/2D9H/xi/D77VPjL98r7kv98/cr3U/ZB+1//HPz09JzyIfce/JT8PPvW/HUAkwGH/2L+fgBUA84DUAKIAD3+Ifuu+UD8GgBs/y/5ofPE9Bf7LwCXAAb+GPu4+PH3dvpu/3ECkACI/B/7bvw+/BD5zPa8+ED8zfwb+wr8lAA+A2v/+/eg83b0yPZ49+33vvp1/2cD1gRyA4X/nPrP98X4Q/st/BP8mv2e/6T9wPdC9UT74gPJBDH90fYc+FP8qfzq+s385wBnAKD6wPaS+DL7UvqY+S394ABl/tT4Dvlv/5ICBP4h+cz6QP5o+730x/MR+v3+L/2i+U/6Ff3p/Kb6m/qK/Jv8zPrp+vz8T/wS+N72J/2uBNEDcfux9s77rQNPBJr+lftV/jYAN/wH94r3IvzA/Rz70/lf/PL94Pot90f4nfz+/jv/FgEEBC0Dg/7c/NMBdAeYBisBQ/7f/oj9bvjN9F/2S/lC+FL0P/L58rrzI/TI9iD7KPyS96ryTvT2+6ICIQRcA24EGgZJBB//pfsC/RoAy/+E+4v3lvdL+7n/9gFTAG77/vZG9xT8LQCX/5r8GPxt/pz/6/0K/NL7X/sJ+uz79QPMDFsNZQSE+mH3m/mT+6374PtJ/Gr7a/oB/CL/pP8V/Q78j/6j/6T6YPPO8RX3M/zi+6P4QPfH91z3NvZ899n7v/+v/xP8LvjT9rD4Xfwu/y3/P/2o/Fn/MwMrBEMBIP6a/noBhwFL/Lf1N/PK9BH2h/U99kD5E/px9fbvo/B/9s35dffY9Jb2/flp+zv9jwJEB70E2/x1+Ln6iv1s/IH7ev+9BKQElf+K+/z6rfv0/BwAsALT/zz5kPf7/SME9gHO+0v7+P+1AJv7wfkyAKgGAQTF/Br8KQLQAwT8mfM09Bv7yP46/FP44/YP97n3bfl4+/j7uPtq/ScAmP9V+w75OPw+AE3/2fox+Mn3cfY49VD4E/4T/0r54vNE9Kn2ovbd92z+DwQVAFj3IvijBJ4NBAg0/Zz88QRtB2z+gvT/8wD67/2G/cX7uvnZ9gz1mfar+aT6VPm393r14fF98K31Xf7IAS79a/cA9hT19O/y6+nx9/5fBfL+W/b++E8FEg72C6wECAEaA44HzArHCfUCfvoL+TkBlglpB3b9kfiY/S8DMQBh+O70g/ac9qrzE/MC9w76Zfe78Qrva/Go9m37yPzN+dz10fU/+dD6b/kq+5ICbwd5AQX2xvEq9838kP30/hMEXwXG/Ojxt/Ck+Nz+gv7K/HL9IP2b+TL3yPmp/ogBkgIoA3QBevzG+D37XQFvBMMCLgBa/j77mvcG+Nb8KP9g+gj0fPSS+iv9j/i58xf2Sv1UAfT/n/6aAcEFCQWC/jz3mvTW913+MgQNBjEDLP5++kz5U/mi+Sj6hPnK9cnwBvBg9br6SPlM8ybxTfVA+QD4bvWp97H9yAEwAvABTAL7AID9j/ts/qsE8gkCC6EHvwKzAKgC7wNi/273FvSX95r62/Z38Hjv1fNo9tjz1e/Y7X7t/O5T9Kv7tf6N+534FfvV/iP+u/xOAhEMGA4KBaX8eP/iB/sIVgGH+1T9+/+t+zfzT++88pv4Fvyn/Db7wveK81Py3fb2/scEagSd/7L7+Puh/tb/Kv8EAEkEyQjiCP8DW/3d9xX1rPZu/N4ADv3+8b/pm+vd8gL2GPSF9Dj6av4O+7X0GvVH/iUIZQr6BD7+lvts/bEAnwK3AqMBBv8f+v30gvTN+vQCiQVBAf/7i/rQ+mH44vMl8tz0I/g3+LT22vc6/NT/kf8h/QT8Z/xx+5L4hPcQ++v/NAC0+8r4tftVAPL/x/pw9yf5mvsz+m33NPn2/3IFUwTW/Wf3H/VE9+b61PsV+NfyF/Kb9yL+uP8q/f37GP6v/wn+/vsf/bj/XP/s+935gvuP/cX7rfYN89X0jvunApMEQ//49lnz5Pfr/6UD0wB+/B/8D/8ZAL788/iE+i0BkgXnAVz6L/ldAXUJQAeW/cH4mf3xAsb+YvTh7xD2Ev8+AQf8LfYN9X347Pzu/tn9tvwK/1MDTAOn/NX2t/pbBZwJTQFg9o71svxy/lD2e+8g9Pn94f6k9I7rau0r9jL85vzh+3H6LfdM9PX2vP7eA0cBqvtl+uX8+/z8+V/6rQClBSUCVfo8+A79gP9I+uD0y/j2AiwH1wDc+Mz4ef7XAD39jvka+nr79fjL9MD1mf3xBZkHsAKk/VL9awCsAnQCqAH9AaYCUQKvASoCngLC/xX5u/Og9Vf9vgEr/EzxLexy8DH2qvVP8q/0Ivxv/jP3L/D79PsCbAzTCeQBAP9tAh8F0gEZ+/P3B/wHAzcESvzl8snyEvwaA2D/ivbk83H4n/pc9fbvtPOa/n8FhwFr92rxr/Rf/XcDmQJJ/RX5j/j9+Vz7Uv1eARQHRAxuDlsL9AIl+p34/v+AB4sFt/wE+RL/CwXXAHv3mfbFAFcJtAUJ+5z1+PcG+sn22PKX87b21PY99IzzpfXh9j72z/fW/eoDfgRaAKz8Y/sB+pb3UveI+4EBZAQUArD72/Oj7iDwg/do/Xj7DPVN8z/4Yfs+9g3vyPBV+/QCWwBY+lP7QAKqBDn+CPdX+E4AkgUKBJQAPwBbAcr/Y/za+63/MATIBWcEFgGl+1/1CPPs9w0AdwPp/2z7z/sm/9v/Qv3X+8b92v/C/s/7b/qY+9/9CAAoAQkAGv2P+479NQAp/2L7EPoQ/OX76fZQ8973zADIAxj+5/cM+Cn7zfrU98/3SvtZ/fn7nPqC+1/8uvto/BUArALM/wf6rfe2+Uf7wPnT95T33vZW9IbzDfiR/28EqwSEAsX/3fzD++L+agTrBggEKv8t/Bj7+vr0/OgAoQLm/mr5pPiD/JH+zPvs+Kj6Wf4G/hP53PSh9fn5Zf0V/Qb6wPfs+Gz8k/7m/fH8+P3w/pX8M/jo9hf7aQGmBE0CoPvI9NHyDfcu/Kn7mvai9F74wPoi9qjwdvQZAA4HVwIS+dX14vkg/9kBzQJ0AjQAiP0K/TL+PP5t/f3+qAIOA0D9Zfbj9dn7YAGjAbj+6/zh/GD8j/rX+Gv4Lfmu+ln8ovws+nP2TvU8+KD72Pp09tfzSfbr+gv9Zvyg/FT/sAGfACX9HPu1/IUAgAPZAygCbADh/57/Gf4J/Er8rP9tAlEAmPoL96P4Avy7/Ff7I/sM/ML69/YS9cn3f/s6+xz42fcS/H3/Pf3n91r2HfvTAekELANk/6b8Ufzk/Vf/n/5g/AL8Rv+bAsQAYvqL9hf63QD5AhX/dvup/Jb/+P4T+3L4AfmM+nz72vzI/s7+v/uS+I74ePqX+o745/eF+nP9zPz5+A==\" type=\"audio/wav\" />\n",
+              "                    Your browser does not support the audio element.\n",
+              "                </audio>\n",
+              "              "
+            ],
+            "text/plain": [
+              "<IPython.lib.display.Audio object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "wav_file_name_example = \"spoken_digits/free-spoken-digit-dataset-1.0.9/recordings/6_nicolas_8.wav\"\n",
+        "display_example(wav_file_name_example)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-rf8iSngtV83"
+      },
+      "source": [
+        "You can see that even widely-used datasets like Spoken Digit contain problematic labels. Never blindly trust your data! You should always check it for potential issues, many of which can be easily identified by `cleanlab`.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "audio_quickstart_tutorial_deterministic.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/docs/source/tutorials/audio.ipynb
+++ b/docs/source/tutorials/audio.ipynb
@@ -110,7 +110,7 @@
         "\n",
         "\n",
         "set_seed(SEED)\n",
-        "\n",
+        "tf.get_logger().setLevel('ERROR')  # suppress TF warnings \n",
         "pd.options.display.max_colwidth = 500\n",
         "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"3\"  # Suppress TF info, warnings and errors\n"
       ]


### PR DESCRIPTION
This PR introduces the audio classification tutorial to the doc site. A mockup is available [here](https://weijinglok.github.io/cleanlab-docs/audio-img-tut/tutorials/image.html). 