### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/cleanlab/version.py
+++ b/cleanlab/version.py
@@ -18,6 +18,18 @@
 __version__ = "2.0.0"
 
 
+# 2.0.0 - "Data-centric AI Ready". Complete re-architecture of cleanlab API.
+#
+#   For users (+ sometimes developers):
+#   - All spects of API have changed (methods, parameters, 
+#   - Added new dataset module for dealing with dataset-level issues
+#   - CleanLearning now handles most cleanlab tasks in one line of code.
+#   - Several new workflows possible with rank, count, and filter modules
+#
+#   For developers:
+#   - You'll need to reclone.
+#   - Extensive support available at https://docs.cleanlab.ai
+
 # ----------------------------------
 # | PREVIOUS VERSION RELEASE NOTES |
 # ----------------------------------

--- a/cleanlab/version.py
+++ b/cleanlab/version.py
@@ -15,12 +15,12 @@
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
 
 
-__version__ = "1.0.1"
+__version__ = "2.0.0"
 
 
-# ----------------------------------------
-# | CURRENT STABLE VERSION RELEASE NOTES |
-# ----------------------------------------
+# ----------------------------------
+# | PREVIOUS VERSION RELEASE NOTES |
+# ----------------------------------
 
 # 1.0.1 - Launch sphinx docs for Cleanlab 1.0 (in preparation for Cleanlab 2.0). Mostly superficial.
 #
@@ -35,10 +35,6 @@ __version__ = "1.0.1"
 #   For developers:
 #   - Moved to GitHub Actions CI
 #   - Significantly shrunk the clone size to a few MB from 100MB+
-
-# ----------------------------------
-# | PREVIOUS VERSION RELEASE NOTES |
-# ----------------------------------
 
 # 1.0 - cleanlab official 1.0 (beta) release!
 #   - Added Amazon Reviews NLP to cleanlab/examples


### PR DESCRIPTION
did not say anything about 2.0.0 in the release note comments in version.py, just moved 1.0.1 under Previous Versions header