### PR TITLE
Make EditorConfig match Jupyter for notebooks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,8 @@ indent_style = space
 trim_trailing_whitespace = true
 indent_size = 4
 
+[*.ipynb]
+insert_final_newline = false
+
 [*.{yml,yaml}]
 indent_size = 2


### PR DESCRIPTION
Jupyter notebook doesn't add a newline at EOF, so we shouldn't have EditorConfig do it for .ipynb files either.