### PR TITLE
[WIP] Label quality scores for multi-annotator

### DIFF
--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -102,6 +102,13 @@ def rank_classes_by_label_quality(
     return df.sort_values(by="Label Quality Score", ascending=True).reset_index(drop=True)
 
 
+def _get_worst_class(labels, pred_probs):
+    ranked_noisy_classes = rank_classes_by_label_quality(labels, pred_probs).query(
+        "`Label Quality Score` < 1.0"
+    )
+    return ranked_noisy_classes["Class Index"][0] if len(ranked_noisy_classes) > 0 else np.nan
+
+
 def find_overlapping_classes(
     labels=None,
     pred_probs=None,

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -1,0 +1,208 @@
+import numpy as np
+from typing import List, Union, Tuple
+from cleanlab.rank import get_label_quality_scores
+from cleanlab.dataset import overall_label_health_score, _get_worst_class
+import pandas as pd
+
+
+def compute_multiannotator_stats(
+    labels_multiannotator, pred_probs, label_quality_scores_multiannotator
+):
+    # TODO: compute agreement_with_consensus
+    # Compute the overall label health score for each annotator
+    overall_label_health_score_df = labels_multiannotator.apply(
+        overall_label_health_score, args=[pred_probs], verbose=False
+    )
+
+    # Compute the number of labels labeled/annotated by each annotator
+    num_labeled = labels_multiannotator.count()
+
+    # Find the worst labeled class for each annotator
+    worst_class = labels_multiannotator.apply(_get_worst_class, args=[pred_probs])
+
+    #
+
+    # Create multi-annotator stats DataFrame from its columns
+    return pd.DataFrame(
+        {
+            "overall_quality": overall_label_health_score_df,
+            "num_labeled": num_labeled,
+            "worst_class": worst_class,
+        }
+    )
+
+
+def get_label_quality_scores_multiannotator(
+    labels_multiannotator: pd.DataFrame,
+    pred_probs: np.array,
+    *,
+    consensus_method: Union[str, List[str]] = "majority",
+    return_annotator_stats: bool = False,
+    verbose: bool = True,
+    kwargs: dict = {},
+) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
+    """Returns label quality scores for each example for each annotator.
+
+    This function is for multiclass classification datasets where examples have been labeled by
+    multiple annotators (not necessarily the same number of annotators per example).
+    It computes quality scores for each annotator's labels and other useful values like how
+    confident we are that the current consensus label is actually correct.
+
+    The score is between 0 and 1; lower scores
+    indicate labels less likely to be correct. For example:
+
+    1 - clean label (the given label is likely correct).
+    0 - dirty label (the given label is unlikely correct).
+
+    Parameters
+    ----------
+    labels_multiannotator : pd.DataFrame
+        2D pandas DataFrame of multiple given labels for each example with shape (N, M),
+        where N is the number of examples and M is the number of annotators.
+        labels_multiannotator[n][m] = given label for n-th example by m-th annotator.
+        For a dataset with K classes, the given labels must be an integer in 0, 1, ..., K-1 or
+        np.nan if this annotator did not label a particular example. Column names should correspond to the annotators' ID.
+
+    pred_probs : np.array
+        An array of shape ``(N, K)`` of model-predicted probabilities,
+        ``P(label=k|x)``. Each row of this matrix corresponds
+        to an example `x` and contains the model-predicted probabilities that
+        `x` belongs to each possible class, for each of the K classes. The
+        columns must be ordered such that these probabilities correspond to
+        class 0, 1, ..., K-1.
+
+        **Caution**: `pred_probs` from your model must be out-of-sample!
+        You should never provide predictions on the same examples used to train the model,
+        as these will be overfit and unsuitable for finding label-errors.
+        To obtain out-of-sample predicted probabilities for every datapoint in your dataset, you can use :ref:`cross-validation <pred_probs_cross_val>`.
+        Alternatively it is ok if your model was trained on a separate dataset and you are only evaluating
+        data that was previously held-out.
+
+    consensus_method : str or List[str]
+        For each example, which method should be used to aggregate labels from multiple annotators into a single consensus label.
+        Options include:
+
+        - ``"majority"``: means consensus labels are reached via a simple majority vote among annotators, with ties broken via ``pred_probs``.
+
+        A List may be passed if you want to consider multiple methods for producing consensus labels.
+        If a List is passed, then the 0th element of List is the method used to produce columns "consensus_label", "quality_of_consensus", "annotator_agreement" in the returned DataFrame.
+        The 1st, 2nd, 3rd, etc. elements of this List are output as extra columns in the returned ``pandas DataFrame`` with names formatted as:
+        consensus_label_SUFFIX, quality_of_consensus_SUFFIX
+        where SUFFIX = the str element of this list, which must correspond to a valid method for computing consensus labels.
+
+    return_annotator_stats : bool = False
+        TODO
+
+    verbose : bool = True
+        If ``verbose`` is set to ``True``, the full ``annotator_stats`` DataFrame is printed out during the execution of this function.
+
+    kwargs : dict
+        Keyword arguments to pass into ``get_label_quality_scores()``.
+
+    Returns
+    -------
+    label_quality_score_multiannotator : pandas.DataFrame
+
+        pandas DataFrame in which each row corresponds to one example, with columns:
+
+        - ``quality_of_annotator_1``, ``quality_of_annotator_2``, ..., ``quality_of_annotator_M``: the label quality score for the labels provided by annotator M (is ``NaN`` for examples which this annotator did not label).
+        - ``annotator_disagreement``: the fraction of annotators that agree with the label chosen by the majority of the annotators (only considering those annotators that labeled a particular example).
+        - ``num_annotations``: the number of annotators that have labeled each example.
+        - ``consensus_labels``: the single label that is best for each example (you can control how it is derived from all annotators' labels via the argument: ``consensus_method``)
+        - ``quality_of_consensus``: cleanlab's label quality score that quantifies how likely the consensus_label is correct.
+
+        Here annotator_1, annotator_2, ..., annotator_M suffixes may be replaced column names in ``labels_multiannotator`` DataFrame used to ID the annotators.
+
+    annotator_stats : pandas.DataFrame
+        TODO
+    """
+
+    consensus_methods = ["majority"]
+
+    # Raise error if consensus_method is a not valid method
+    if not consensus_method in consensus_methods:
+        raise ValueError(
+            f"""
+                {consensus_method} is not a valid consensus method!
+                Please choose a valid consensus_method: {consensus_methods}
+            """
+        )
+
+    # Raise error if labels_multiannotator has np.NaN rows
+    if labels_multiannotator.isna().all(axis=1).any():
+        raise ValueError(
+            f"""
+                labels_multiannotator cannot have rows with all np.NaN.
+            """
+        )
+
+    # Raise error if labels_multiannotator has <= 1 column
+
+    # Raise error if labels_multiannotator only has 1 set of labels
+
+    # Raise warning if no examples with 2 or more annotators agree
+
+    # Count number of non-NaN values for each example
+    num_annotations = labels_multiannotator.count(axis=1)
+
+    # Compute the label quality scores for each annotators' labels
+    label_quality_scores_multiannotator = labels_multiannotator.apply(
+        get_label_quality_scores, args=[pred_probs], **kwargs
+    )
+
+    # Prefix column name referring to the annotators' label quality scores
+    label_quality_scores_multiannotator = label_quality_scores_multiannotator.add_prefix(
+        "quality_of_"
+    )
+
+    # Compute the consensus_labels
+    # TODO: conditional based on consensus_method, consensus_method can be a List[str], add dawid-skene
+    mode_labels_multiannotator = labels_multiannotator.mode(axis=1)
+    consensus_labels = []
+    for i in range(len(mode_labels_multiannotator)):
+        consensus_labels.append(
+            int(
+                mode_labels_multiannotator.iloc[i][
+                    pred_probs[i][
+                        mode_labels_multiannotator.iloc[i].dropna().astype(int).to_numpy()
+                    ].argmax()
+                ]
+            )
+        )
+
+    # Compute the fraction of annotator disagreeing with the consensus labels
+    # annotator_disagreement = labels_multiannotator.assign(consensus_labels=consensus_labels).apply(
+    #     lambda s: 1.0 - s[:-1].value_counts(normalize=True)[s["consensus_labels"]],
+    #     axis=1,
+    # )
+
+    annotator_disagreement = labels_multiannotator.assign(consensus_labels=consensus_labels).apply(
+        lambda s: np.mean(s != s["consensus_labels"]),
+        axis=1,
+    )
+
+    # Compute the label quality scores of the consensus labels
+    lqs_of_consensus = get_label_quality_scores(consensus_labels, pred_probs, **kwargs)
+    frac = pred_probs[range(len(consensus_labels)), (consensus_labels)] / num_annotations
+    quality_of_consensus = frac * lqs_of_consensus + (1 - frac) * (1 - annotator_disagreement)
+
+    # Concatenate additional columns to the label_quality_scores_multiannotator DataFrame
+    (
+        label_quality_scores_multiannotator["consensus_label"],
+        label_quality_scores_multiannotator["annotator_disagreement"],
+        label_quality_scores_multiannotator["quality_of_consensus"],
+    ) = (consensus_labels, annotator_disagreement, quality_of_consensus)
+
+    annotator_stats = compute_multiannotator_stats(labels_multiannotator, pred_probs)
+
+    if verbose:
+        print(
+            "Here are various overall statistics about the annotators (column names are defined in documentation):"
+        )
+        print(annotator_stats.to_string())
+
+    return (
+        (label_quality_scores_multiannotator, annotator_stats)
+        if return_annotator_stats
+        else label_quality_scores_multiannotator
+    )

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -33,14 +33,12 @@ labels in data that was previously held-out.
 
 
 import numpy as np
-from typing import List, Union, Tuple
+from typing import List
 import warnings
 from cleanlab.internal.label_quality_utils import (
     _subtract_confident_thresholds,
     get_normalized_entropy,
 )
-from cleanlab.dataset import overall_label_health_score, rank_classes_by_label_quality
-import pandas as pd
 from sklearn.metrics import log_loss
 from sklearn.neighbors import NearestNeighbors
 
@@ -427,133 +425,6 @@ def get_label_quality_ensemble_scores(
         )
 
     return label_quality_scores
-
-
-def get_worst_class(labels, pred_probs):
-    ranked_noisy_classes = rank_classes_by_label_quality(labels, pred_probs).query(
-        "`Label Quality Score` < 1.0"
-    )
-    return ranked_noisy_classes["Class Index"][0] if len(ranked_noisy_classes) > 0 else np.nan
-
-
-def get_label_quality_scores_multiannotator(
-    labels_multiannotator: pd.DataFrame,
-    pred_probs: np.array,
-    *,
-    consensus_method: Union[str, List[str]] = "majority",
-    return_annotator_stats: bool = False,
-    kwargs: dict = {},
-) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
-    """Returns label quality scores for each example for each annotator.
-
-    This function computes the label quality scores for each example
-    for each annotator in a given classification dataset.
-
-    The score is between 0 and 1; lower scores
-    indicate labels less likely to be correct. For example:
-
-    1 - clean label (the given label is likely correct).
-    0 - dirty label (the given label is unlikely correct).
-
-    Parameters
-    ----------
-    labels_multiannotator : pd.DataFrame
-        2D pandas DataFrame of multiple given labels for each example with shape (N, M),
-        where N is the number of examples and M is the number of annotators.
-        labels_multiannotator[n][m] = given label for n-th example by m-th annotator.
-        For a dataset with K classes, the given labels must be an integer in 0, 1, ..., K-1 or
-        np.nan if not annotated. Column names should correspond to the annotators' ID.
-
-    pred_probs : np.array
-        An array of shape ``(N, K)`` of model-predicted probabilities,
-        ``P(label=k|x)``. Each row of this matrix corresponds
-        to an example `x` and contains the model-predicted probabilities that
-        `x` belongs to each possible class, for each of the K classes. The
-        columns must be ordered such that these probabilities correspond to
-        class 0, 1, ..., K-1.
-
-        **Caution**: `pred_probs` from your model must be out-of-sample!
-        You should never provide predictions on the same examples used to train the model,
-        as these will be overfit and unsuitable for finding label-errors.
-        To obtain out-of-sample predicted probabilities for every datapoint in your dataset, you can use :ref:`cross-validation <pred_probs_cross_val>`.
-        Alternatively it is ok if your model was trained on a separate dataset and you are only evaluating
-        data that was previously held-out.
-
-    consensus_method : str or List[str]
-        Describing which algorithm to reach the consensus label.
-        If a List is passed, then the 0th element of List is the method used to produce
-        consensus_label, quality_of_consensus, annotator_agreement (may or may not be affected by this argument).
-        The 1st, 2nd, 3rd, etc. elements of this List are output as extra columns in the returned DF with names formatted as:
-        consensus_label_SUFFIX, quality_of_consensus_SUFFIX
-        where SUFFIX = the str element of this list.
-
-    kwargs : Same additional arguments as for get_label_quality_scores().
-
-    Returns
-    -------
-    df : pandas DataFrame in which each row corresponds to one example, with columns:
-                quality_annotator_1, quality_annotator_2, ..., quality_annotator_M, annotator_agreement, consensus_label, quality_of_consensus
-            (Here _1, _2, ..., _M suffixes may be replaced column names used to describe annotators in `labels` input)
-    """
-
-    # Compute the overall label health score for each annotator (part of annotator_stats)
-    overall_label_health_score_df = labels_multiannotator.apply(
-        overall_label_health_score, args=[pred_probs], verbose=False
-    )
-
-    # Compute the number of labels labeled/annotated by each annotator (part of annotator_stats)
-    num_labeled = labels_multiannotator.count()
-
-    # Find the worst labeled class for each annotator (part of annotator_stats)
-    worst_class = labels_multiannotator.apply(get_worst_class, args=[pred_probs])
-
-    # Create annotator_stats DataFrame from its columns
-    annotator_stats = pd.DataFrame(
-        {
-            "overall_quality": overall_label_health_score_df,
-            "num_labeled": num_labeled,
-            "worst_class": worst_class,
-        }
-    )
-
-    # Compute the label quality scores for each annotators' labels
-    label_quality_scores_multiannotator = labels_multiannotator.apply(
-        get_label_quality_scores, args=[pred_probs], **kwargs
-    )
-
-    # Prefix column name referring to the annotators' label quality scores
-    label_quality_scores_multiannotator = label_quality_scores_multiannotator.add_prefix(
-        "quality_of_"
-    )
-
-    # Compute the consensus_labels
-    # TODO: deal with ties, conditional based on consensus_method, consensus_method can be a List[str], add dawid-skene
-    consensus_labels = labels_multiannotator.mode(axis=1)
-
-    # Compute the fraction of annotator disagreeing with the consensus labels
-    # i.e. 1 - fraction of annotator agreeing with the consensus labels
-    annotator_disagreement = labels_multiannotator.assign(consensus_label=consensus_labels).apply(
-        lambda s: 1.0 - s[:-1].value_counts(normalize=True)[s["consensus_label"]],
-        axis=1,
-    )
-
-    # Compute the label quality scores of the consensus labels
-    quality_of_consensus = get_label_quality_scores(
-        consensus_labels.to_numpy(), pred_probs, **kwargs
-    )
-
-    # Concatenate additional columns to the label_quality_scores_multiannotator DataFrame
-    (
-        label_quality_scores_multiannotator["consensus_label"],
-        label_quality_scores_multiannotator["annotator_disagreement"],
-        label_quality_scores_multiannotator["quality_of_consensus"],
-    ) = (consensus_labels, annotator_disagreement, quality_of_consensus)
-
-    return (
-        (label_quality_scores_multiannotator, annotator_stats)
-        if return_annotator_stats
-        else label_quality_scores_multiannotator
-    )
 
 
 def get_self_confidence_for_each_label(

--- a/tests/test_multiannotator.py
+++ b/tests/test_multiannotator.py
@@ -1,0 +1,107 @@
+import numpy as np
+import pytest
+from cleanlab import rank
+from cleanlab.internal.label_quality_utils import _subtract_confident_thresholds
+from cleanlab.benchmarking.noise_generation import generate_noise_matrix_from_trace
+from cleanlab.benchmarking.noise_generation import generate_noisy_labels
+from cleanlab import count
+import pandas as pd
+
+
+def make_data(
+    means=[[3, 2], [7, 7], [0, 8]],
+    covs=[[[5, -1.5], [-1.5, 1]], [[1, 0.5], [0.5, 4]], [[5, 1], [1, 5]]],
+    sizes=[80, 40, 40],
+    avg_trace=0.8,
+    seed=1,  # set to None for non-reproducible randomness
+):
+    np.random.seed(seed=seed)
+
+    m = len(means)  # number of classes
+    n = sum(sizes)
+    local_data = []
+    labels = []
+    test_data = []
+    test_labels = []
+
+    for idx in range(m):
+        local_data.append(
+            np.random.multivariate_normal(mean=means[idx], cov=covs[idx], size=sizes[idx])
+        )
+        test_data.append(
+            np.random.multivariate_normal(mean=means[idx], cov=covs[idx], size=sizes[idx])
+        )
+        labels.append(np.array([idx for i in range(sizes[idx])]))
+        test_labels.append(np.array([idx for i in range(sizes[idx])]))
+    X_train = np.vstack(local_data)
+    true_labels_train = np.hstack(labels)
+    X_test = np.vstack(test_data)
+    true_labels_test = np.hstack(test_labels)
+
+    # Compute p(true_label=k)
+    py = np.bincount(true_labels_train) / float(len(true_labels_train))
+
+    noise_matrix = generate_noise_matrix_from_trace(
+        m,
+        trace=avg_trace * m,
+        py=py,
+        valid_noise_matrix=True,
+        seed=seed,
+    )
+
+    # Generate our noisy labels using the noise_matrix.
+    s = generate_noisy_labels(true_labels_train, noise_matrix)
+    ps = np.bincount(s) / float(len(s))
+
+    # Compute inverse noise matrix
+    inv = count.compute_inv_noise_matrix(py, noise_matrix, ps=ps)
+
+    # Estimate pred_probs
+    latent = count.estimate_py_noise_matrices_and_cv_pred_proba(
+        X=X_train,
+        labels=s,
+        cv_n_folds=3,
+    )
+
+    label_errors_mask = s != true_labels_train
+
+    return {
+        "X_train": X_train,
+        "true_labels_train": true_labels_train,
+        "X_test": X_test,
+        "true_labels_test": true_labels_test,
+        "labels": s,
+        "label_errors_mask": label_errors_mask,
+        "ps": ps,
+        "py": py,
+        "noise_matrix": noise_matrix,
+        "inverse_noise_matrix": inv,
+        "est_py": latent[0],
+        "est_nm": latent[1],
+        "est_inv": latent[2],
+        "cj": latent[3],
+        "pred_probs": latent[4],
+        "m": m,
+        "n": n,
+    }
+
+
+# Global to be used by all test methods. Only compute this once for speed.
+data = make_data()
+
+
+def test_get_worst_class():
+
+    labels = data["labels"]
+    pred_probs = data["pred_probs"]
+
+    # Assert that the worst class index should be the class with the highest noise
+    assert rank.get_worst_class(labels, pred_probs) == data["noise_matrix"].diagonal().argmax()
+
+
+def test_label_quality_scores_multiannotator():
+
+    labels = data["labels"]
+    pred_probs = data["pred_probs"]
+
+    rank.get_label_quality_scores_multiannotator()


### PR DESCRIPTION
This PR is still a WIP. This PR adds multi-annotator support for computing the label quality scores via the `label_quality_scores_multiannotator` function. 

TODO:
- [ ] Complete TODO for the `consensus_method` arg
- [ ] Write docstrings
- [ ] Add tests