### PR TITLE
bug fixes and jupyter notebook support added

### DIFF
--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -458,13 +458,6 @@ def smart_display_dataframe(df):  # pragma: no cover
     try:
         from IPython.display import display
 
-        # no exception, let's determine if we are running inside a jupyter notebook
-        shell = get_ipython().__class__.__name__
-        if shell == "ZMQInteractiveShell":
-            display(df)  # Jupyter notebook or qtconsole
-        elif shell == "TerminalInteractiveShell":
-            print(df)  # terminal, not notebook
-        else:
-            print(df)  # something else, but not notebook
-    except:  # pragma: no cover
+        display(df)
+    except:
         print(df)

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -453,7 +453,7 @@ def compress_int_array(int_array, num_possible_values):
     return int_array
 
 
-def smart_display_dataframe(df):
+def smart_display_dataframe(df):  # pragma: no cover
     """Display a pandas dataframe if in a jupyter notebook, otherwise print it to console."""
     try:
         from IPython.display import display

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -451,3 +451,20 @@ def compress_int_array(int_array, num_possible_values):
     if compressed_type is not None:
         int_array = int_array.astype(compressed_type)
     return int_array
+
+
+def smart_display_dataframe(df):
+    """Display a pandas dataframe if in a jupyter notebook, otherwise print it to console."""
+    try:
+        from IPython.display import display
+
+        # no exception, let's determine if we are running inside a jupyter notebook
+        shell = get_ipython().__class__.__name__
+        if shell == "ZMQInteractiveShell":
+            display(df)  # Jupyter notebook or qtconsole
+        elif shell == "TerminalInteractiveShell":
+            print(df)  # terminal, not notebook
+        else:
+            print(df)  # something else, but not notebook
+    except:  # pragma: no cover
+        print(df)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -437,7 +437,12 @@ def test_real_datasets(dataset_name):
     class_names = eval(dataset_name)
     pred_probs, labels = _get_pred_probs_labels_from_labelerrors_datasets(dataset_name)
     # if this runs without issue no all four datasets, the test passes
-    _ = health_summary(pred_probs=pred_probs, labels=labels, class_names=class_names)
+    _ = health_summary(
+        pred_probs=pred_probs,
+        labels=labels,
+        class_names=class_names,
+        verbose=dataset_name != "mnist",  # test out verbose=False on one of the datasets.
+    )
 
 
 @pytest.mark.parametrize("asymmetric", [True, False])


### PR DESCRIPTION
This PR adds three things to ``dataset.health_summary``
* Support for displaying pandas dataframe in a jupyter notebook instead of printing it out, but if the user runs `health_summary` in a terminal with no jupyter notebook, it should still print to console.
* Fixed a bug that would cause health_summary to fail if `pred_probs` is not provided.
* Fixed the printing of the header at the top.