### PR TITLE
Add Negative Log Loss Weighting Scheme for Ensemble Label Quality Score

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ cl.predict(test_data)
 cleanlab.dataset.health_summary(labels, confident_joint=cl.confident_joint)
 ```
 
-Get started with: [documentation](https://docs.cleanlab.ai/), [tutorials](https://docs.cleanlab.ai/v2.0.0/tutorials/image.html), [examples](https://github.com/cleanlab/examples), and [blogs](https://cleanlab.ai/blog/).
+Get started with: [documentation](https://docs.cleanlab.ai/), [tutorials](https://docs.cleanlab.ai/stable/tutorials/image.html), [examples](https://github.com/cleanlab/examples), and [blogs](https://cleanlab.ai/blog/).
 
-- Learn [how to run](https://docs.cleanlab.ai/v2.0.0/tutorials/index) cleanlab on your own data in just 5 minutes!
-- Quickstart with 5-minute tutorials for classification with: [image](https://docs.cleanlab.ai/v2.0.0/tutorials/image.html), [text](https://docs.cleanlab.ai/v2.0.0/tutorials/text.html), [audio](https://docs.cleanlab.ai/v2.0.0/tutorials/audio.html), and [tabular](https://docs.cleanlab.ai/v2.0.0/tutorials/tabular.html) data.
+ - [Learn how to](https://docs.cleanlab.ai/stable/tutorials/index) run cleanlab on your own data in just 5 minutes!
+ - Quickstart with 5-minute tutorials for classification with: [image](https://docs.cleanlab.ai/stable/tutorials/image.html), [text](https://docs.cleanlab.ai/stable/tutorials/text.html), [audio](https://docs.cleanlab.ai/stable/tutorials/audio.html), and [tabular](https://docs.cleanlab.ai/stable/tutorials/tabular.html) data.
+
 
 [![pypi](https://img.shields.io/pypi/v/cleanlab.svg)](https://pypi.org/pypi/cleanlab/)
 [![os](https://img.shields.io/badge/platform-noarch-lightgrey)](https://pypi.org/pypi/cleanlab/)
@@ -298,7 +299,7 @@ Many methods and their default parameters are not covered here. Check out the [d
 pred_probs (num_examples x num_classes matrix of predicted probabilities) should already be computed on your own, with any classifier. pred_probs must be obtained in a holdout/out-of-sample manner (e.g. via cross-validation).
 * cleanlab can do this for you via [`cleanlab.count.estimate_cv_predicted_probabilities`](https://docs.cleanlab.ai/master/cleanlab/count.html)]
 * Tutorial with more info: [[here](https://docs.cleanlab.ai/master/tutorials/pred_probs_cross_val.html)]
-* Examples how to compute pred_probs with: [[CNN image classifier (PyTorch)](https://docs.cleanlab.ai/v2.0.0/tutorials/image.html)], [[NN text classifier (TensorFlow)](https://docs.cleanlab.ai/v2.0.0/tutorials/text.html)]
+* Examples how to compute pred_probs with: [[CNN image classifier (PyTorch)](https://docs.cleanlab.ai/stable/tutorials/image.html)], [[NN text classifier (TensorFlow)](https://docs.cleanlab.ai/stable/tutorials/text.html)]
 
 ```python
 # label issues are ordered by likelihood of being an error. First index is most likely error.
@@ -496,6 +497,8 @@ cleanlab is based on peer-reviewed research. Here are the relevant papers to cit
 * Have code improvements for cleanlab? See the [development guide](DEVELOPMENT.md) and [submit a pull request](CONTRIBUTING.md).
 
 * Have an issue with cleanlab? [Search existing issues](https://github.com/cleanlab/cleanlab/issues?q=is%3Aissue) or [submit a new issue](https://github.com/cleanlab/cleanlab/issues/new).
+
+* Need professional help with cleanlab? Set up a 20-minute 1:1 session with one of our core developers, Jonas Mueller, via [Cal](https://cal.com/jonas-mueller-ndevin/20min).
 
 ## License
 

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -284,6 +284,8 @@ def get_label_quality_ensemble_scores(
 
     """
 
+    MIN_ALLOWED = 1e-6  # lower-bound clipping threshold to prevents 0 in logs and division
+
     # Check pred_probs_list for errors
     assert isinstance(
         pred_probs_list, list
@@ -321,7 +323,10 @@ def get_label_quality_ensemble_scores(
 
             # pred_probs for each model
             for pred_probs in pred_probs_list:
-                neg_log_loss = np.exp(t * (-log_loss(labels, pred_probs)))
+                pred_probs_clipped = np.clip(
+                    pred_probs, a_min=MIN_ALLOWED, a_max=None
+                )  # lower-bound clipping threshold to prevents 0 in logs when calculating log loss
+                neg_log_loss = np.exp(t * (-log_loss(labels, pred_probs_clipped)))
                 neg_log_loss_list.append(neg_log_loss)
 
             # weights using negative log loss

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -220,6 +220,7 @@ def get_label_quality_ensemble_scores(
     adjust_pred_probs: bool = False,
     weight_ensemble_members_by: str = "accuracy",
     custom_weights: np.array = None,
+    log_loss_search_T_values: List[float] = [1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 2e2],
     verbose: bool = True,
 ) -> np.array:
     """Returns label quality scores based on predictions from an ensemble of models.
@@ -266,6 +267,9 @@ def get_label_quality_ensemble_scores(
       Weights used to aggregate scores from each model if weight_ensemble_members_by="custom".
       Length of this array must match the number of models: len(pred_probs_list).
 
+    log_loss_search_T_values : List, default=[1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 2e2]
+      List of t values used if weight_ensemble_members_by="log_loss_search".
+
     verbose : bool, default=True
       Set to ``False`` to suppress all print statements.
 
@@ -305,14 +309,12 @@ def get_label_quality_ensemble_scores(
     # This weighting scheme performs search of T for "best" log loss
     if weight_ensemble_members_by == "log_loss_search":
 
-        T = [1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 2e2]  # make this a parameter in function
-
         pred_probs_avg_log_loss_weighted = None  # average pred_probs weighted by exp(t * -log_loss)
         neg_log_loss_weights = None  # weights using exp(t * -log_loss)
         best_eval_log_loss = float("inf")  # initial value
         best_t = None
 
-        for t in T:
+        for t in log_loss_search_T_values:
 
             neg_log_loss_list = []
 

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -310,7 +310,7 @@ def get_label_quality_ensemble_scores(
     # This weighting scheme performs search of t in log_loss_search_T_values for "best" log loss
     if weight_ensemble_members_by == "log_loss_search":
 
-        # Initialize
+        # Initialize variables for log loss search
         pred_probs_avg_log_loss_weighted = None
         neg_log_loss_weights = None
         best_eval_log_loss = float("inf")

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -260,7 +260,7 @@ def get_label_quality_ensemble_scores(
 
       - "uniform": take the simple average of scores
       - "accuracy": take weighted average of scores, weighted by model accuracy
-      - "log_loss_search": take weighted average of scores, weighted by negative log loss
+      - "log_loss_search": take weighted average of scores, weighted by exp(t * -log_loss) where t is selected from log_loss_search_T_values parameter.
       - "custom": take weighted average of scores using custom weights that the user passes to the custom_weights parameter.
 
     custom_weights : np.array, default=None
@@ -306,13 +306,12 @@ def get_label_quality_ensemble_scores(
             """
         )
 
-    # This weighting scheme performs search of T for "best" log loss
+    # This weighting scheme performs search of t in log_loss_search_T_values for "best" log loss
     if weight_ensemble_members_by == "log_loss_search":
 
         pred_probs_avg_log_loss_weighted = None  # average pred_probs weighted by exp(t * -log_loss)
         neg_log_loss_weights = None  # weights using exp(t * -log_loss)
         best_eval_log_loss = float("inf")  # initial value
-        best_t = None
 
         for t in log_loss_search_T_values:
 
@@ -337,7 +336,6 @@ def get_label_quality_ensemble_scores(
             # check if eval_log_loss is the best so far (lower the better)
             if best_eval_log_loss > eval_log_loss:
                 best_eval_log_loss = eval_log_loss
-                best_t = t
                 pred_probs_avg_log_loss_weighted = pred_probs_avg_log_loss_weighted_temp.copy()
                 neg_log_loss_weights = neg_log_loss_weights_temp.copy()
 

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -305,7 +305,7 @@ def get_label_quality_ensemble_scores(
     # This weighting scheme performs search of T for "best" log loss
     if weight_ensemble_members_by == "log_loss_search":
 
-        T = [1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 2e2]  # make this a parameter
+        T = [1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 2e2]  # make this a parameter in function
 
         pred_probs_avg_log_loss_weighted = None  # average pred_probs weighted by exp(t * -log_loss)
         neg_log_loss_weights = None  # weights using exp(t * -log_loss)

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -323,9 +323,12 @@ def get_label_quality_ensemble_scores(
 
             # pred_probs for each model
             for pred_probs in pred_probs_list:
+
                 pred_probs_clipped = np.clip(
                     pred_probs, a_min=MIN_ALLOWED, a_max=None
                 )  # lower-bound clipping threshold to prevents 0 in logs when calculating log loss
+                pred_probs_clipped /= pred_probs_clipped.sum(axis=1)[:, np.newaxis]  # renormalize
+
                 neg_log_loss = np.exp(t * (-log_loss(labels, pred_probs_clipped)))
                 neg_log_loss_list.append(neg_log_loss)
 
@@ -389,7 +392,9 @@ def get_label_quality_ensemble_scores(
     elif weight_ensemble_members_by == "log_loss_search":
         weights = neg_log_loss_weights  # Weight by exp(t * -log_loss) where t is found by searching set of T
         if verbose:
-            print("Ensemble members will be weighted by log-loss between their predicted probabilities and given labels")
+            print(
+                "Ensemble members will be weighted by log-loss between their predicted probabilities and given labels"
+            )
             for i, weight in enumerate(weights):
                 print(f"  Model {i} weight   : {weight}")
 

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -309,9 +309,10 @@ def get_label_quality_ensemble_scores(
     # This weighting scheme performs search of t in log_loss_search_T_values for "best" log loss
     if weight_ensemble_members_by == "log_loss_search":
 
-        pred_probs_avg_log_loss_weighted = None  # average pred_probs weighted by exp(t * -log_loss)
-        neg_log_loss_weights = None  # weights using exp(t * -log_loss)
-        best_eval_log_loss = float("inf")  # initial value
+        # Initialize
+        pred_probs_avg_log_loss_weighted = None
+        neg_log_loss_weights = None
+        best_eval_log_loss = float("inf")
 
         for t in log_loss_search_T_values:
 

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -258,10 +258,10 @@ def get_label_quality_ensemble_scores(
     weight_ensemble_members_by : {"uniform", "accuracy", "log_loss_search", "custom"}, default="accuracy"
       Weighting scheme used to aggregate scores from each model:
 
-      - "uniform": take the simple average of scores
-      - "accuracy": take weighted average of scores, weighted by model accuracy
-      - "log_loss_search": take weighted average of scores, weighted by exp(t * -log_loss) where t is selected from log_loss_search_T_values parameter and log_loss is the log-loss between a model's pred_probs and the given labels.
-      - "custom": take weighted average of scores using custom weights that the user passes to the custom_weights parameter.
+      - "uniform": Take the simple average of scores.
+      - "accuracy": Take weighted average of scores, weighted by model accuracy.
+      - "log_loss_search": Take weighted average of scores, weighted by exp(t * -log_loss) where t is selected from log_loss_search_T_values parameter and log_loss is the log-loss between a model's pred_probs and the given labels.
+      - "custom": Take weighted average of scores using custom weights that the user passes to the custom_weights parameter.
 
     custom_weights : np.array, default=None
       Weights used to aggregate scores from each model if weight_ensemble_members_by="custom".

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -390,7 +390,7 @@ def get_label_quality_ensemble_scores(
         label_quality_scores = (scores_ensemble * weights).sum(axis=1)
 
     elif weight_ensemble_members_by == "log_loss_search":
-        weights = neg_log_loss_weights  # Weight by exp(t * -log_loss) where t is found by searching set of T
+        weights = neg_log_loss_weights  # Weight by exp(t * -log_loss) where t is found by searching through log_loss_search_T_values
         if verbose:
             print(
                 "Ensemble members will be weighted by log-loss between their predicted probabilities and given labels"

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -215,7 +215,7 @@ def test__subtract_confident_thresholds():
     ],
 )
 @pytest.mark.parametrize("adjust_pred_probs", [False, True])
-@pytest.mark.parametrize("weight_ensemble_members_by", ["uniform", "accuracy"])
+@pytest.mark.parametrize("weight_ensemble_members_by", ["uniform", "accuracy", "log_loss_search"])
 def test_ensemble_scoring_func(method, adjust_pred_probs, weight_ensemble_members_by):
 
     labels = data["labels"]


### PR DESCRIPTION
This PR implements a weighting scheme for ensemble label quality scoring which was initially proposed by @jwmueller .

This weighting scheme is enabled by setting `weight_ensemble_members_by="log_loss_search"` and optionally allows the user to pass a list of hyper-parameter values into `log_loss_search_T_values` for the search procedure.

This weighting scheme weights the scores from each model based on `exp(t * -log_loss)` where `t` is a hyper-parameter and log_loss is the log_loss between the given label and the model's prediction.

For each `t` value in `log_loss_search_T_values`, we weight each model based on `exp(t * -log_loss)`. We then take the weighted average of predictions from all models using these weights and compute the log loss between the given label and this weighted average ensemble prediction. The `t` with the lowest log loss is selected.

This PR also adds this weighting scheme to the unit tests.
