### PR TITLE
Allow users to pass custom weights for ensemble label quality scoring

### DIFF
--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -344,10 +344,6 @@ def get_label_quality_ensemble_scores(
             custom_weights is not None
         ), "custom_weights is None! Please pass a valid custom_weights."
 
-        assert len(custom_weights) == len(
-            pred_probs_list
-        ), "Size of custom_weights needs to match the first dimension of pred_probs_list."
-
         # Aggregate scores with custom weights
         label_quality_scores = (scores_ensemble * custom_weights).sum(axis=1)
 

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -262,6 +262,7 @@ def get_label_quality_ensemble_scores(
 
     custom_weights : np.array, default=None
       Weights used to aggregate scores from each model if weight_ensemble_members_by="custom".
+      Length of this array must match the number of models: len(pred_probs_list).
 
     verbose : bool, default=True
       Set to ``False`` to suppress all print statements.
@@ -291,10 +292,12 @@ def get_label_quality_ensemble_scores(
             """
         )
 
-    # Raise a warning if user passed custom_weights array but did not choose weight_ensemble_members_by="custom"
+    # Raise ValueError if user passed custom_weights array but did not choose weight_ensemble_members_by="custom"
     if custom_weights is not None and weight_ensemble_members_by != "custom":
-        warnings.warn(
-            f"Ignoring custom_weights because the chosen weighting scheme for ensemble is: {weight_ensemble_members_by}"
+        raise ValueError(
+            f"""
+            custom_weights provided but weight_ensemble_members_by is not "custom"!
+            """
         )
 
     # Generate scores for each model's pred_probs
@@ -343,6 +346,10 @@ def get_label_quality_ensemble_scores(
         assert (
             custom_weights is not None
         ), "custom_weights is None! Please pass a valid custom_weights."
+
+        assert len(custom_weights) == len(
+            pred_probs_list
+        ), "Length of custom_weights array must match the number of models: len(pred_probs_list)."
 
         # Aggregate scores with custom weights
         label_quality_scores = (scores_ensemble * custom_weights).sum(axis=1)

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -296,7 +296,25 @@ def test_custom_weights():
         assert (scores_custom_weights == scores_uniform_weights).all()
 
 
-def test_bad_custom_weights_error():
+def test_empty_custom_weights_error():
+
+    labels = data["labels"]
+    pred_probs = data["pred_probs"]
+
+    # baseline scenario where all the pred_probs are the same in the ensemble list
+    num_repeat = 3
+    pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
+
+    with pytest.raises(AssertionError) as e:
+        _ = rank.get_label_quality_ensemble_scores(
+            labels,
+            pred_probs_list,
+            weight_ensemble_members_by="custom",
+            custom_weights=None,  # this should raise AssertionError because custom_weights is None
+        )
+
+
+def test_wrong_length_custom_weights_error():
 
     labels = data["labels"]
     pred_probs = data["pred_probs"]
@@ -309,15 +327,6 @@ def test_bad_custom_weights_error():
     custom_weights = np.ones(num_repeat) / 3
 
     with pytest.raises(AssertionError) as e:
-
-        _ = rank.get_label_quality_ensemble_scores(
-            labels,
-            pred_probs_list,
-            weight_ensemble_members_by="custom",
-            custom_weights=None,  # this should raise AssertionError because custom_weights is None
-        )
-
-    with pytest.raises(AssertionError) as e:
         _ = rank.get_label_quality_ensemble_scores(
             labels,
             pred_probs_list,
@@ -326,6 +335,19 @@ def test_bad_custom_weights_error():
                 1:
             ],  # this should raise AssertionError because length of custom_weights don't match len(pred_probs_list)
         )
+
+
+def test_wrong_weight_ensemble_members_by_for_custom_weights_error():
+
+    labels = data["labels"]
+    pred_probs = data["pred_probs"]
+
+    # baseline scenario where all the pred_probs are the same in the ensemble list
+    num_repeat = 3
+    pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
+
+    # baseline scenario where custom_weights are uniform
+    custom_weights = np.ones(num_repeat) / 3
 
     with pytest.raises(ValueError) as e:
         _ = rank.get_label_quality_ensemble_scores(

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -268,6 +268,52 @@ def test_bad_weight_ensemble_members_by_parameter_error():
         )
 
 
+def test_custom_weights():
+    with pytest.raises(AssertionError) as e:
+
+        labels = data["labels"]
+        pred_probs = data["pred_probs"]
+
+        # baseline scenario where all the pred_probs are the same in the ensemble list
+        num_repeat = 3
+        pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
+
+        # baseline scenario where custom_weights are uniform
+        custom_weights = np.ones(num_repeat) / 3
+
+        scores_custom_weights = rank.get_label_quality_ensemble_scores(
+            labels,
+            pred_probs_list,
+            weight_ensemble_members_by="custom",
+            custom_weights=custom_weights,  # this should raise AssertionError
+        )
+
+        scores_uniform_weights = rank.get_label_quality_ensemble_scores(
+            labels, pred_probs_list, weight_ensemble_members_by="uniform"
+        )
+
+        # if custom_weights are uniform, then it should be the same as using weight_ensemble_members_by="uniform"
+        assert (scores_custom_weights == scores_uniform_weights).all()
+
+
+def test_bad_custom_weights_error():
+    with pytest.raises(AssertionError) as e:
+
+        labels = data["labels"]
+        pred_probs = data["pred_probs"]
+
+        # baseline scenario where all the pred_probs are the same in the ensemble list
+        num_repeat = 3
+        pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
+
+        _ = rank.get_label_quality_ensemble_scores(
+            labels,
+            pred_probs_list,
+            weight_ensemble_members_by="custom",
+            custom_weights=None,  # this should raise AssertionError
+        )
+
+
 def test_bad_pred_probs_list_parameter_error():
     with pytest.raises(AssertionError) as e:
 

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -297,20 +297,42 @@ def test_custom_weights():
 
 
 def test_bad_custom_weights_error():
+
+    labels = data["labels"]
+    pred_probs = data["pred_probs"]
+
+    # baseline scenario where all the pred_probs are the same in the ensemble list
+    num_repeat = 3
+    pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
+
+    # baseline scenario where custom_weights are uniform
+    custom_weights = np.ones(num_repeat) / 3
+
     with pytest.raises(AssertionError) as e:
-
-        labels = data["labels"]
-        pred_probs = data["pred_probs"]
-
-        # baseline scenario where all the pred_probs are the same in the ensemble list
-        num_repeat = 3
-        pred_probs_list = list(np.repeat([pred_probs], num_repeat, axis=0))
 
         _ = rank.get_label_quality_ensemble_scores(
             labels,
             pred_probs_list,
             weight_ensemble_members_by="custom",
-            custom_weights=None,  # this should raise AssertionError
+            custom_weights=None,  # this should raise AssertionError because custom_weights is None
+        )
+
+    with pytest.raises(AssertionError) as e:
+        _ = rank.get_label_quality_ensemble_scores(
+            labels,
+            pred_probs_list,
+            weight_ensemble_members_by="custom",
+            custom_weights=custom_weights[
+                1:
+            ],  # this should raise AssertionError because length of custom_weights don't match len(pred_probs_list)
+        )
+
+    with pytest.raises(ValueError) as e:
+        _ = rank.get_label_quality_ensemble_scores(
+            labels,
+            pred_probs_list,
+            weight_ensemble_members_by="accuracy",  # this should raise ValueError because custom_weights array is provided
+            custom_weights=custom_weights,
         )
 
 


### PR DESCRIPTION
The purpose of this PR is to allow users to use custom weights for aggregating scores in the `get_label_quality_ensemble_scores` method.

To use custom weights, the user will need to set `weight_ensemble_members_by="custom"` and pass a numpy array of weights into `custom_weights`.

This PR also adds tests for scenarios using `custom_weights`.