### PR TITLE
Add a GitHub icon and link below the docs' project title

### DIFF
--- a/docs/source/_templates/brand.html
+++ b/docs/source/_templates/brand.html
@@ -20,7 +20,7 @@
 </a>
 
 <div class="centered">
-    <a class="github-button" href="https://github.com/cleanlab/cleanlab" data-size="large" data-show-count="true"
+    <a style="margin-top: 6px;" class="github-button" href="https://github.com/cleanlab/cleanlab" data-size="large" data-show-count="true"
     aria-label="Star cleanlab/cleanlab on GitHub">Star</a>
 </div>
 

--- a/docs/source/_templates/brand.html
+++ b/docs/source/_templates/brand.html
@@ -1,0 +1,26 @@
+<a style="padding-bottom: 0px;" class="sidebar-brand{% if logo %} centered{% endif %}" href="{{ pathto(master_doc) }}">
+    {% block brand_content %}
+    {%- if logo_url %}
+    <div class="sidebar-logo-container">
+        <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo" />
+    </div>
+    {%- endif %}
+    {%- if theme_light_logo and theme_dark_logo %}
+    <div class="sidebar-logo-container">
+        <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo" />
+        <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo" />
+    </div>
+    {%- endif %}
+    {% if not theme_sidebar_hide_name %}
+    <span style="margin-bottom:0px" class="sidebar-brand-text">
+        {{ docstitle if docstitle else project }}
+    </span>
+    {%- endif %}
+    {% endblock brand_content %}
+</a>
+
+<div class="centered">
+    <a class="github-button" href="https://github.com/cleanlab/cleanlab" data-size="large" data-show-count="true"
+    aria-label="Star cleanlab/cleanlab on GitHub">Star</a>
+</div>
+

--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -1,5 +1,5 @@
-{% extends "!page.html" %} 
-{% block content %} 
+{% extends "!page.html" %}
+{% block content %}
 
 <noscript>
   <div class="admonition warning">
@@ -24,7 +24,7 @@
         const path_arr = window.location.pathname.split("/");
 
         if (path_arr.includes("master")) {
-            document.getElementById("doc_ver_warning").innerHTML = 
+            document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="{{ DOCS_SITE_URL }}">here</a>.</p>
@@ -56,4 +56,8 @@
     });
 </script>
 
+{% endblock %}
+
+{% block regular_scripts %}{{ super() }}
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -179,7 +179,7 @@ if os.getenv("SKIP_NOTEBOOKS", "0") != "0":
 #
 html_theme = "furo"
 html_favicon = (
-    "https://raw.githubusercontent.com/cleanlab/assets/master/cleanlab/cleanlab_logo_only.png"
+    "https://raw.githubusercontent.com/cleanlab/assets/a4483476d449f2f05a4c7cde329e72358099cc07/cleanlab/cleanlab_favicon.svg"
 )
 html_title = "cleanlab"
 html_logo = (
@@ -207,7 +207,7 @@ html_static_path = ["_static"]
 
 html_sidebars = {
     "**": [
-        "sidebar/brand.html",
+        "brand.html",
         "sidebar/search.html",
         "sidebar/scroll-start.html",
         "sidebar/navigation.html",


### PR DESCRIPTION
This PR adds a GitHub icon and link below the docs' project title. A mockup is available [here](https://weijinglok.github.io/cleanlab-docs/doc-gh/index.html).
<img width="638" alt="image" src="https://user-images.githubusercontent.com/90272361/162508185-56c54fde-969f-4ed6-999c-cd1a891b6a2f.png">
