### PR TITLE
Make small fixes

### DIFF
--- a/docs/source/tutorials/indepth_overview.ipynb
+++ b/docs/source/tutorials/indepth_overview.ipynb
@@ -510,7 +510,7 @@
     "2. **Label Issues**: A ton of examples (which actually belong to the purple class) have been mislabeled as \"green\" in our dataset.\n",
     "\n",
     "### Now, let's see what happens if we merge classes \"seafoam green\" and \"yellow\"\n",
-    "* the top two classes found automatically by ``cleanlab.dataset.find_overlapping_classes()``"
+    "* The top two classes found automatically by ``cleanlab.dataset.find_overlapping_classes()``"
    ]
   },
   {
@@ -571,6 +571,7 @@
    },
    "source": [
     "If your test and training data were randomly split (IID), then be aware that your test labels are likely noisy too! It is thus important to fix label issues in them before we can trust measures like test accuracy.\n",
+    "\n",
     "* More about what can go wrong if you don't use a clean test set [in this paper](https://arxiv.org/abs/2103.14749)."
    ]
   },
@@ -680,8 +681,8 @@
     "\n",
     "- Using these modules directly is intended for more experienced cleanlab users. But once you understand how they work, you can create numerous powerful workflows.\n",
     "- For these workflows, you **always** need two things:\n",
-    "  1.  out-of-sample predicted probabilities (e.g. computed via cross-validation)\n",
-    "  2.  labels (can contain label errors and various issues)\n",
+    "  1.  Out-of-sample predicted probabilities (e.g. computed via cross-validation)\n",
+    "  2.  Labels (can contain label errors and various issues)\n",
     "\n",
     "#### cleanlab can compute out-of-sample  predicted probabilities for you:\n"
    ]
@@ -714,7 +715,7 @@
     "  - For all classes K, this is the distribution over the actual true labels (which cleanlab can estimate for you even though you don't have the true labels).\n",
     "- `noise_matrix: p(noisy|true)`\n",
     "  - This describes how errors were introduced into your labels. It's a conditional probability matrix with the probability of flipping from the true class to every other class for the given label.\n",
-    "- `inverse noise matrix: p(true|noisy)`\n",
+    "- `inverse_noise_matrix: p(true|noisy)`\n",
     "  - This tells you the probability, for every class, that the true label is actually a different class.\n",
     "- `confident_joint`\n",
     "  - This is an unnormalized (count-based) estimate of the number of examples in our dataset with each possible (true label, given label) pairing.\n",
@@ -786,9 +787,10 @@
     "### **Workflow 6.2 (filter):** Find label issues for any dataset and any model in one line of code\n",
     "\n",
     "Features of ``cleanlab.filter.find_label_issues``:\n",
+    "\n",
     "* Versatility -- Choose from several [state-of-the-art](https://arxiv.org/abs/1911.00068) label-issue detection algorithms using ``filter_by=``.\n",
     "* Works with any model by using predicted probabilities (no model needed).\n",
-    "* one line of code :)\n",
+    "* One line of code :)\n",
     "\n",
     "Remember ``CleanLearning.find_label_issues``? It uses this method internally."
    ]


### PR DESCRIPTION
Note: the docs system and Jupyter render Markdown cells slightly differently. E.g. this renders as a paragraph followed by a bulleted list in Jupyter, but in the rendered docs, it will render as a paragraph that contains the `* bulleted list` as part of the _text_ in the paragraph.

```
An example paragraph.
* bulleted list that doesn't have an empty newline before it
```