### PR TITLE
Add KNN distance OOD scoring function and unit tests

### DIFF
--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -544,7 +544,9 @@ def get_confidence_weighted_entropy_for_each_label(
     return label_quality_scores
 
 
-def get_knn_distance_ood_scores(features: np.array, nbrs: NearestNeighbors, k: int) -> np.array:
+def get_knn_distance_ood_scores(
+    features: np.array, nbrs: NearestNeighbors, k: int = None
+) -> np.array:
     """Returns the KNN distance out-of-distribution (OOD) score for each datapoint.
 
     This is a function to compute OOD scores where higher scores indicate the datapoint is more likely to be OOD.
@@ -560,9 +562,10 @@ def get_knn_distance_ood_scores(features: np.array, nbrs: NearestNeighbors, k: i
       Note that the distance metric and n_neighbors is specified when instantiating this class.
       See: https://scikit-learn.org/stable/modules/neighbors.html
 
-    k : int
+    k : int, default=None
       Number of neighbors to use when calculating average distance to neighbors.
       This value k needs to be less than or equal to max_k which is the n_neighbors used when fitting instantiated NearestNeighbors class object.
+      If k=None, then by default k=min(10, max_k) is used where max_k is extracted from the given nbrs.
 
     Returns
     -------
@@ -572,6 +575,10 @@ def get_knn_distance_ood_scores(features: np.array, nbrs: NearestNeighbors, k: i
 
     # number of neighbors specified when fitting instantiated NearestNeighbors class object
     max_k = nbrs.n_neighbors
+
+    # if k is not provided, then use default
+    if k is None:
+        k = min(10, max_k)
 
     assert (
         k <= max_k

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -545,7 +545,7 @@ def get_confidence_weighted_entropy_for_each_label(
 
 
 def get_knn_distance_ood_scores(
-    query_features: np.array, nbrs: NearestNeighbors, k: int
+    features: np.array, nbrs: NearestNeighbors, k: int = 10
 ) -> np.array:
     """Returns the KNN distance out-of-distribution (OOD) score for each datapoint.
 
@@ -553,8 +553,8 @@ def get_knn_distance_ood_scores(
 
     Parameters
     ----------
-    query_features : np.array
-      Feature matrix of shape ``(N, ...)``, where N is the number of datapoints.
+    features : np.array
+      Feature matrix of shape (N, M), where N is the number of datapoints and M is the number of features.
       This is the "query set" of features for each datapoint which are used for nearest neighbor search.
 
     nbrs : sklearn.neighbors.NearestNeighbors
@@ -562,7 +562,7 @@ def get_knn_distance_ood_scores(
       Note that the distance metric and n_neighbors is specified when instantiating this class.
       See: https://scikit-learn.org/stable/modules/neighbors.html
 
-    k : int
+    k : int, default=10
       Number of neighbors to use when calculating average distance to neighbors.
       This value k needs to be less than or equal to max_k which is the n_neighbors used when fitting instantiated NearestNeighbors class object.
 
@@ -581,8 +581,8 @@ def get_knn_distance_ood_scores(
 
     # Get distances to k-nearest neighbors
     # Note that the nbrs object contains the specification of distance metric and n_neighbors (k value)
-    # If our query set (query_features) matches the training set used to fit nbrs, the nearest neighbor of each point is the point itself, at a distance of zero.
-    distances, _ = nbrs.kneighbors(query_features)
+    # If our query set of features matches the training set used to fit nbrs, the nearest neighbor of each point is the point itself, at a distance of zero.
+    distances, _ = nbrs.kneighbors(features)
 
     # Calculate average distance to k-nearest neighbors
     avg_nbrs_distances = distances[:, :k].mean(axis=1)

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -544,9 +544,7 @@ def get_confidence_weighted_entropy_for_each_label(
     return label_quality_scores
 
 
-def get_knn_distance_ood_scores(
-    features: np.array, nbrs: NearestNeighbors, k: int = 10
-) -> np.array:
+def get_knn_distance_ood_scores(features: np.array, nbrs: NearestNeighbors, k: int) -> np.array:
     """Returns the KNN distance out-of-distribution (OOD) score for each datapoint.
 
     This is a function to compute OOD scores where higher scores indicate the datapoint is more likely to be OOD.
@@ -562,7 +560,7 @@ def get_knn_distance_ood_scores(
       Note that the distance metric and n_neighbors is specified when instantiating this class.
       See: https://scikit-learn.org/stable/modules/neighbors.html
 
-    k : int, default=10
+    k : int
       Number of neighbors to use when calculating average distance to neighbors.
       This value k needs to be less than or equal to max_k which is the n_neighbors used when fitting instantiated NearestNeighbors class object.
 

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -415,6 +415,14 @@ def test_get_knn_distance_ood_scores():
     idx_max_score = np.argsort(knn_distance_ood_score)[-1]
     assert idx_max_score == (X_test_with_ood.shape[0] - 1)
 
+    # Get KNN distance as OOD score without passing k
+    # By default k=min(10, max_k) is used where max_k is extracted from the given nbrs
+    knn_distance_ood_score = rank.get_knn_distance_ood_scores(features=X_test_with_ood, nbrs=nbrs)
+
+    # Index of the datapoint with max ood score should correspond to the last element of X_test_with_ood
+    idx_max_score = np.argsort(knn_distance_ood_score)[-1]
+    assert idx_max_score == (X_test_with_ood.shape[0] - 1)
+
 
 def test_bad_k_for_get_knn_distance_ood_scores():
 

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -403,7 +403,7 @@ def test_get_knn_distance_ood_scores():
     X_test_with_ood = np.vstack([X_test, X_ood])
 
     # Fit nearest neighbors on X_train
-    nbrs = NearestNeighbors(n_neighbors=5, algorithm="ball_tree").fit(X_train)
+    nbrs = NearestNeighbors(n_neighbors=5).fit(X_train)
 
     # Get KNN distance as OOD score
     k = 5
@@ -428,7 +428,7 @@ def test_bad_k_for_get_knn_distance_ood_scores():
     X_test_with_ood = np.vstack([X_test, X_ood])
 
     # Fit nearest neighbors on X_train
-    nbrs = NearestNeighbors(n_neighbors=5, algorithm="ball_tree").fit(X_train)
+    nbrs = NearestNeighbors(n_neighbors=5).fit(X_train)
 
     with pytest.raises(AssertionError) as e:
         _ = rank.get_knn_distance_ood_scores(

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -21,6 +21,7 @@ from cleanlab.internal.label_quality_utils import _subtract_confident_thresholds
 from cleanlab.benchmarking.noise_generation import generate_noise_matrix_from_trace
 from cleanlab.benchmarking.noise_generation import generate_noisy_labels
 from cleanlab import count
+from sklearn.neighbors import NearestNeighbors
 
 
 def make_data(
@@ -388,3 +389,48 @@ def test_unsupported_method_for_adjust_pred_probs():
         method = "confidence_weighted_entropy"
 
         _ = rank.get_label_quality_scores(labels, pred_probs, adjust_pred_probs=True, method=method)
+
+
+def test_get_knn_distance_ood_scores():
+
+    X_train = data["X_train"]
+    X_test = data["X_test"]
+
+    # Create OOD datapoint
+    X_ood = np.array([[999999999.0, 999999999.0]])
+
+    # Add OOD datapoint to X_test
+    X_test_with_ood = np.vstack([X_test, X_ood])
+
+    # Fit nearest neighbors on X_train
+    nbrs = NearestNeighbors(n_neighbors=5, algorithm="ball_tree").fit(X_train)
+
+    # Get KNN distance as OOD score
+    k = 5
+    knn_distance_ood_score = rank.get_knn_distance_ood_scores(
+        query_features=X_test_with_ood, nbrs=nbrs, k=k
+    )
+
+    # Index of the datapoint with max ood score should correspond to the last element of X_test_with_ood
+    idx_max_score = np.argsort(knn_distance_ood_score)[-1]
+    assert idx_max_score == (X_test_with_ood.shape[0] - 1)
+
+
+def test_bad_k_for_get_knn_distance_ood_scores():
+
+    X_train = data["X_train"]
+    X_test = data["X_test"]
+
+    # Create OOD datapoint
+    X_ood = np.array([[999999999.0, 999999999.0]])
+
+    # Add OOD datapoint to X_test
+    X_test_with_ood = np.vstack([X_test, X_ood])
+
+    # Fit nearest neighbors on X_train
+    nbrs = NearestNeighbors(n_neighbors=5, algorithm="ball_tree").fit(X_train)
+
+    with pytest.raises(AssertionError) as e:
+        _ = rank.get_knn_distance_ood_scores(
+            query_features=X_test_with_ood, nbrs=nbrs, k=10  # this should throw an assertion error
+        )

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -408,7 +408,7 @@ def test_get_knn_distance_ood_scores():
     # Get KNN distance as OOD score
     k = 5
     knn_distance_ood_score = rank.get_knn_distance_ood_scores(
-        query_features=X_test_with_ood, nbrs=nbrs, k=k
+        features=X_test_with_ood, nbrs=nbrs, k=k
     )
 
     # Index of the datapoint with max ood score should correspond to the last element of X_test_with_ood
@@ -432,5 +432,5 @@ def test_bad_k_for_get_knn_distance_ood_scores():
 
     with pytest.raises(AssertionError) as e:
         _ = rank.get_knn_distance_ood_scores(
-            query_features=X_test_with_ood, nbrs=nbrs, k=10  # this should throw an assertion error
+            features=X_test_with_ood, nbrs=nbrs, k=10  # this should throw an assertion error
         )


### PR DESCRIPTION
This PR introduces an out-of-distribution (OOD) scoring function using KNN distances.

Example of workflow:

```python
from sklearn.neighbors import NearestNeighbors
from cleanlab.rank import get_knn_distance_ood_scores

# Fit nearest neighbors on feature matrix X_train
nbrs = NearestNeighbors(n_neighbors=10, metric="cosine").fit(X_train)

# Get OOD scores for feature matrix X_test
ood_scores = get_knn_distance_ood_scores(features=X_test, nbrs=nbrs, k=3) # k can be lower than n_neighbors
```

The OOD scoring function takes as input an instantiated sklearn NearestNeighbors class object `nbrs` that's been fitted on a dataset. However, it's important to note that we can extend this to other KNN implementations (e.g. Annoy) as long as the `nbrs` can return an array of nearest neighbor distances.

Example below of workflow using [Annoy](https://github.com/spotify/annoy):

```python
from annoy import AnnoyIndex

class ApproxNearestNeighbors:

    def __init__(self, n_neighbors: int = 5, metric: str = "angular", n_trees: int = 10):
        self.ann_index = None
        self.n_neighbors = n_neighbors
        self.metric = metric
        self.n_trees = n_trees
        
    def fit(self, features: np.array):
        dim = features.shape[1]
        self.ann_index = AnnoyIndex(dim, self.metric)
        for i, x in enumerate(features):
            self.ann_index.add_item(i, x)
        self.ann_index.build(self.n_trees)
        return self
    
    def kneighbors(self, features: np.array):
    
        distances = []
        indices = []
        for x in features:
            idx, dist = self.ann_index.get_nns_by_vector(x, self.n_neighbors, include_distances=True)    
            distances.append(dist)
            indices.append(idx)
        distances = np.array(distances)
        indices = np.array(indices)
        
        return distances, indices

nbrs = ApproxNearestNeighbors(n_neighbors=5, metric="angular").fit(X_train)
ood_scores = get_knn_distance_ood_scores(features=X_test, nbrs=nbrs, k=3)
```

This PR also includes 2 unit tests.