### PR TITLE
Hardcode v1.0.1 hyperlink in in doc site

### DIFF
--- a/docs/source/_templates/versioning.html
+++ b/docs/source/_templates/versioning.html
@@ -23,6 +23,14 @@
                 >developer</a
             >
         </li>
+        <li class="toctree-l1">
+            <a
+                id="v1.0.1"
+                class="reference internal"
+                href="{{DOCS_SITE_URL}}v1.0.1/"
+                >v1.0.1</a
+            >
+        </li>
     </ul>
 </div>
 


### PR DESCRIPTION
This PR hardcodes the hyperlink to the v1.0.1 doc site. Mock-up here: https://weijinglok.github.io/cleanlab-docs/v2.0.0/index.html