### PR TITLE
Add test to check examples are found by cleanlab

### DIFF
--- a/docs/source/tutorials/audio.ipynb
+++ b/docs/source/tutorials/audio.ipynb
@@ -511,6 +511,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Hidden code cell to check if the highlighted examples that are shown later were found in the indices output by find_label_issues.\n",
+    "# If it is not found, throws an exception and breaks the docs build.\n",
+    "if not all(x in label_issues_indices for x in [1946, 516, 469, 2132]):\n",
+    "    raise Exception(\"Highlighted examples not found in the array of label issues indices.\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "id": "iI07jQ0BnTgt"

--- a/docs/source/tutorials/image.ipynb
+++ b/docs/source/tutorials/image.ipynb
@@ -260,6 +260,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Hidden code cell to check if the highlighted examples that are shown later were found in the indices output by find_label_issues.\n",
+    "# If it is not found, throws an exception and breaks the docs build.\n",
+    "if not all(x in ranked_label_issues for x in [59915, 24798, 59701, 50340]):\n",
+    "    raise Exception(\"Highlighted examples not found in the array of label issues indices.\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/source/tutorials/text.ipynb
+++ b/docs/source/tutorials/text.ipynb
@@ -379,7 +379,7 @@
    "source": [
     "# Hidden code cell to check if the highlighted examples that are shown later were found in the indices output by find_label_issues.\n",
     "# If it is not found, throws an exception and breaks the docs build.\n",
-    "if not all(x in ranked_label_issues for x in [44582, 10404, 30151]):\n",
+    "if not all(x in ranked_label_issues for x in [44582, 10404, 301510000000000000000000000]):\n",
     "    raise Exception(\"Highlighted examples not found in the array of label issues indices.\")"
    ]
   },
@@ -673,7 +673,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/text.ipynb
+++ b/docs/source/tutorials/text.ipynb
@@ -379,7 +379,7 @@
    "source": [
     "# Hidden code cell to check if the highlighted examples that are shown later were found in the indices output by find_label_issues.\n",
     "# If it is not found, throws an exception and breaks the docs build.\n",
-    "if not all(x in ranked_label_issues for x in [44582, 10404, 301510000000000000000000000]):\n",
+    "if not all(x in ranked_label_issues for x in [44582, 10404, 30151]):\n",
     "    raise Exception(\"Highlighted examples not found in the array of label issues indices.\")"
    ]
   },

--- a/docs/source/tutorials/text.ipynb
+++ b/docs/source/tutorials/text.ipynb
@@ -370,6 +370,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Hidden code cell to check if the highlighted examples that are shown later were found in the indices output by find_label_issues.\n",
+    "# If it is not found, throws an exception and breaks the docs build.\n",
+    "if not all(x in ranked_label_issues for x in [44582, 10404, 30151]):\n",
+    "    raise Exception(\"Highlighted examples not found in the array of label issues indices.\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -659,7 +673,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add test to check that highlighted examples are found by `cleanlab`'s `find_label_issues` in the tutorials.

1. A mockup is available [here ](https://weijinglok.github.io/cleanlab-docs/clean-tuts/)- visually should have no differences from how it already is.
2. An example of a failed build (i.e., checking an index that doesn't exist) is available [here](https://github.com/weijinglok/cleanlab/runs/5842542218?check_suite_focus=true).
3. Examples of successful builds are available [here](https://github.com/weijinglok/cleanlab/actions/runs/2099245747) and [here](https://github.com/weijinglok/cleanlab/actions/runs/2099351624).

Commits were not squashed for traceability and audit. **Please squash them before merging**.
