### PR TITLE
Set num classes based on num columns of pred_probs

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -145,7 +145,7 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False):
     """
     num_classes = confident_joint.shape[0]
     if multi_label:
-        label_counts = value_counts([x for lst in labels for x in lst])  # TODO:FIXME
+        label_counts = value_counts([x for lst in labels for x in lst])
     else:
         label_counts = value_counts(labels, num_classes)
     # Calibrate confident joint to have correct p(labels) prior on noisy labels.
@@ -268,7 +268,7 @@ def _compute_confident_joint_multi_label(
         sometimes works as well as filter.find_label_issues(confident_joint)."""
 
     # Compute unique number of classes K by flattening labels (list of lists)
-    K = len(np.unique([i for lst in labels for i in lst]))  # TODO:FIXME when num_classes specified
+    K = pred_probs.shape[1]
     # Compute thresholds = p(label=k | k in set of given labels)
     k_in_l = np.array([[k in lst for lst in labels] for k in range(K)])
     if thresholds is None:

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -175,10 +175,10 @@ def clip_values(x, low=0.0, high=1.0, new_sum=None):
     return x
 
 
-def value_counts(x):
+def value_counts(x, K=None):
     """Returns an np.array of shape (K, 1), with the
     value counts for every unique item in the labels list/array,
-    where K is the number of unique entries in labels.
+    where K is the number of unique entries in labels x (if None).
 
     Why this matters? Here is an example:
 
@@ -201,14 +201,28 @@ def value_counts(x):
     x : list or np.array (one dimensional)
         A list of discrete objects, like lists or strings, for
         example, class labels 'y' when training a classifier.
-        e.g. ["dog","dog","cat"] or [1,2,0,1,1,0,2]"""
-    try:
-        return x.value_counts()
-    except:
-        if type(x[0]) is int and (np.array(x) >= 0).all():
-            return np.bincount(x)
-        else:
-            return np.unique(x, return_counts=True)[1]
+        e.g. ["dog","dog","cat"] or [1,2,0,1,1,0,2].
+    K : int, optional
+        Specifies number of classes. If None, it is set as ``len(unique(x))``.
+    """
+    if K is None or K == len(np.unique(x)):
+        try:
+            return x.value_counts()
+        except:
+            if type(x[0]) is int and (np.array(x) >= 0).all():
+                return np.bincount(x)
+            else:
+                return np.unique(x, return_counts=True)[1]
+    else:  # not every class is present in x
+        try:
+            return x.value_counts().reindex(range(K), fill_value=0)
+        except:
+            if type(x[0]) is int and (np.array(x) >= 0).all():
+                return np.bincount(x, minlength=K)
+            else:
+                return np.concatenate(
+                    [np.unique(x, return_counts=True)[1], np.zeros(K - len(np.unique(x)))]
+                )
 
 
 def round_preserving_sum(iterable):

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -239,7 +239,16 @@ def test_compute_confident_joint():
     assert cj_extra.shape[1] == cj.shape[1] + 1
     assert np.all(cj == cj_extra[:-1, :-1])
 
-    try:  # mismatch between pred_probs and num_classes
+    # Missing class 0 in labels:
+    labels_miss = np.array([l if l > 0 else 1 for l in data["labels"]])
+    cj_miss = count.compute_confident_joint(
+        labels=labels_miss,
+        pred_probs=data["pred_probs"],
+    )
+    assert np.all(cj_miss[0,1:] == 0)
+    assert np.all(cj_miss[1:,0] == 0)
+
+    try:  # pred_probs with less columns than unique values in labels
         cj_fail = count.compute_confident_joint(
             labels=data["labels"],
             pred_probs=data["pred_probs"][:, :-1],

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -245,8 +245,8 @@ def test_compute_confident_joint():
         labels=labels_miss,
         pred_probs=data["pred_probs"],
     )
-    assert np.all(cj_miss[0,1:] == 0)
-    assert np.all(cj_miss[1:,0] == 0)
+    assert np.all(cj_miss[0, 1:] == 0)
+    assert np.all(cj_miss[1:, 0] == 0)
 
     try:  # pred_probs with less columns than unique values in labels
         cj_fail = count.compute_confident_joint(

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -229,6 +229,25 @@ def test_compute_confident_joint():
     # Check that confident joint is correct shape
     assert np.shape(cj) == (data["m"], data["m"])
 
+    # Add extra class which does not appear in labels:
+    pred_probs_extra = np.concatenate([data["pred_probs"], np.zeros((data["n"], 1))], axis=1)
+    cj_extra = count.compute_confident_joint(
+        labels=data["labels"],
+        pred_probs=pred_probs_extra,
+    )
+    assert cj_extra.shape[0] == cj.shape[0] + 1
+    assert cj_extra.shape[1] == cj.shape[1] + 1
+    assert np.all(cj == cj_extra[:-1, :-1])
+
+    try:  # mismatch between pred_probs and num_classes
+        cj_fail = count.compute_confident_joint(
+            labels=data["labels"],
+            pred_probs=data["pred_probs"][:, :-1],
+        )
+        assert False
+    except Exception as e:
+        assert "unique values" in str(e)
+
 
 def test_estimate_latent_py_method():
     for py_method in ["cnt", "eqn", "marginal"]:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -59,6 +59,15 @@ def test_value_counts_str():
     assert all(np.array([2, 1, 0]) - r2 < 1e-4)
 
 
+def test_value_counts_int():
+    x = [2, 2, 1, 0, 2]
+    r = util.value_counts(x)
+    assert all(np.array([1, 1, 2]) - r < 1e-4)
+    r2 = util.value_counts(x, 4)
+    assert all(np.array([1, 1, 2, 0]) - r2 < 1e-4)
+    assert all(np.array([1, 0, 2]) - util.value_counts([2, 2, 0], 3) < 1e-4)
+
+
 def test_pu_remove_noise():
     nm = np.array(
         [

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -52,8 +52,11 @@ def test_pu_f1():
 
 
 def test_value_counts_str():
-    r = util.value_counts(["a", "b", "a"])
+    x = ["a", "b", "a"]
+    r = util.value_counts(x)
     assert all(np.array([2, 1]) - r < 1e-4)
+    r2 = util.value_counts(x, 3)
+    assert all(np.array([2, 1, 0]) - r2 < 1e-4)
 
 
 def test_pu_remove_noise():


### PR DESCRIPTION
Instead of setting the number of classes based on `len(unique(labels))`. This addresses issue:  https://github.com/cleanlab/cleanlab/issues/85

Thanks @[vtsouval](https://github.com/vtsouval) for pointing out where some of the fixes had to be made and providing a helpful candidate implementation!
