### PR TITLE
Add link checking for compiled docs

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -135,3 +135,20 @@ jobs:
           publish_branch: master
           publish_dir: cleanlab-docs
           keep_files: true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: docs-html
+          path: cleanlab-docs
+          retention-days: 1 # don't need this except in link checking step below
+  links:
+    needs: deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: docs-html
+          path: cleanlab-docs
+      - uses: anishathalye/proof-html@v1
+        with:
+          directory: ./cleanlab-docs
+          external_only: true

--- a/cleanlab/internal/label_quality_utils.py
+++ b/cleanlab/internal/label_quality_utils.py
@@ -61,7 +61,7 @@ def get_normalized_entropy(pred_probs: np.array) -> np.array:
 
     Normalized entropy is between 0 and 1. Higher values of entropy indicate higher uncertainty in the model's prediction of the correct label.
 
-    Read more about normalized entropy here: https://en.wikipedia.org/wiki/Entropy_(information_theory)
+    Read more about normalized entropy `on Wikipedia <https://en.wikipedia.org/wiki/Entropy_(information_theory)>`_.
 
     Normalized entropy is used in active learning for uncertainty sampling: https://towardsdatascience.com/uncertainty-sampling-cheatsheet-ec57bc067c0b
 


### PR DESCRIPTION
Example failing run: https://github.com/anishathalye/cleanlab/runs/5870279217?check_suite_focus=true (reST parsed this link incorrectly)
Example passing run: https://github.com/anishathalye/cleanlab/runs/5870656641?check_suite_focus=true