### PR TITLE
Fix link checking

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,3 +22,5 @@ jobs:
           directory: .
           check_favicon: false
           empty_alt_ignore: true
+          url_ignore_re: |
+            ^https:\/\/docs\.github\.com\/


### PR DESCRIPTION
For some reason, GitHub is returning a 403 to the GitHub actions runner when it tries to access these URLs. Maybe docs.github.com doesn't allow access from GitHub actions.