### PR TITLE
Deploy docs when new release is tagged

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -135,7 +135,7 @@ jobs:
           cp docs/source/_templates/redirect-to-stable.html cleanlab-docs/index.html
 
       - name: Deploy
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ (github.ref == 'refs/heads/master') || (github.ref_type == 'tag') }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/docs/source/tutorials/dataset_health.ipynb
+++ b/docs/source/tutorials/dataset_health.ipynb
@@ -17,15 +17,18 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Install dependencies and import them"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "## Install dependencies and import them"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "You can use pip to install all packages required for this tutorial as follows:\n",
     "\n",
@@ -36,10 +39,7 @@
     "# E.g. if viewing master branch documentation:\n",
     "#     !pip install git+https://github.com/cleanlab/cleanlab.git\n",
     "```"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
This PR fixes the issue where docs are not deployed when a new release is tagged. 

Previously, it only deploys if there is a trigger from the `master` branch. I've added an OR condition to also deploy if it's a trigger from a new release tag.