### PR TITLE
Add spaces at the end of doc side nav toc

### DIFF
--- a/docs/source/_templates/versioning.html
+++ b/docs/source/_templates/versioning.html
@@ -26,6 +26,9 @@
     </ul>
 </div>
 
+<br>
+<br>
+
 <script
     type="text/javascript"
     src="{{ DOCS_SITE_URL }}versioning.js"


### PR DESCRIPTION
This PR adds spaces after the side navigation TOC in the doc site. A mock-up is available [here](https://weijinglok.github.io/cleanlab-docs/add-space-toc/index.html).