### PR TITLE
Returns DataFrame type from CleanLearning functions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -21,6 +21,7 @@ exclude_lines =
     # Don't complain if tests don't hit defensive assertion code:
     raise AssertionError
     raise NotImplementedError
+    Raise ValueError
 
     # Don't complain if non-runnable code isn't run:
     if 0:

--- a/.coveragerc
+++ b/.coveragerc
@@ -21,7 +21,7 @@ exclude_lines =
     # Don't complain if tests don't hit defensive assertion code:
     raise AssertionError
     raise NotImplementedError
-    Raise ValueError
+    raise ValueError
 
     # Don't complain if non-runnable code isn't run:
     if 0:

--- a/.coveragerc
+++ b/.coveragerc
@@ -22,6 +22,7 @@ exclude_lines =
     raise AssertionError
     raise NotImplementedError
     raise ValueError
+    warnings.warn
 
     # Don't complain if non-runnable code isn't run:
     if 0:

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -363,8 +363,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           `self.label_issues_df`: a pd.DataFrame accessible via
           :py:meth:`get_label_issues
           <cleanlab.classification.CleanLearning.get_label_issues>`
-          of similar format as the one returned by:
-          :py:meth:`CleanLearning.find_label_issues
+          of similar format as the one returned by: :py:meth:`CleanLearning.find_label_issues
             <cleanlab.classification.CleanLearning.find_label_issues>`.
           See documentation of :py:meth:`CleanLearning.find_label_issues
             <cleanlab.classification.CleanLearning.find_label_issues>`

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -340,8 +340,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           pruned from the data before training the final `clf` model.
 
           Caution: If you provide `label_issues` without having previously called
-          :py:meth:`self.find_label_issues
-          <cleanlab.classification.CleanLearning.find_label_issues>`,
+          :py:meth:`self.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`,
           e.g. as a np.array, then some functionality like training with sample weights may be disabled.
 
         clf_kwargs : dict, optional
@@ -363,10 +362,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           `self.label_issues_df`: a pd.DataFrame accessible via
           :py:meth:`get_label_issues
           <cleanlab.classification.CleanLearning.get_label_issues>`
-          of similar format as the one returned by: :py:meth:`CleanLearning.find_label_issues
-            <cleanlab.classification.CleanLearning.find_label_issues>`.
-          See documentation of :py:meth:`CleanLearning.find_label_issues
-            <cleanlab.classification.CleanLearning.find_label_issues>`
+          of similar format as the one returned by: :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`.
+          See documentation of :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`
           for column descriptions.
           After calling ``self.fit()``, `self.label_issues_df` may also contain an extra column:
 
@@ -590,24 +587,12 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             Each row represents an example from our dataset and
             `label_issues_df` may contain the following columns:
 
-            * *is_label_issue*: boolean mask for the entire dataset where ``True`` represents a
-            label issue and ``False`` represents an example that is accurately
-            labeled with high confidence.
-            This column is equivalent to `label_issues_mask` output from
-            :py:func:`filter.find_label_issues<cleanlab.filter.find_label_issues>`.
-            * *label_quality*: Numeric score that measures the quality of each label
-            (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
-            * *given_label*: Integer indices corresponding to the class label originally given for this example
-            (same as `labels` input). Included here for ease of comparison against `clf` predictions,
-             only present if "predicted_label" column is present.
-            * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model
-            Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
-            * *sample_weight*: Numeric values used to weight examples during
-            the final training of `clf` in :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`.
-            This column not be present after `self.find_label_issues()` but may be added
-            after call to :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`.
-            For more precise definition of sample weights, see documentation of
-            :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`.
+            * *is_label_issue*: boolean mask for the entire dataset where ``True`` represents a label issue and ``False`` represents an example that is accurately labeled with high confidence. This column is equivalent to `label_issues_mask` output from :py:func:`filter.find_label_issues<cleanlab.filter.find_label_issues>`.
+            * *label_quality*: Numeric score that measures the quality of each label (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
+            * *given_label*: Integer indices corresponding to the class label originally given for this example (same as `labels` input). Included here for ease of comparison against `clf` predictions, only present if "predicted_label" column is present.
+            * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model. Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
+            * *sample_weight*: Numeric values used to weight examples during the final training of `clf` in :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. This column not be present after `self.find_label_issues()` but may be added
+            after call to :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. For more precise definition of sample weights, see documentation of :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`
         """
 
         if self.label_issues_df is not None and self.verbose and not save_space:

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -128,6 +128,7 @@ from cleanlab.count import (
     estimate_py_and_noise_matrices_from_probabilities,
     estimate_cv_predicted_probabilities,
     estimate_latent,
+    compute_confident_joint,
 )
 from cleanlab.internal.latent_algebra import (
     compute_py_inv_noise_matrix,
@@ -691,6 +692,13 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                     thresholds=thresholds,
                     converge_latent_estimates=self.converge_latent_estimates,
                 )
+        # If needed, compute the confident_joint (e.g. occurs if noise_matrix was given)
+        if self.confident_joint is None:
+            self.confident_joint = compute_confident_joint(
+                labels=labels,
+                pred_probs=pred_probs,
+                thresholds=thresholds,
+            )
         # If needed, compute P(label=k|x), denoted pred_probs (the predicted probabilities)
         if pred_probs is None:
             if self.verbose:

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -692,13 +692,6 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                     thresholds=thresholds,
                     converge_latent_estimates=self.converge_latent_estimates,
                 )
-        # If needed, compute the confident_joint (e.g. occurs if noise_matrix was given)
-        if self.confident_joint is None:
-            self.confident_joint = compute_confident_joint(
-                labels=labels,
-                pred_probs=pred_probs,
-                thresholds=thresholds,
-            )
         # If needed, compute P(label=k|x), denoted pred_probs (the predicted probabilities)
         if pred_probs is None:
             if self.verbose:
@@ -714,6 +707,13 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                 cv_n_folds=self.cv_n_folds,
                 seed=self.seed,
                 clf_kwargs=self.clf_kwargs,
+            )
+        # If needed, compute the confident_joint (e.g. occurs if noise_matrix was given)
+        if self.confident_joint is None:
+            self.confident_joint = compute_confident_joint(
+                labels=labels,
+                pred_probs=pred_probs,
+                thresholds=thresholds,
             )
         # if pulearning == the integer specifying the class without noise.
         if self.num_classes == 2 and self.pulearning is not None:  # pragma: no cover

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -358,6 +358,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         -------
         CleanLearning
           ``self`` - Fitted estimator that has all the same methods as any sklearn estimator.
+          
+          
           After calling ``self.fit()``, this estimator also stores a few extra useful attributes, in particular
           `self.label_issues_df`: a pd.DataFrame accessible via
           :py:meth:`get_label_issues
@@ -365,8 +367,6 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           of similar format as the one returned by: :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`.
           See documentation of :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`
           for column descriptions.
-          
-
           After calling ``self.fit()``, `self.label_issues_df` may also contain an extra column:
 
           * *sample_weight*: Numeric values that were used to weight examples during

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -716,7 +716,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         if self.num_classes < np.iinfo(np.dtype("int16")).max:
             compressed_type = "int16"
         elif self.num_classes < np.iinfo(np.dtype("int32")).max:
-            compressed_type = "int32"
+            compressed_type = "int32"  # pragma: no cover
         if compressed_type is not None:
             predicted_labels = predicted_labels.astype(compressed_type)
         label_issues_df["given_label"] = labels
@@ -726,7 +726,9 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             self.label_issues_df = label_issues_df
             self.label_issues_mask = label_issues_mask
         elif self.verbose:
-            print("Not storing label_issues as attributes since save_space was specified.")
+            print(  # pragma: no cover
+                "Not storing label_issues as attributes since save_space was specified."
+            )
 
         return label_issues_df
 
@@ -750,7 +752,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         (e.g. you cannot call `fit()` anymore).
         """
         if self.label_issues_df is None and self.verbose:
-            print("self.label_issues_df is already empty")
+            print("self.label_issues_df is already empty")  # pragma: no cover
         self.label_issues_df = None
         self.sample_weight = None
         self.label_issues_mask = None

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -361,8 +361,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           ``self`` - Fitted estimator that has all the same methods as any sklearn estimator.
           After calling ``self.fit()``, this estimator also stores a few extra useful attributes, in particular
           `self.label_issues_df`: a pd.DataFrame accessible via
-          :py:meth:`self.get_label_issues
-            <cleanlab.classification.CleanLearning.get_label_issues>`
+          :py:meth:`get_label_issues
+          <cleanlab.classification.CleanLearning.get_label_issues>`
           of similar format as the one returned by:
           :py:meth:`CleanLearning.find_label_issues
             <cleanlab.classification.CleanLearning.find_label_issues>`.
@@ -587,8 +587,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           pd.DataFrame
             Unless `save_space` is specified, this DataFrame is also stored as
             `self.label_issues_df` attribute accessible via
-            :py:meth:`self.get_label_issues()
-            <cleanlab.classification.CleanLearning.get_label_issues>`.
+            :py:meth:`get_label_issues
+          <cleanlab.classification.CleanLearning.get_label_issues>`.
             Each row represents an example from our dataset and
             `label_issues_df` may contain the following columns:
 

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -121,6 +121,7 @@ import warnings
 from cleanlab.internal.util import (
     assert_inputs_are_valid,
     value_counts,
+    compress_int_array,
 )
 from cleanlab.count import (
     estimate_py_noise_matrices_and_cv_pred_proba,
@@ -556,11 +557,9 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         This is the method called to find label issues inside
         :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`. 
-        Most of the **Parameters** of this method are  
-        For info about the other parameters, see the docstring of :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`.
-
+        <cleanlab.classification.CleanLearning.fit>`
+        and they share mostly the same parameters.
+        
         Parameters
         ----------
         save_space : bool, optional
@@ -570,7 +569,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         For info about the other parameters, see the docstring of :py:meth:`CleanLearning.fit()
         <cleanlab.classification.CleanLearning.fit>`.
-        
+
         Returns
         -------
         label_issues_df : pd.DataFrame
@@ -718,16 +717,9 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             print(f"Identified {np.sum(label_issues_mask)} examples with label issues.")
 
         predicted_labels = pred_probs.argmax(axis=1)
-        compressed_type = None
-        if self.num_classes < np.iinfo(np.dtype("int16")).max:
-            compressed_type = "int16"
-        elif self.num_classes < np.iinfo(np.dtype("int32")).max:  # pragma: no cover
-            compressed_type = "int32"  # pragma: no cover
-        if compressed_type is not None:
-            predicted_labels = predicted_labels.astype(compressed_type)
-        label_issues_df["given_label"] = labels
-        label_issues_df["predicted_label"] = predicted_labels
-
+        label_issues_df["given_label"] = compress_int_array(labels, self.num_classes)
+        label_issues_df["predicted_label"] = compress_int_array(predicted_labels, self.num_classes)
+        
         if not save_space:
             self.label_issues_df = label_issues_df
             self.label_issues_mask = label_issues_mask

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -544,7 +544,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           Runs cross-validation to get out-of-sample pred_probs from `clf`
           and then calls :py:func:`filter.find_label_issues
           <cleanlab.filter.find_label_issues>` to find label issues.
-          The resulting mask is cached internally and returned.
+          These label issues are cached internally and returned in a pandas DataFrame.
           Kwargs for :py:func:`filter.find_label_issues
           <cleanlab.filter.find_label_issues>` must have already been specified
           in the initialization of this class, not here.
@@ -575,7 +575,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             This means some other methods like `self.get_label_issues()` will no longer work.
 
 
-          For info about the other parameters, see the docstring of :py:meth:`CleanLearning.fit()
+          For info about the **other parameters**, see the docstring of :py:meth:`CleanLearning.fit()
           <cleanlab.classification.CleanLearning.fit>`.
 
           Returns

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -558,8 +558,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         :py:meth:`CleanLearning.fit()
         <cleanlab.classification.CleanLearning.fit>`.
 
-        Parameters
-        ----------
+        Extra Parameters
+        ----------------
         save_space : bool, optional
           If True, then returned `label_issues_df` will not be stored as attribute.
           This means some other methods like `self.get_label_issues()` will no longer work.

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -356,28 +356,21 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         `self.label_issues_df`: a pd.DataFrame in which each row represents an example from our dataset. 
         `self.label_issues_df` may contain the following columns:
 
-          * *is_label_issue*: boolean mask for the entire dataset where ``True`` represents a
-          label issue and ``False`` represents an example that is accurately
-          labeled with high confidence.
-          This column is equivalent to `label_issues_mask` output from `filter.find_label_issues()`.
-          * *label_quality*: Numeric score that measures the quality of each label
-          (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
-          * *given_label*: Integer indices corresponding to the class label originally given for this example
-          (same as `labels` input). Included here for ease of comparison against `clf` predictions,  
-           only present if "predicted_label" column is present.
-          * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model
-          Only present if `pred_probs` were provided as input or computed during label-issue-finding.
-          * *sample_weight*: Numeric values that were used to weight examples during
-          the final training of `clf` in `CleanLearning.fit()`.
-          sample_weight column will only be present if sample weights were actually used.
-          These weights are assigned to each example based on the class it belongs to,
-          i.e. there are only num_classes unique sample_weight values.
-          The sample weight for an example belonging to class k is computed as 1 / p(given_label = k | true_label = k).
-          This sample_weight normalizes the loss to effectively trick `clf` into learning with the distribution
-          of the true labels by accounting for the noisy data pruned out prior to training on cleaned data.
-          In other words, examples with label issues were removed, so this weights the data proportionally 
-          so that the classifier trains as if it had all the true labels,
-          not just the subset of cleaned data left after pruning out the label issues.
+          - "is_label_issue": boolean where ``True`` represents a
+            label issue and ``False`` represents an example that is accurately
+            labeled with high confidence.
+            This column is equivalent to `label_issues_mask` output from `filter.find_label_issues()`.
+
+          - "label_quality": numeric score that measures the quality of each label
+            (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
+
+          - "predicted_class": integer indices corresponding the class predicted by trained `clf` model
+            (only present if `pred_probs` were provided as input or computed during label-issue-finding).
+
+          - "sample_weight": numeric values corresponding to weights to assign each example
+            based on how trustworthy its label is.
+            These sample weights were used in the final model training in `CleanLearning.fit()`.
+            sample_weight column will only be present if sample weights were actually used.
         """
 
         try_import_pandas()

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -556,17 +556,21 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         This is the method called to find label issues inside
         :py:meth:`CleanLearning.fit()
+        <cleanlab.classification.CleanLearning.fit>`. 
+        Most of the **Parameters** of this method are  
+        For info about the other parameters, see the docstring of :py:meth:`CleanLearning.fit()
         <cleanlab.classification.CleanLearning.fit>`.
 
-        Extra Parameters
-        ----------------
+        Parameters
+        ----------
         save_space : bool, optional
           If True, then returned `label_issues_df` will not be stored as attribute.
           This means some other methods like `self.get_label_issues()` will no longer work.
 
+
         For info about the other parameters, see the docstring of :py:meth:`CleanLearning.fit()
         <cleanlab.classification.CleanLearning.fit>`.
-
+        
         Returns
         -------
         label_issues_df : pd.DataFrame

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -333,14 +333,16 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           default :py:func:`filter.find_label_issues <cleanlab.filter.find_label_issues>`,
           or integer indices as output by
           :py:func:`filter.find_label_issues <cleanlab.filter.find_label_issues>`
-          with its `return_indices_ranked_by` argument specified.
+          with its ``return_indices_ranked_by`` argument specified.
           Providing this argument significantly reduces the time this method takes to run by
           skipping the slow cross-validation step necessary to find label issues.
           Examples identified to have label issues will be
           pruned from the data before training the final `clf` model.
 
-          Caution: If you provide `label_issues` without having previously called `self.find_label_issues()`,
-          e.g. as np.array, then some functionality like training with sample weights may be disabled.
+          Caution: If you provide `label_issues` without having previously called
+          :py:meth:`self.find_label_issues
+          <cleanlab.classification.CleanLearning.find_label_issues>`,
+          e.g. as a np.array, then some functionality like training with sample weights may be disabled.
 
         clf_kwargs : dict, optional
           Optional keyword arguments to pass into `clf`'s ``fit()`` method.
@@ -359,28 +361,20 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             Fitted estimator that has all the same methods as any sklearn estimator.
 
 
-        After calling `fit()` this estimator also stores a few extra useful attributes, in particular
-        `self.label_issues_df`: a pd.DataFrame accessible via `self.get_label_issues()`
+        After calling ``self.fit()`` this estimator also stores a few extra useful attributes, in particular
+        `self.label_issues_df`: a pd.DataFrame accessible via
+        :py:meth:`self.get_label_issues
+          <cleanlab.classification.CleanLearning.get_label_issues>`
         of similar format as the one returned by:
         :py:meth:`CleanLearning.find_label_issues
+          <cleanlab.classification.CleanLearning.find_label_issues>`.
+        See documentation of :py:meth:`CleanLearning.find_label_issues
           <cleanlab.classification.CleanLearning.find_label_issues>`
+        for column descriptions.
+        After calling ``self.fit()`` `self.label_issues_df` may also contain an extra column:
 
-        `self.label_issues_df`: a pd.DataFrame in which each row represents an example from our dataset.
-        `self.label_issues_df` may contain the following columns:
-
-          * *is_label_issue*: boolean mask for the entire dataset where ``True`` represents a
-          label issue and ``False`` represents an example that is accurately
-          labeled with high confidence.
-          This column is equivalent to `label_issues_mask` output from `filter.find_label_issues()`.
-          * *label_quality*: Numeric score that measures the quality of each label
-          (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
-          * *given_label*: Integer indices corresponding to the class label originally given for this example
-          (same as `labels` input). Included here for ease of comparison against `clf` predictions,
-           only present if "predicted_label" column is present.
-          * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model
-          Only present if `pred_probs` were provided as input or computed during label-issue-finding.
-          * *sample_weight*: Numeric values that were used to weight examples during
-          the final training of `clf` in `CleanLearning.fit()`.
+        * *sample_weight*: Numeric values that were used to weight examples during
+          the final training of ``clf`` in ``CleanLearning.fit()``.
           sample_weight column will only be present if sample weights were actually used.
           These weights are assigned to each example based on the class it belongs to,
           i.e. there are only num_classes unique sample_weight values.
@@ -591,9 +585,33 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         Returns
         -------
         label_issues_df : pd.DataFrame
-          DataFrame with same format as the one returned by :py:meth:`CleanLearning.fit()
+          Unless `save_space` is specified, this DataFrame is also stored as
+          `self.label_issues_df` attribute accessible via
+          :py:meth:`self.get_label_issues
+          <cleanlab.classification.CleanLearning.get_label_issues>`.
+          Each row represents an example from our dataset and
+          `label_issues_df` may contain the following columns:
+
+          * *is_label_issue*: boolean mask for the entire dataset where ``True`` represents a
+          label issue and ``False`` represents an example that is accurately
+          labeled with high confidence.
+          This column is equivalent to ``label_issues_mask`` output from ``filter.find_label_issues()``.
+          * *label_quality*: Numeric score that measures the quality of each label
+          (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
+          * *given_label*: Integer indices corresponding to the class label originally given for this example
+          (same as `labels` input). Included here for ease of comparison against `clf` predictions,
+           only present if "predicted_label" column is present.
+          * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model
+          Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
+          * *sample_weight*: Numeric values used to weight examples during
+          the final training of `clf` in :py:meth:`CleanLearning.fit()
         <cleanlab.classification.CleanLearning.fit>`.
-          See there for documentation regarding column definitions.
+          This column not be present after `self.find_label_issues()` but may be added
+          after call to :py:meth:`CleanLearning.fit()
+        <cleanlab.classification.CleanLearning.fit>`.
+          For more precise definition of sample weights, see documentation of
+          :py:meth:`CleanLearning.fit()
+        <cleanlab.classification.CleanLearning.fit>`.
         """
 
         if self.label_issues_df is not None and self.verbose and not save_space:

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -752,7 +752,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
     def get_label_issues(self):
         """
         Accessor. Returns `label_issues_df` attribute if previously already computed.
-        This pd.DataFrame describes the label issues identified for each example (as rows).
+        This pd.DataFrame describes the label issues identified for each example 
+        (each row corresponds to an example).
         For column definitions, see the documentation of
         :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`.
 

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -586,8 +586,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           pd.DataFrame
             Unless `save_space` is specified, this DataFrame is also stored as
             `self.label_issues_df` attribute accessible via
-            :py:meth:`get_label_issues
-          <cleanlab.classification.CleanLearning.get_label_issues>`.
+            :py:meth:`get_label_issues<cleanlab.classification.CleanLearning.get_label_issues>`.
             Each row represents an example from our dataset and
             `label_issues_df` may contain the following columns:
 
@@ -595,8 +594,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             label issue and ``False`` represents an example that is accurately
             labeled with high confidence.
             This column is equivalent to `label_issues_mask` output from
-            :py:func:`filter.find_label_issues
-        <cleanlab.filter.find_label_issues>`.
+            :py:func:`filter.find_label_issues<cleanlab.filter.find_label_issues>`.
             * *label_quality*: Numeric score that measures the quality of each label
             (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
             * *given_label*: Integer indices corresponding to the class label originally given for this example
@@ -605,14 +603,11 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model
             Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
             * *sample_weight*: Numeric values used to weight examples during
-            the final training of `clf` in :py:meth:`CleanLearning.fit()
-          <cleanlab.classification.CleanLearning.fit>`.
+            the final training of `clf` in :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`.
             This column not be present after `self.find_label_issues()` but may be added
-            after call to :py:meth:`CleanLearning.fit()
-          <cleanlab.classification.CleanLearning.fit>`.
+            after call to :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`.
             For more precise definition of sample weights, see documentation of
-            :py:meth:`CleanLearning.fit()
-          <cleanlab.classification.CleanLearning.fit>`.
+            :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`.
         """
 
         if self.label_issues_df is not None and self.verbose and not save_space:

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -581,9 +581,10 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           Returns
           -------
           pd.DataFrame
-            Unless `save_space` is specified, this DataFrame is also stored as
+            pandas DataFrame that is also stored as
             `self.label_issues_df` attribute accessible via
-            :py:meth:`get_label_issues<cleanlab.classification.CleanLearning.get_label_issues>`.
+            :py:meth:`get_label_issues<cleanlab.classification.CleanLearning.get_label_issues>` 
+            (unless `save_space` argument is specified). 
             Each row represents an example from our dataset and
             `label_issues_df` may contain the following columns:
 

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -591,8 +591,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             * *label_quality*: Numeric score that measures the quality of each label (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
             * *given_label*: Integer indices corresponding to the class label originally given for this example (same as `labels` input). Included here for ease of comparison against `clf` predictions, only present if "predicted_label" column is present.
             * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model. Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
-            * *sample_weight*: Numeric values used to weight examples during the final training of `clf` in :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. This column not be present after `self.find_label_issues()` but may be added
-            after call to :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. For more precise definition of sample weights, see documentation of :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`
+            * *sample_weight*: Numeric values used to weight examples during the final training of `clf` in :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. This column not be present after `self.find_label_issues()` but may be added after call to :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. For more precise definition of sample weights, see documentation of :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`
         """
 
         if self.label_issues_df is not None and self.verbose and not save_space:

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -545,73 +545,77 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         clf_kwargs={},
     ):
         """
-        Identifies potential label issues in the dataset using confident learning.
+          Identifies potential label issues in the dataset using confident learning.
 
-        Runs cross-validation to get out-of-sample pred_probs from `clf`
-        and then calls :py:func:`filter.find_label_issues
-        <cleanlab.filter.find_label_issues>` to find label issues.
-        The resulting mask is cached internally and returned.
-        Kwargs for :py:func:`filter.find_label_issues
-        <cleanlab.filter.find_label_issues>` must have already been specified
-        in the initialization of this class, not here.
+          Runs cross-validation to get out-of-sample pred_probs from `clf`
+          and then calls :py:func:`filter.find_label_issues
+          <cleanlab.filter.find_label_issues>` to find label issues.
+          The resulting mask is cached internally and returned.
+          Kwargs for :py:func:`filter.find_label_issues
+          <cleanlab.filter.find_label_issues>` must have already been specified
+          in the initialization of this class, not here.
 
-        Unlike :py:func:`filter.find_label_issues
-        <cleanlab.filter.find_label_issues>`, which requires `pred_probs`,
-        this method only requires a classifier and it can do the cross-validation for you.
-        Both methods return the same boolean mask that identifies which examples have label issues.
-        This is the preferred method to use if you plan to subsequently invoke: `CleanLearning.fit()`.
-
-        Note: this method computes the label issues from scratch. To access
-        previously-computed label issues from this :py:class:`CleanLearning
-        <cleanlab.classification.CleanLearning>` instance, use the
-        :py:meth:`get_label_issues
-        <cleanlab.classification.CleanLearning.get_label_issues>` method.
-
-        This is the method called to find label issues inside
-        :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`
-        and they share mostly the same parameters.
-
-        Parameters
-        ----------
-        save_space : bool, optional
-          If True, then returned `label_issues_df` will not be stored as attribute.
-          This means some other methods like `self.get_label_issues()` will no longer work.
-
-
-        For info about the other parameters, see the docstring of :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`.
-
-        Returns
-        -------
-        label_issues_df : pd.DataFrame
-          Unless `save_space` is specified, this DataFrame is also stored as
-          `self.label_issues_df` attribute accessible via
-          :py:meth:`self.get_label_issues
-          <cleanlab.classification.CleanLearning.get_label_issues>`.
-          Each row represents an example from our dataset and
-          `label_issues_df` may contain the following columns:
-
-          * *is_label_issue*: boolean mask for the entire dataset where ``True`` represents a
-          label issue and ``False`` represents an example that is accurately
-          labeled with high confidence.
-          This column is equivalent to ``label_issues_mask`` output from ``filter.find_label_issues()``.
-          * *label_quality*: Numeric score that measures the quality of each label
-          (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
-          * *given_label*: Integer indices corresponding to the class label originally given for this example
-          (same as `labels` input). Included here for ease of comparison against `clf` predictions,
-           only present if "predicted_label" column is present.
-          * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model
-          Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
-          * *sample_weight*: Numeric values used to weight examples during
-          the final training of `clf` in :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`.
-          This column not be present after `self.find_label_issues()` but may be added
-          after call to :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`.
-          For more precise definition of sample weights, see documentation of
+          Unlike :py:func:`filter.find_label_issues
+          <cleanlab.filter.find_label_issues>`, which requires `pred_probs`,
+          this method only requires a classifier and it can do the cross-validation for you.
+          Both methods return the same boolean mask that identifies which examples have label issues.
+          This is the preferred method to use if you plan to subsequently invoke:
           :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`.
+          <cleanlab.classification.CleanLearning.fit>`.
+
+          Note: this method computes the label issues from scratch. To access
+          previously-computed label issues from this :py:class:`CleanLearning
+          <cleanlab.classification.CleanLearning>` instance, use the
+          :py:meth:`get_label_issues
+          <cleanlab.classification.CleanLearning.get_label_issues>` method.
+
+          This is the method called to find label issues inside
+          :py:meth:`CleanLearning.fit()
+          <cleanlab.classification.CleanLearning.fit>`
+          and they share mostly the same parameters.
+
+          Parameters
+          ----------
+          save_space : bool, optional
+            If True, then returned `label_issues_df` will not be stored as attribute.
+            This means some other methods like `self.get_label_issues()` will no longer work.
+
+
+          For info about the other parameters, see the docstring of :py:meth:`CleanLearning.fit()
+          <cleanlab.classification.CleanLearning.fit>`.
+
+          Returns
+          -------
+          pd.DataFrame
+            Unless `save_space` is specified, this DataFrame is also stored as
+            `self.label_issues_df` attribute accessible via
+            :py:meth:`self.get_label_issues()
+            <cleanlab.classification.CleanLearning.get_label_issues>`.
+            Each row represents an example from our dataset and
+            `label_issues_df` may contain the following columns:
+
+            * *is_label_issue*: boolean mask for the entire dataset where ``True`` represents a
+            label issue and ``False`` represents an example that is accurately
+            labeled with high confidence.
+            This column is equivalent to `label_issues_mask` output from
+            :py:func:`filter.find_label_issues
+        <cleanlab.filter.find_label_issues>`.
+            * *label_quality*: Numeric score that measures the quality of each label
+            (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
+            * *given_label*: Integer indices corresponding to the class label originally given for this example
+            (same as `labels` input). Included here for ease of comparison against `clf` predictions,
+             only present if "predicted_label" column is present.
+            * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model
+            Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
+            * *sample_weight*: Numeric values used to weight examples during
+            the final training of `clf` in :py:meth:`CleanLearning.fit()
+          <cleanlab.classification.CleanLearning.fit>`.
+            This column not be present after `self.find_label_issues()` but may be added
+            after call to :py:meth:`CleanLearning.fit()
+          <cleanlab.classification.CleanLearning.fit>`.
+            For more precise definition of sample weights, see documentation of
+            :py:meth:`CleanLearning.fit()
+          <cleanlab.classification.CleanLearning.fit>`.
         """
 
         if self.label_issues_df is not None and self.verbose and not save_space:
@@ -771,8 +775,14 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
     def get_label_issues(self):
         """
         Accessor. Returns `label_issues_df` attribute if previously already computed.
-        This pd.DataFrame describes the label issues identified for each datapoint,
-        column definitions are in documentation of CleanLearning.fit().
+        This pd.DataFrame describes the label issues identified for each example (as rows).
+        For column definitions, see the documentation of
+        :py:meth:`CleanLearning.find_label_issues
+          <cleanlab.classification.CleanLearning.find_label_issues>`.
+
+        Returns
+        -------
+        pd.DataFrame
         """
 
         if self.label_issues_df is None:
@@ -787,7 +797,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         This includes the DataFrame attribute that stored label issues which may be large for big datasets.
         You may want to call this method before deploying this model (i.e. if you just care about producing predictions).
         After calling this method, certain non-prediction-related attributes/functionality will no longer be available
-        (e.g. you cannot call `fit()` anymore).
+        (e.g. you cannot call ``self.fit()`` anymore).
         """
 
         if self.label_issues_df is None and self.verbose:

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -333,7 +333,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           default :py:func:`filter.find_label_issues <cleanlab.filter.find_label_issues>`,
           or integer indices as output by
           :py:func:`filter.find_label_issues <cleanlab.filter.find_label_issues>`
-          with its ``return_indices_ranked_by`` argument specified.
+          with its `return_indices_ranked_by` argument specified.
           Providing this argument significantly reduces the time this method takes to run by
           skipping the slow cross-validation step necessary to find label issues.
           Examples identified to have label issues will be
@@ -357,33 +357,31 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         Returns
         -------
-        self
-            Fitted estimator that has all the same methods as any sklearn estimator.
+        CleanLearning
+          ``self`` - Fitted estimator that has all the same methods as any sklearn estimator.
+          After calling ``self.fit()``, this estimator also stores a few extra useful attributes, in particular
+          `self.label_issues_df`: a pd.DataFrame accessible via
+          :py:meth:`self.get_label_issues
+            <cleanlab.classification.CleanLearning.get_label_issues>`
+          of similar format as the one returned by:
+          :py:meth:`CleanLearning.find_label_issues
+            <cleanlab.classification.CleanLearning.find_label_issues>`.
+          See documentation of :py:meth:`CleanLearning.find_label_issues
+            <cleanlab.classification.CleanLearning.find_label_issues>`
+          for column descriptions.
+          After calling ``self.fit()``, `self.label_issues_df` may also contain an extra column:
 
-
-        After calling ``self.fit()`` this estimator also stores a few extra useful attributes, in particular
-        `self.label_issues_df`: a pd.DataFrame accessible via
-        :py:meth:`self.get_label_issues
-          <cleanlab.classification.CleanLearning.get_label_issues>`
-        of similar format as the one returned by:
-        :py:meth:`CleanLearning.find_label_issues
-          <cleanlab.classification.CleanLearning.find_label_issues>`.
-        See documentation of :py:meth:`CleanLearning.find_label_issues
-          <cleanlab.classification.CleanLearning.find_label_issues>`
-        for column descriptions.
-        After calling ``self.fit()`` `self.label_issues_df` may also contain an extra column:
-
-        * *sample_weight*: Numeric values that were used to weight examples during
-          the final training of ``clf`` in ``CleanLearning.fit()``.
-          sample_weight column will only be present if sample weights were actually used.
-          These weights are assigned to each example based on the class it belongs to,
-          i.e. there are only num_classes unique sample_weight values.
-          The sample weight for an example belonging to class k is computed as 1 / p(given_label = k | true_label = k).
-          This sample_weight normalizes the loss to effectively trick `clf` into learning with the distribution
-          of the true labels by accounting for the noisy data pruned out prior to training on cleaned data.
-          In other words, examples with label issues were removed, so this weights the data proportionally
-          so that the classifier trains as if it had all the true labels,
-          not just the subset of cleaned data left after pruning out the label issues.
+          * *sample_weight*: Numeric values that were used to weight examples during
+            the final training of ``clf`` in ``CleanLearning.fit()``.
+            sample_weight column will only be present if sample weights were actually used.
+            These weights are assigned to each example based on the class it belongs to,
+            i.e. there are only num_classes unique sample_weight values.
+            The sample weight for an example belonging to class k is computed as 1 / p(given_label = k | true_label = k).
+            This sample_weight normalizes the loss to effectively trick `clf` into learning with the distribution
+            of the true labels by accounting for the noisy data pruned out prior to training on cleaned data.
+            In other words, examples with label issues were removed, so this weights the data proportionally
+            so that the classifier trains as if it had all the true labels,
+            not just the subset of cleaned data left after pruning out the label issues.
         """
 
         clf_final_kwargs = {**clf_kwargs, **clf_final_kwargs}

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -769,8 +769,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         Accessor. Returns `label_issues_df` attribute if previously already computed.
         This pd.DataFrame describes the label issues identified for each example (as rows).
         For column definitions, see the documentation of
-        :py:meth:`CleanLearning.find_label_issues
-          <cleanlab.classification.CleanLearning.find_label_issues>`.
+        :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`.
 
         Returns
         -------

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -715,7 +715,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         compressed_type = None
         if self.num_classes < np.iinfo(np.dtype("int16")).max:
             compressed_type = "int16"
-        elif self.num_classes < np.iinfo(np.dtype("int32")).max:
+        elif self.num_classes < np.iinfo(np.dtype("int32")).max:  # pragma: no cover
             compressed_type = "int32"  # pragma: no cover
         if compressed_type is not None:
             predicted_labels = predicted_labels.astype(compressed_type)

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -358,8 +358,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         -------
         CleanLearning
           ``self`` - Fitted estimator that has all the same methods as any sklearn estimator.
-          
-          
+
+
           After calling ``self.fit()``, this estimator also stores a few extra useful attributes, in particular
           `self.label_issues_df`: a pd.DataFrame accessible via
           :py:meth:`get_label_issues
@@ -541,60 +541,60 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         clf_kwargs={},
     ):
         """
-          Identifies potential label issues in the dataset using confident learning.
+        Identifies potential label issues in the dataset using confident learning.
 
-          Runs cross-validation to get out-of-sample pred_probs from `clf`
-          and then calls :py:func:`filter.find_label_issues
-          <cleanlab.filter.find_label_issues>` to find label issues.
-          These label issues are cached internally and returned in a pandas DataFrame.
-          Kwargs for :py:func:`filter.find_label_issues
-          <cleanlab.filter.find_label_issues>` must have already been specified
-          in the initialization of this class, not here.
+        Runs cross-validation to get out-of-sample pred_probs from `clf`
+        and then calls :py:func:`filter.find_label_issues
+        <cleanlab.filter.find_label_issues>` to find label issues.
+        These label issues are cached internally and returned in a pandas DataFrame.
+        Kwargs for :py:func:`filter.find_label_issues
+        <cleanlab.filter.find_label_issues>` must have already been specified
+        in the initialization of this class, not here.
 
-          Unlike :py:func:`filter.find_label_issues
-          <cleanlab.filter.find_label_issues>`, which requires `pred_probs`,
-          this method only requires a classifier and it can do the cross-validation for you.
-          Both methods return the same boolean mask that identifies which examples have label issues.
-          This is the preferred method to use if you plan to subsequently invoke:
-          :py:meth:`CleanLearning.fit()
-          <cleanlab.classification.CleanLearning.fit>`.
+        Unlike :py:func:`filter.find_label_issues
+        <cleanlab.filter.find_label_issues>`, which requires `pred_probs`,
+        this method only requires a classifier and it can do the cross-validation for you.
+        Both methods return the same boolean mask that identifies which examples have label issues.
+        This is the preferred method to use if you plan to subsequently invoke:
+        :py:meth:`CleanLearning.fit()
+        <cleanlab.classification.CleanLearning.fit>`.
 
-          Note: this method computes the label issues from scratch. To access
-          previously-computed label issues from this :py:class:`CleanLearning
-          <cleanlab.classification.CleanLearning>` instance, use the
-          :py:meth:`get_label_issues
-          <cleanlab.classification.CleanLearning.get_label_issues>` method.
+        Note: this method computes the label issues from scratch. To access
+        previously-computed label issues from this :py:class:`CleanLearning
+        <cleanlab.classification.CleanLearning>` instance, use the
+        :py:meth:`get_label_issues
+        <cleanlab.classification.CleanLearning.get_label_issues>` method.
 
-          This is the method called to find label issues inside
-          :py:meth:`CleanLearning.fit()
-          <cleanlab.classification.CleanLearning.fit>`
-          and they share mostly the same parameters.
+        This is the method called to find label issues inside
+        :py:meth:`CleanLearning.fit()
+        <cleanlab.classification.CleanLearning.fit>`
+        and they share mostly the same parameters.
 
-          Parameters
-          ----------
-          save_space : bool, optional
-            If True, then returned `label_issues_df` will not be stored as attribute.
-            This means some other methods like `self.get_label_issues()` will no longer work.
+        Parameters
+        ----------
+        save_space : bool, optional
+          If True, then returned `label_issues_df` will not be stored as attribute.
+          This means some other methods like `self.get_label_issues()` will no longer work.
 
 
-          For info about the **other parameters**, see the docstring of :py:meth:`CleanLearning.fit()
-          <cleanlab.classification.CleanLearning.fit>`.
+        For info about the **other parameters**, see the docstring of :py:meth:`CleanLearning.fit()
+        <cleanlab.classification.CleanLearning.fit>`.
 
-          Returns
-          -------
-          pd.DataFrame
-            pandas DataFrame of label issues for each example. 
-            Unless `save_space` argument is specified, same DataFrame is also stored as
-            `self.label_issues_df` attribute accessible via
-            :py:meth:`get_label_issues<cleanlab.classification.CleanLearning.get_label_issues>`. 
-            Each row represents an example from our dataset and
-            the DataFrame may contain the following columns:
+        Returns
+        -------
+        pd.DataFrame
+          pandas DataFrame of label issues for each example.
+          Unless `save_space` argument is specified, same DataFrame is also stored as
+          `self.label_issues_df` attribute accessible via
+          :py:meth:`get_label_issues<cleanlab.classification.CleanLearning.get_label_issues>`.
+          Each row represents an example from our dataset and
+          the DataFrame may contain the following columns:
 
-            * *is_label_issue*: boolean mask for the entire dataset where ``True`` represents a label issue and ``False`` represents an example that is accurately labeled with high confidence. This column is equivalent to `label_issues_mask` output from :py:func:`filter.find_label_issues<cleanlab.filter.find_label_issues>`.
-            * *label_quality*: Numeric score that measures the quality of each label (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
-            * *given_label*: Integer indices corresponding to the class label originally given for this example (same as `labels` input). Included here for ease of comparison against `clf` predictions, only present if "predicted_label" column is present.
-            * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model. Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
-            * *sample_weight*: Numeric values used to weight examples during the final training of `clf` in :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. This column not be present after `self.find_label_issues()` but may be added after call to :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. For more precise definition of sample weights, see documentation of :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`
+          * *is_label_issue*: boolean mask for the entire dataset where ``True`` represents a label issue and ``False`` represents an example that is accurately labeled with high confidence. This column is equivalent to `label_issues_mask` output from :py:func:`filter.find_label_issues<cleanlab.filter.find_label_issues>`.
+          * *label_quality*: Numeric score that measures the quality of each label (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
+          * *given_label*: Integer indices corresponding to the class label originally given for this example (same as `labels` input). Included here for ease of comparison against `clf` predictions, only present if "predicted_label" column is present.
+          * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model. Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
+          * *sample_weight*: Numeric values used to weight examples during the final training of `clf` in :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. This column not be present after `self.find_label_issues()` but may be added after call to :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. For more precise definition of sample weights, see documentation of :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`
         """
 
         if self.label_issues_df is not None and self.verbose and not save_space:
@@ -754,7 +754,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
     def get_label_issues(self):
         """
         Accessor. Returns `label_issues_df` attribute if previously already computed.
-        This pd.DataFrame describes the label issues identified for each example 
+        This pd.DataFrame describes the label issues identified for each example
         (each row corresponds to an example).
         For column definitions, see the documentation of
         :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`.

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -62,7 +62,7 @@ Examples
 If the model is not sklearn-compatible by default, it might be the case that
 standard packages can adapt the model. For example, you can adapt PyTorch
 models using `skorch <https://skorch.readthedocs.io/>`_ and adapt Keras models
-using `SkiKeras <https://www.adriangb.com/scikeras/>`_.
+using `SciKeras <https://www.adriangb.com/scikeras/>`_.
 
 If an open-source adapter doesn't already exist, you can manually wrap the
 model to be sklearn-compatible. This is made easy by inheriting from
@@ -164,7 +164,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
       If the model is not sklearn-compatible by default, it might be the case that
       standard packages can adapt the model. For example, you can adapt PyTorch
       models using `skorch <https://skorch.readthedocs.io/>`_ and adapt Keras models
-      using `SkiKeras <https://www.adriangb.com/scikeras/>`_.
+      using `SciKeras <https://www.adriangb.com/scikeras/>`_.
 
       Stores the classifier used in Confident Learning.
       Default classifier used is `sklearn.linear_model.LogisticRegression
@@ -365,11 +365,13 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           of similar format as the one returned by: :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`.
           See documentation of :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`
           for column descriptions.
+          
+
           After calling ``self.fit()``, `self.label_issues_df` may also contain an extra column:
 
           * *sample_weight*: Numeric values that were used to weight examples during
-            the final training of ``clf`` in ``CleanLearning.fit()``.
-            sample_weight column will only be present if sample weights were actually used.
+            the final training of `clf` in ``CleanLearning.fit()``.
+            `sample_weight` column will only be present if sample weights were actually used.
             These weights are assigned to each example based on the class it belongs to,
             i.e. there are only num_classes unique sample_weight values.
             The sample weight for an example belonging to class k is computed as 1 / p(given_label = k | true_label = k).

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -387,6 +387,12 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         self.clf_final_kwargs = clf_final_kwargs
 
         if label_issues is None:
+            if self.label_issues_df is not None and self.verbose:
+                print(
+                    "If you already ran self.find_label_issues() and don't want to recompute, you "
+                    "should pass the label_issues in as a parameter to this function next time."
+                )
+
             label_issues = self.find_label_issues(
                 X,
                 labels,
@@ -396,11 +402,16 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                 inverse_noise_matrix=inverse_noise_matrix,
                 clf_kwargs=clf_kwargs,
             )
+
         else:  # have to set some args that may not have been set if `self.find_label_issues()` wasn't called yet
             if self.num_classes is None:
                 self.num_classes = len(np.unique(labels))
             if self.verbose:
                 print("Using provided label_issues instead of finding label issues.")
+                if self.label_issues_df is not None:
+                    print(
+                        "These will overwrite self.label_issues_df and will be returned by `self.get_label_issues()`."
+                    )
 
         # label_issues always overwrites self.label_issues_df. Ensure it is properly formatted:
         self.label_issues_df = self._process_label_issues_arg(label_issues, labels)
@@ -474,7 +485,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         if self.verbose:
             print(
-                "Label issues stored in `label_issues_df` DataFrame accessible via: self.get_label_issues(). "
+                "Label issues stored in label_issues_df DataFrame accessible via: self.get_label_issues(). "
                 "Call self.save_space() to delete this potentially large DataFrame attribute."
             )
         return self
@@ -601,9 +612,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         if self.label_issues_df is not None and self.verbose and not save_space:
             print(
                 "Overwriting previously identified label issues stored at self.label_issues_df. "
-                "`self.get_label_issues()` will now return the newly identified label issues. "
-                "If you already ran `self.find_label_issues()` and don't want to recompute, you "
-                "should pass the `label_issues_df` in as a parameter to this function."
+                "self.get_label_issues() will now return the newly identified label issues. "
             )
 
         # Check inputs
@@ -621,7 +630,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         if len(labels) / self.num_classes < self.cv_n_folds:
             raise ValueError(
                 "Need more data from each class for cross-validation. "
-                "Try decreasing `cv_n_folds` (eg. to 2,3) in CleanLearning()"
+                "Try decreasing cv_n_folds (eg. to 2 or 3) in CleanLearning()"
             )
         # 'ps' is p(labels=k)
         self.ps = value_counts(labels) / float(len(labels))

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -581,12 +581,12 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           Returns
           -------
           pd.DataFrame
-            pandas DataFrame that is also stored as
+            pandas DataFrame of label issues for each example. 
+            Unless `save_space` argument is specified, same DataFrame is also stored as
             `self.label_issues_df` attribute accessible via
-            :py:meth:`get_label_issues<cleanlab.classification.CleanLearning.get_label_issues>` 
-            (unless `save_space` argument is specified). 
+            :py:meth:`get_label_issues<cleanlab.classification.CleanLearning.get_label_issues>`. 
             Each row represents an example from our dataset and
-            `label_issues_df` may contain the following columns:
+            the DataFrame may contain the following columns:
 
             * *is_label_issue*: boolean mask for the entire dataset where ``True`` represents a label issue and ``False`` represents an example that is accurately labeled with high confidence. This column is equivalent to `label_issues_mask` output from :py:func:`filter.find_label_issues<cleanlab.filter.find_label_issues>`.
             * *label_quality*: Numeric score that measures the quality of each label (how likely it is to be correct, with lower scores indicating potentially erroneous labels).

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -556,14 +556,16 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         This is the method called to find label issues inside
         :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`. See there for
-        documentation for the arguments `pred_probs`, `thresholds`, etc.
+        <cleanlab.classification.CleanLearning.fit>`.
 
         Parameters
         ----------
         save_space : bool, optional
           If True, then returned `label_issues_df` will not be stored as attribute.
           This means some other methods like `self.get_label_issues()` will no longer work.
+
+        For info about the other parameters, see the docstring of :py:meth:`CleanLearning.fit()
+        <cleanlab.classification.CleanLearning.fit>`.
 
         Returns
         -------

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -726,7 +726,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         After calling this method, certain non-prediction-related attributes/functionality will no longer be available
         (e.g. you cannot call `fit()` anymore).
         """
-        if self.label_issues_df is None:
+        if self.label_issues_df is None and self.verbose:
             print("self.label_issues_df is already empty")
         self.label_issues_df = None
         self.sample_weight = None
@@ -744,7 +744,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         self.inverse_noise_matrix = None
         self.clf_kwargs = None
         self.clf_final_kwargs = None
-        print("Deleted non-sklearn attributes such as label_issues_df to save space.")
+        if self.verbose:
+            print("Deleted non-sklearn attributes such as label_issues_df to save space.")
 
     def _process_label_issues_kwargs(self, find_label_issues_kwargs):
         """Private helper function that is used to modify the arguments to passed to

--- a/cleanlab/internal/label_quality_utils.py
+++ b/cleanlab/internal/label_quality_utils.py
@@ -56,7 +56,7 @@ def _subtract_confident_thresholds(labels: np.array, pred_probs: np.array) -> np
     return pred_probs_adj
 
 
-def get_normalized_entropy(pred_probs: np.array) -> np.array:
+def get_normalized_entropy(pred_probs: np.array, min_allowed_prob=1e-6) -> np.array:
     """Returns the normalized entropy of pred_probs.
 
     Normalized entropy is between 0 and 1. Higher values of entropy indicate higher uncertainty in the model's prediction of the correct label.
@@ -76,6 +76,9 @@ def get_normalized_entropy(pred_probs: np.array) -> np.array:
       The columns must be ordered such that these probabilities correspond to class 0,1,2,...
       `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
 
+    min_allowed_prob : float, default=1e-6
+      Minimum allowed probability value. Entries of `pred_probs` below this value will be clipped to this value.
+      Ensures entropy remains well-behaved even when `pred_probs` contains zeros.
     Returns
     -------
     entropy : np.array (float)
@@ -85,4 +88,5 @@ def get_normalized_entropy(pred_probs: np.array) -> np.array:
     num_classes = pred_probs.shape[1]
 
     # Note that dividing by log(num_classes) changes the base of the log which rescales entropy to 0-1 range
-    return -np.sum(pred_probs * np.log(pred_probs), axis=1) / np.log(num_classes)
+    clipped_pred_probs = np.clip(pred_probs, a_min=min_allowed_prob, a_max=None)
+    return -np.sum(pred_probs * np.log(clipped_pred_probs), axis=1) / np.log(num_classes)

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -439,12 +439,3 @@ def print_joint_matrix(joint_matrix, round_places=2):
         short_title="p(labels,y)",
         round_places=round_places,
     )
-
-
-def try_import_pandas():
-    try:
-        import pandas
-    except Exception as e:
-        print(
-            "This functionality requires the `pandas` package. Install via: `pip install pandas>=1.0.0`"
-        )

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -439,3 +439,14 @@ def print_joint_matrix(joint_matrix, round_places=2):
         short_title="p(labels,y)",
         round_places=round_places,
     )
+
+def compress_int_array(int_array, num_possible_values):
+    """Compresses dtype of np.array<int> if num_possible_values is small enough."""
+    compressed_type = None
+    if num_possible_values < np.iinfo(np.dtype("int16")).max:
+        compressed_type = "int16"
+    elif num_possible_values < np.iinfo(np.dtype("int32")).max:  # pragma: no cover
+        compressed_type = "int32"  # pragma: no cover
+    if compressed_type is not None:
+        int_array = int_array.astype(compressed_type)
+    return int_array

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -439,3 +439,12 @@ def print_joint_matrix(joint_matrix, round_places=2):
         short_title="p(labels,y)",
         round_places=round_places,
     )
+
+
+def try_import_pandas():
+    try:
+        import pandas
+    except Exception as e:
+        print(
+            "This functionality requires the `pandas` package. Install via: `pip install pandas>=1.0.0`"
+        )

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -440,12 +440,14 @@ def get_confidence_weighted_entropy_for_each_label(
       being correctly labeled.
     """
 
+    MIN_ALLOWED_RAW_SCORE = 1e-6 - 1  # lower-bound clipping threshold to prevent 0 in logarithm
     self_confidence = get_self_confidence_for_each_label(labels, pred_probs)
 
     # Divide entropy by self confidence
     label_quality_scores = get_normalized_entropy(**{"pred_probs": pred_probs}) / self_confidence
 
     # Rescale
+    label_quality_scores = np.clip(label_quality_scores, a_min=MIN_ALLOWED_RAW_SCORE, a_max=None)
     label_quality_scores = np.log(label_quality_scores + 1) / label_quality_scores
 
     return label_quality_scores

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         "scikit-learn>=0.18",
         "scipy>=1.1.0",
         "tqdm>=4.53.0",
+        "pandas>=1.0.0",
     ],
 )
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -199,7 +199,10 @@ def test_aux_inputs():
     # Verbose off
     cl = CleanLearning(
         clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED),
-        verbose=0,
+    )
+    cl.save_space()  # dummy call test
+    cl = CleanLearning(
+        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED), verbose=1
     )
 
     # Test with label_issues_mask input
@@ -601,6 +604,7 @@ def test_cj_in_find_label_issues_kwargs(filter_by, seed):
                     "filter_by": "both",
                     "min_examples_per_class": 1,
                 },
+                verbose=1,
             )
         else:
             cl = CleanLearning(
@@ -609,6 +613,7 @@ def test_cj_in_find_label_issues_kwargs(filter_by, seed):
                     "filter_by": "both",
                     "min_examples_per_class": 1,
                 },
+                verbose=0,
             )
         label_issues_df = cl.find_label_issues(DATA["X_train"], labels=labels)
         label_issues_mask = label_issues_df["is_label_issue"].values

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -23,12 +23,13 @@ from numpy.random import multivariate_normal
 import scipy
 import pytest
 import numpy as np
+import pandas as pd
 from cleanlab.classification import CleanLearning
 from cleanlab.benchmarking.noise_generation import generate_noise_matrix_from_trace
 from cleanlab.benchmarking.noise_generation import generate_noisy_labels
 from cleanlab.internal.latent_algebra import compute_inv_noise_matrix
 from cleanlab.count import compute_confident_joint, estimate_cv_predicted_probabilities
-
+from cleanlab.filter import find_label_issues
 
 SEED = 1
 
@@ -164,31 +165,75 @@ def test_aux_inputs():
         find_label_issues_kwargs=find_label_issues_kwargs,
         verbose=1,
     )
-    label_issues_mask = cl.find_label_issues(data["X_train"], data["labels"], clf_kwargs={})
-    assert (label_issues_mask == cl.get_label_issues()).all()
+    label_issues_df = cl.find_label_issues(data["X_train"], data["labels"], clf_kwargs={})
+    assert isinstance(label_issues_df, pd.DataFrame)
+    FIND_OUTPUT_COLUMNS = ["is_label_issue", "label_quality", "given_label", "predicted_label"]
+    assert list(label_issues_df.columns) == FIND_OUTPUT_COLUMNS
+    assert label_issues_df.equals(cl.get_label_issues())
     cl.fit(
         data["X_train"],
         data["labels"],
-        label_issues_mask=label_issues_mask,
+        label_issues=label_issues_df,
         clf_kwargs={},
         clf_final_kwargs={},
     )
+    label_issues_df = cl.get_label_issues()
+    assert isinstance(label_issues_df, pd.DataFrame)
+    assert list(label_issues_df.columns) == (FIND_OUTPUT_COLUMNS + ["sample_weight"])
     score = cl.score(data["X_test"], data["true_labels_test"])
-    # Test cl find_label_issues with pred_prob input
-    pred_probs_test = cl.predict_proba(data["X_test"])
-    label_issues_mask_test = cl.find_label_issues(
-        X=None, labels=data["true_labels_test"], pred_probs=pred_probs_test
-    )
 
     # Test a second fit
     cl.fit(data["X_train"], data["labels"])
+
+    # Test cl.find_label_issues with pred_prob input
+    pred_probs_test = cl.predict_proba(data["X_test"])
+    label_issues_df = cl.find_label_issues(
+        X=None, labels=data["true_labels_test"], pred_probs=pred_probs_test
+    )
+    assert isinstance(label_issues_df, pd.DataFrame)
+    assert list(label_issues_df.columns) == FIND_OUTPUT_COLUMNS
+    assert label_issues_df.equals(cl.get_label_issues())
+    cl.save_space()
+    assert cl.label_issues_df is None
 
     # Verbose off
     cl = CleanLearning(
         clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED),
         verbose=0,
     )
-    cl.fit(data["X_train"], data["labels"])
+
+    # Test with label_issues_mask input
+    label_issues_mask = find_label_issues(
+        labels=data["true_labels_test"], pred_probs=pred_probs_test
+    )
+    cl.fit(data["X_test"], data["true_labels_test"], label_issues=label_issues_mask)
+    label_issues_df = cl.get_label_issues()
+    assert isinstance(label_issues_df, pd.DataFrame)
+    assert set(label_issues_df.columns).issubset(FIND_OUTPUT_COLUMNS)
+
+    # Test with label_issues_indices input
+    label_issues_indices = find_label_issues(
+        labels=data["true_labels_test"],
+        pred_probs=pred_probs_test,
+        return_indices_ranked_by="confidence_weighted_entropy",
+    )
+    cl.fit(data["X_test"], data["true_labels_test"], label_issues=label_issues_indices)
+    label_issues_df2 = cl.get_label_issues().copy()
+    assert isinstance(label_issues_df2, pd.DataFrame)
+    assert set(label_issues_df2.columns).issubset(FIND_OUTPUT_COLUMNS)
+    assert label_issues_df2["is_label_issue"].equals(label_issues_df["is_label_issue"])
+
+    # Test fit() with pred_prob input:
+    cl.fit(
+        data["X_test"],
+        data["true_labels_test"],
+        pred_probs=pred_probs_test,
+        label_issues=label_issues_mask,
+    )
+    label_issues_df = cl.get_label_issues()
+    assert isinstance(label_issues_df, pd.DataFrame)
+    assert set(label_issues_df.columns).issubset(FIND_OUTPUT_COLUMNS)
+    assert "label_quality" in label_issues_df.columns
 
 
 def test_raise_error_no_clf_fit():
@@ -565,7 +610,8 @@ def test_cj_in_find_label_issues_kwargs(filter_by, seed):
                     "min_examples_per_class": 1,
                 },
             )
-        label_issues_mask = cl.find_label_issues(DATA["X_train"], labels=labels)
+        label_issues_df = cl.find_label_issues(DATA["X_train"], labels=labels)
+        label_issues_mask = label_issues_df["is_label_issue"].values
         # Check if the noise matrix was computed based on the passed in confident joint
         cj_reconstruct = (cl.inverse_noise_matrix * np.bincount(DATA["labels"])).T.astype(int)
         np.all(cl.confident_joint == cj_reconstruct)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -198,16 +198,25 @@ def test_aux_inputs():
 
     # Verbose off
     cl = CleanLearning(
-        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED),
+        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED), verbose=0
     )
     cl.save_space()  # dummy call test
+
+    cl = CleanLearning(
+        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED), verbose=0
+    )
+    cl.find_label_issues(
+        labels=data["true_labels_test"], pred_probs=pred_probs_test, save_space=True
+    )
+
     cl = CleanLearning(
         clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED), verbose=1
     )
 
     # Test with label_issues_mask input
     label_issues_mask = find_label_issues(
-        labels=data["true_labels_test"], pred_probs=pred_probs_test
+        labels=data["true_labels_test"],
+        pred_probs=pred_probs_test,
     )
     cl.fit(data["X_test"], data["true_labels_test"], label_issues=label_issues_mask)
     label_issues_df = cl.get_label_issues()


### PR DESCRIPTION
CleanLearning.fit() can take in intermediate computation from either:
CleanLearning.find_label_issues() -- now a DataFrame
or filter.find_label_issues() -- a 1D np.array which is Boolean mask or integer indices if return_indices_ranked_by was specified.


This PR also fixes bug in entropy() and in get_confidence_weighted_entropy_for_each_label() related to potential 0s in logarithms.

Note: I have not updated unit tests (so currently tests will fail). I'll update the unit tests after getting feedback on the APIs/code.

Many possible workflows (updated):

```
from cleanlab.classification import CleanLearning
from sklearn.ensemble import RandomForestClassifier

clf = RandomForestClassifier()
pred_probs = get_cross_validated_pred_probs(data, clf)

cl = CleanLearning(clf=RandomForestClassifier())

df = cl.find_label_issues(data, labels)
```

```
>>> df
    is_label_issue  label_quality  given_label  predicted_label
0             True       0.393853            2                1
1             True       0.322861            4                3
2             True       0.345246            4                3
3            False       0.850860            0                0
4            False       0.855554            0                0
..             ...            ...          ...              ...
95           False       0.500262            4                4
96           False       0.787859            0                0
97           False       0.706194            4                4
98           False       0.825338            4                4
99           False       0.970152            4                4
```

```
_ = cl.fit(data, labels)  # returns self 
```

```
>>> cl.get_label_issues()
    is_label_issue  label_quality  given_label  predicted_label  sample_weight
0             True       0.287438            2                1            0.0
1             True       0.468316            4                3            0.0
2             True       0.374178            4                3            0.0
3            False       0.949294            0                0            1.0
4            False       0.808242            0                0            1.0
..             ...            ...          ...              ...            ...
95            True       0.424141            4                3            0.0
96           False       0.869043            0                0            1.0
97           False       0.699087            4                4            1.0
98           False       0.895582            4                4            1.0
99           False       0.970152            4                4            1.0
```

```
issue_mask = find_label_issues(labels, pred_probs)
_ = cl.fit(data, labels, label_issues=issue_mask)
```

```
>>> cl.get_label_issues()
    is_label_issue  sample_weight
0             True            0.0
1             True            0.0
2             True            0.0
3            False            1.0
4            False            1.0
..             ...            ...
95           False            1.0
96           False            1.0
97           False            1.0
98           False            1.0
99           False            1.0
```

```
issue_inds = find_label_issues(y, pred_probs, return_indices_ranked_by='normalized_margin')
_ = cl.fit(data, labels,  label_issues=issue_inds)
```

```
>>> cl.get_label_issues()
    is_label_issue  sample_weight
0             True            0.0
1             True            0.0
2             True            0.0
3            False            1.0
4            False            1.0
..             ...            ...
95           False            1.0
96           False            1.0
97           False            1.0
98           False            1.0
99           False            1.0
```

```
>>> cl.save_space()
Deleted non-sklearn attributes such as label_issues_df to save space.

>>> cl.get_label_issues()
UserWarning: The label issues have not yet been computed. Run `self.find_label_issues()` or `self.fit()` first.
```