### PR TITLE
update anaconda upload instructions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,9 @@ Curtis G. Northcutt notes on how to perform pypi upload:
 5. python3 -m twine upload dist/*
 
 For conda upload (after pypi upload)
-1. cd ~; conda skeleton pypi cleanlab --noarch-python
+# if this fails, try conda update --force conda; conda update conda
+1. cd ~; conda skeleton pypi cleanlab --noarch-python --python-version 3.6
 2. conda-build cleanlab
 3. anaconda upload --user cleanlab LOCATION/cleanlab-x.x.x_0.tar.bz2  # location printed by previous command
+4. cd ~; rm -r cleanlab  # clean-up meta data created by anaconda for upload
 """


### PR DESCRIPTION
* necessary to add  `--python-version 3.6` to conda upload now that we no longer support 2.0
* add clean up step.