### PR TITLE
more specific filter-warning

### DIFF
--- a/docs/source/tutorials/image.ipynb
+++ b/docs/source/tutorials/image.ipynb
@@ -93,7 +93,7 @@
     "torch.backends.cudnn.deterministic = True\n",
     "torch.backends.cudnn.benchmark = False\n",
     "torch.cuda.manual_seed_all(SEED)\n",
-    "warnings.filterwarnings(\"ignore\")"
+    "warnings.filterwarnings(\"ignore\", \"Lazy modules are a new feature.*\")"
    ]
   },
   {


### PR DESCRIPTION
Should not be using nonspecific filter-warning in tutorials, that is too broad.