### PR TITLE
Add self.labels as attribute of FastTextClassifier

### DIFF
--- a/cleanlab/experimental/fasttext.py
+++ b/cleanlab/experimental/fasttext.py
@@ -117,6 +117,7 @@ class FastTextClassifier(BaseEstimator):  # Inherits sklearn base classifier
         self.p_at_k = p_at_k
         self.batch_size = batch_size
         self.clf = None
+        self.labels = None
 
         if labels is None:
             # Find all class labels across the train and test set (if provided)

--- a/cleanlab/experimental/fasttext.py
+++ b/cleanlab/experimental/fasttext.py
@@ -117,7 +117,7 @@ class FastTextClassifier(BaseEstimator):  # Inherits sklearn base classifier
         self.p_at_k = p_at_k
         self.batch_size = batch_size
         self.clf = None
-        self.labels = None
+        self.labels = labels
 
         if labels is None:
             # Find all class labels across the train and test set (if provided)


### PR DESCRIPTION
This is a small PR to add `self.labels` in the constructor of `FastTextClassifier()` to fix issue below.

This is needed when we clone an instance of this class with `sklean.base.clone()`

Below code to reproduce the error:
```
import sklearn
from cleanlab.experimental.fasttext import FastTextClassifier

# download data here: https://github.com/cleanlab/label-errors/releases/tag/amazon-reviews-dataset
clf = FastTextClassifier(train_data_fn="./data/amazon5core.preprocessed.txt")

# this will throw an error
clf_copy = sklearn.base.clone(clf)
```

Error:
`AttributeError: 'FastTextClassifier' object has no attribute 'labels'`

We use `sklearn.base.clone()` in `count.py` [here](https://github.com/cleanlab/cleanlab/blob/master/cleanlab/count.py#L666)

For reference, from [sklearn documentation](https://scikit-learn.org/stable/developers/develop.html): 
"every keyword argument accepted by __init__ should correspond to an attribute on the instance"

----

This was not an issue in older versions of `cleanlab` because the older versions used `copy.deepcopy()` instead. See usage [here in v1.0.0](https://github.com/cleanlab/cleanlab/blob/v1.0/cleanlab/latent_estimation.py#L610).