### PR TITLE
Upgrade to latest version of coverage

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Python dependencies for development
-coverage<6.3
+coverage != 6.3, != 6.3.*
 pre-commit
 pytest
 pytest-cov


### PR DESCRIPTION
The issue with coverage==6.3 has been fixed: https://github.com/nedbat/coveragepy/issues/1310#issuecomment-1129894701.