### PR TITLE
Updated project urls in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,12 @@ setup(
     long_description_content_type="text/markdown",
     description="The standard package for data-centric AI, machine learning with label errors, "
     "and automatically finding and fixing dataset issues in Python.",
-    url="https://github.com/cleanlab/cleanlab",
+    url="https://cleanlab.ai",
+    project_urls={
+        "Documentation": "https://docs.cleanlab.ai",
+        "Bug Tracker": "https://github.com/cleanlab/cleanlab/issues",
+        "Source Code": "https://github.com/cleanlab/cleanlab"
+    },
     author="Cleanlab, Inc.",
     author_email="team@cleanlab.ai",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
The PyPI page has a section for Project links, such as Homepage, Documentation, Source Code, and Bug Tracker. (See [pandas](https://pypi.org/project/pandas/) as an example.)

This PR updates `setup.py` to include said project links.