### PR TITLE
Generalize text tutorial to multiclass datasets

### DIFF
--- a/docs/source/tutorials/text.ipynb
+++ b/docs/source/tutorials/text.ipynb
@@ -128,7 +128,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "num_classes = len(set(full_labels))"
+    "num_classes = len(set(full_labels))\n",
+    "print(f\"Classes: {set(full_labels)}\")"
    ],
    "metadata": {}
   },
@@ -351,8 +352,7 @@
    "source": [
     "from sklearn.metrics import log_loss\n",
     "\n",
-    "loss = log_loss(full_labels, pred_probs)\n",
-    "# a lower log loss value means better predictions\n",
+    "loss = log_loss(full_labels, pred_probs)  # score to evaluate probabilistic predictions, lower values are better\n",
     "print(f\"Cross-validated estimate of log loss: {loss:.3f}\")"
    ]
   },

--- a/docs/source/tutorials/text.ipynb
+++ b/docs/source/tutorials/text.ipynb
@@ -130,12 +130,7 @@
    "source": [
     "num_classes = len(set(full_labels))"
    ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/docs/source/tutorials/text.ipynb
+++ b/docs/source/tutorials/text.ipynb
@@ -120,7 +120,8 @@
     "raw_full_ds = tfds.load(\n",
     "    name=\"imdb_reviews\", split=(\"train+test\"), batch_size=-1, as_supervised=True\n",
     ")\n",
-    "raw_full_texts, full_labels = tfds.as_numpy(raw_full_ds)"
+    "raw_full_texts, full_labels = tfds.as_numpy(raw_full_ds)\n",
+    "num_classes = len(set(full_labels))"
    ]
   },
   {
@@ -269,14 +270,15 @@
     "            layers.Dropout(0.2),\n",
     "            layers.GlobalAveragePooling1D(),\n",
     "            layers.Dropout(0.2),\n",
-    "            layers.Dense(1),\n",
+    "            layers.Dense(num_classes),\n",
+    "            layers.Softmax()\n",
     "        ]\n",
     "    )  # outputs probability that text belongs to class 1\n",
     "\n",
     "    net.compile(\n",
     "        optimizer=\"adam\",\n",
-    "        loss=losses.BinaryCrossentropy(from_logits=True),\n",
-    "        metrics=metrics.BinaryAccuracy(),\n",
+    "        loss=losses.SparseCategoricalCrossEntropy(),\n",
+    "        metrics=metrics.CategoricalAccuracy(),\n",
     "    )\n",
     "    return net"
    ]
@@ -339,10 +341,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.metrics import roc_auc_score\n",
+    "from sklearn.metrics import log_loss\n",
     "\n",
-    "auc = roc_auc_score(full_labels, pred_probs[:, 1])\n",
-    "print(f\"Cross-validated estimate of held-out AUC score: {auc}\")"
+    "loss = log_loss(full_labels, pred_probs)\n",
+    "# a lower log loss value means better predictions\n",
+    "print(f\"Cross-validated estimate of log loss: {loss:.3f}\")"
    ]
   },
   {
@@ -581,7 +584,7 @@
     "\n",
     "preds = model.predict(test_texts)\n",
     "acc_og = accuracy_score(test_labels, preds)\n",
-    "print(f\"\\n Test acuracy of original neural net: {acc_og}\")"
+    "print(f\"\\n Test accuracy of original neural net: {acc_og}\")"
    ]
   },
   {

--- a/docs/source/tutorials/text.ipynb
+++ b/docs/source/tutorials/text.ipynb
@@ -637,7 +637,7 @@
    "source": [
     "pred_labels = cl.predict(test_texts)\n",
     "acc_cl = accuracy_score(test_labels, pred_labels)\n",
-    "print(f\"Test acuracy of cleanlab's neural net: {acc_cl}\")"
+    "print(f\"Test accuracy of cleanlab's neural net: {acc_cl}\")"
    ]
   },
   {

--- a/docs/source/tutorials/text.ipynb
+++ b/docs/source/tutorials/text.ipynb
@@ -120,9 +120,22 @@
     "raw_full_ds = tfds.load(\n",
     "    name=\"imdb_reviews\", split=(\"train+test\"), batch_size=-1, as_supervised=True\n",
     ")\n",
-    "raw_full_texts, full_labels = tfds.as_numpy(raw_full_ds)\n",
-    "num_classes = len(set(full_labels))"
+    "raw_full_texts, full_labels = tfds.as_numpy(raw_full_ds)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "num_classes = len(set(full_labels))"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",

--- a/docs/source/tutorials/text.ipynb
+++ b/docs/source/tutorials/text.ipynb
@@ -277,7 +277,7 @@
     "\n",
     "    net.compile(\n",
     "        optimizer=\"adam\",\n",
-    "        loss=losses.SparseCategoricalCrossEntropy(),\n",
+    "        loss=losses.SparseCategoricalCrossentropy(),\n",
     "        metrics=metrics.CategoricalAccuracy(),\n",
     "    )\n",
     "    return net"


### PR DESCRIPTION
The current training model assumes that the dataset has binary labels. This PR tweaks the model setup to generalize to datasets where there are >2 classes. As part of this change, the ROC-AUC score has been replaced with Log Loss.