### PR TITLE
Fix error in docstring. missing item in tuple

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -606,7 +606,7 @@ def estimate_py_and_noise_matrices_from_probabilities(
     Returns
     ------
     tuple
-        A tuple of (py, noise_matrix, inverse_noise_matrix)."""
+        A tuple of (py, noise_matrix, inverse_noise_matrix, confident_joint)."""
 
     confident_joint = compute_confident_joint(
         labels=labels,


### PR DESCRIPTION
Tiny bug fix. missing item in the docstring for the return. made it look like the method returns 3 items but it returns 4.