### PR TITLE
Configure display setting of Dataframe in 2.0 tutorial

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,10 +147,6 @@ nbsphinx_prolog = (
             display: none;
         }
 
-        .dataframe {
-            background: white;
-        }        
-
         .output_area {
             max-height: 300px;
             overflow: auto;

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,6 +147,10 @@ nbsphinx_prolog = (
             display: none;
         }
 
+        .dataframe {
+            background: white;
+        }        
+
         .output_area {
             max-height: 300px;
             overflow: auto;
@@ -186,9 +190,7 @@ if os.getenv("SKIP_NOTEBOOKS", "0") != "0":
 # a list of builtin themes.
 #
 html_theme = "furo"
-html_favicon = (
-    "https://raw.githubusercontent.com/cleanlab/assets/a4483476d449f2f05a4c7cde329e72358099cc07/cleanlab/cleanlab_favicon.svg"
-)
+html_favicon = "https://raw.githubusercontent.com/cleanlab/assets/a4483476d449f2f05a4c7cde329e72358099cc07/cleanlab/cleanlab_favicon.svg"
 html_title = "cleanlab"
 html_logo = (
     "https://raw.githubusercontent.com/cleanlab/assets/master/cleanlab/cleanlab_logo_only.png"

--- a/docs/source/tutorials/indepth_overview.ipynb
+++ b/docs/source/tutorials/indepth_overview.ipynb
@@ -80,6 +80,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%HTML\n",
+    "<style>\n",
+    "    .dataframe {\n",
+    "        background: #F0F0F0;\n",
+    "    }\n",
+    "    \n",
+    "    th {\n",
+    "        color:black;\n",
+    "    }\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "avXlHJcXjruP"
    },

--- a/docs/source/tutorials/indepth_overview.ipynb
+++ b/docs/source/tutorials/indepth_overview.ipynb
@@ -80,7 +80,7 @@
     "HTML(\"\"\"\n",
     "<style>\n",
     "    .dataframe {\n",
-    "        background: green;\n",
+    "        background: #D7D7D7;\n",
     "    }\n",
     "    \n",
     "    th {\n",

--- a/docs/source/tutorials/indepth_overview.ipynb
+++ b/docs/source/tutorials/indepth_overview.ipynb
@@ -74,25 +74,20 @@
     "        print(*missing_dependencies, sep=\", \")\n",
     "        print(\"\\nPlease install them before running the rest of this notebook.\")\n",
     "\n",
-    "%config InlineBackend.print_figure_kwargs={\"facecolor\": \"w\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%HTML\n",
+    "%config InlineBackend.print_figure_kwargs={\"facecolor\": \"w\"}\n",
+    "\n",
+    "from IPython.core.display import HTML\n",
+    "HTML(\"\"\"\n",
     "<style>\n",
     "    .dataframe {\n",
-    "        background: #D7D7D7;\n",
+    "        background: green;\n",
     "    }\n",
     "    \n",
     "    th {\n",
     "        color:black;\n",
     "    }\n",
-    "</style>"
+    "</style>\n",
+    "\"\"\")"
    ]
   },
   {

--- a/docs/source/tutorials/indepth_overview.ipynb
+++ b/docs/source/tutorials/indepth_overview.ipynb
@@ -86,7 +86,7 @@
     "%%HTML\n",
     "<style>\n",
     "    .dataframe {\n",
-    "        background: #F0F0F0;\n",
+    "        background: #D7D7D7;\n",
     "    }\n",
     "    \n",
     "    th {\n",


### PR DESCRIPTION
Configure display setting of Dataframe in 2.0 tutorial to address issues with background color of header in dark mode for docs.

Background color of rows will be addressed in another PR after 2.0 tagging.

```
from IPython.core.display import HTML
HTML("""
<style>
    .dataframe {
        background: #D7D7D7;
    }
    
    th {
        color:black;
    }
</style>
""")
```

Preview in dark mode of Jupyter Lab:
<img width="168" alt="image" src="https://user-images.githubusercontent.com/7146915/163650518-115ae557-e596-4d21-ba0d-0c33c8be01b9.png">

Preview in non-dark mode:
<img width="202" alt="image" src="https://user-images.githubusercontent.com/7146915/163651142-3058871b-6440-42a4-a57b-c9d5ad0911ba.png">
