### PR TITLE
Clarify labels format

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Get started with: [documentation](https://docs.cleanlab.ai/), [tutorials](https:
 <ul>
 <li> <b>Dec 2021 🎉</b>  NeurIPS published the <a href="https://arxiv.org/abs/2103.14749">label errors paper (Northcutt, Athalye, & Mueller, 2021)</a>.</li>
 <li> <b>Apr 2021 🎉</b>  Journal of AI Research published the <a href="https://jair.org/index.php/jair/article/view/12125">confident learning paper (Northcutt, Jiang, & Chuang, 2021)</a>.</li>
-<li> <b>Mar 2021 😲</b>  cleanlab used to find and fix label issues in 10 of the most common ML benchmark datasets, published in: <a href="https://datasets-benchmarks-proceedings.neurips.cc/paper/2021/hash/f2217062e9a397a1dca429e7d70bc6ca-Abstract-round1.html">NeurIPS 2021</a>. Along with <a href="https://arxiv.org/abs/2103.14749">the paper (Northcutt, Athalye, & Mueller, 2021)</a>, the authors launched <a href="https://labelerrors.com">labelerrors.com</a> where you can view the label issues in these datasets.</li>
+<li> <b>Mar 2021 😲</b>  cleanlab used to find and fix label issues in 10 of the most common ML benchmark datasets, published in: <a href="https://neurips.cc/Conferences/2021/ScheduleMultitrack?event=22763">NeurIPS 2021</a>. Along with <a href="https://arxiv.org/abs/2103.14749">the paper (Northcutt, Athalye, & Mueller, 2021)</a>, the authors launched <a href="https://labelerrors.com">labelerrors.com</a> where you can view the label issues in these datasets.</li>
 </ul>
 </p>
 </details>

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -126,6 +126,9 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False):
     labels : np.array
       A discrete vector of noisy labels, i.e. some labels may be erroneous.
       *Format requirements*: for dataset with K classes, labels must be in 0, 1, ..., K-1.
+      All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
+      len(set(labels)) == pred_probs.shape[1] for single-labeled labels, e.g. [1,0,2,1,1,0...]
+      len(set(k for l in labels for k in l)) == pred_probs.shape[1] for multi_label, e.g. [[1,2],[1],[0],..]
 
     multi_label : bool, optional
       If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
@@ -169,6 +172,9 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
     labels : np.array
       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
+      All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
+      len(set(labels)) == pred_probs.shape[1] for single-labeled labels, e.g. [1,0,2,1,1,0...]
+      len(set(k for l in labels for k in l)) == pred_probs.shape[1] for multi_label, e.g. [[1,2],[1],[0],..]
 
     pred_probs : np.array
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -127,8 +127,9 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False):
       A discrete vector of noisy labels, i.e. some labels may be erroneous.
       *Format requirements*: for dataset with K classes, labels must be in 0, 1, ..., K-1.
       All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
-      ``len(set(labels)) == pred_probs.shape[1]`` for single-labeled labels, e.g. [1,0,2,1,1,0...]
-      ``len(set(k for l in labels for k in l)) == pred_probs.shape[1]`` for multi_label, e.g. [[1,2],[1],[0],..]
+      ``len(set(labels)) == pred_probs.shape[1]`` for standard multi-class classification with single-labeled data (e.g. ``labels =  [1,0,2,1,1,0...]``).
+      For multi-label classification where each example can belong to multiple classes(e.g. ``labels = [[1,2],[1],[0],..]``),
+      your labels should instead satisfy: ``len(set(k for l in labels for k in l)) == pred_probs.shape[1])``.
 
     multi_label : bool, optional
       If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
@@ -173,8 +174,9 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
       All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
-      ``len(set(labels)) == pred_probs.shape[1]`` for single-labeled labels, e.g. [1,0,2,1,1,0...]
-      ``len(set(k for l in labels for k in l)) == pred_probs.shape[1]`` for multi_label, e.g. [[1,2],[1],[0],..]
+      ``len(set(labels)) == pred_probs.shape[1]`` for standard multi-class classification with single-labeled data (e.g. ``labels =  [1,0,2,1,1,0...]``).
+      For multi-label classification where each example can belong to multiple classes(e.g. ``labels = [[1,2],[1],[0],..]``),
+      your labels should instead satisfy: ``len(set(k for l in labels for k in l)) == pred_probs.shape[1])``.
 
     pred_probs : np.array
       An array of shape ``(N, K)`` of model-predicted probabilities,
@@ -1103,7 +1105,9 @@ def get_confident_thresholds(
       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
       All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
-      len(set(k for l in labels for k in l)) == pred_probs.shape[1]
+      ``len(set(labels)) == pred_probs.shape[1]`` for standard multi-class classification with single-labeled data (e.g. ``labels =  [1,0,2,1,1,0...]``).
+      For multi-label classification where each example can belong to multiple classes(e.g. ``labels = [[1,2],[1],[0],..]``),
+      your labels should instead satisfy: ``len(set(k for l in labels for k in l)) == pred_probs.shape[1])``.
 
     pred_probs : np.array
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -336,6 +336,9 @@ def compute_confident_joint(
     labels : np.array
       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
+      ``len(set(labels)) == pred_probs.shape[1]`` for standard multi-class classification with single-labeled data (e.g. ``labels =  [1,0,2,1,1,0...]``).
+      For multi-label classification where each example can belong to multiple classes(e.g. ``labels = [[1,2],[1],[0],..]``),
+      your labels should instead satisfy: ``len(set(k for l in labels for k in l)) == pred_probs.shape[1])``.
 
     pred_probs : np.array, optional
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -127,8 +127,8 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False):
       A discrete vector of noisy labels, i.e. some labels may be erroneous.
       *Format requirements*: for dataset with K classes, labels must be in 0, 1, ..., K-1.
       All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
-      len(set(labels)) == pred_probs.shape[1] for single-labeled labels, e.g. [1,0,2,1,1,0...]
-      len(set(k for l in labels for k in l)) == pred_probs.shape[1] for multi_label, e.g. [[1,2],[1],[0],..]
+      ``len(set(labels)) == pred_probs.shape[1]`` for single-labeled labels, e.g. [1,0,2,1,1,0...]
+      ``len(set(k for l in labels for k in l)) == pred_probs.shape[1]`` for multi_label, e.g. [[1,2],[1],[0],..]
 
     multi_label : bool, optional
       If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
@@ -173,8 +173,8 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
       All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
-      len(set(labels)) == pred_probs.shape[1] for single-labeled labels, e.g. [1,0,2,1,1,0...]
-      len(set(k for l in labels for k in l)) == pred_probs.shape[1] for multi_label, e.g. [[1,2],[1],[0],..]
+      ``len(set(labels)) == pred_probs.shape[1]`` for single-labeled labels, e.g. [1,0,2,1,1,0...]
+      ``len(set(k for l in labels for k in l)) == pred_probs.shape[1]`` for multi_label, e.g. [[1,2],[1],[0],..]
 
     pred_probs : np.array
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -154,6 +154,9 @@ def find_overlapping_classes(
     labels : np.array, optional
       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
+      All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
+      len(set(labels)) == pred_probs.shape[1] for single-labeled labels, e.g. [1,0,2,1,1,0...]
+      len(set(k for l in labels for k in l)) == pred_probs.shape[1] for multi_label, e.g. [[1,2],[1],[0],..]
 
     pred_probs : np.array, optional
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -154,9 +154,10 @@ def find_overlapping_classes(
     labels : np.array, optional
       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
-      All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
-      ``len(set(labels)) == pred_probs.shape[1]`` for single-labeled labels, e.g. [1,0,2,1,1,0...]
-      ``len(set(k for l in labels for k in l)) == pred_probs.shape[1]`` for multi_label, e.g. [[1,2],[1],[0],..]
+      All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that
+      ``len(set(labels)) == pred_probs.shape[1]`` for standard multi-class classification with single-labeled data (e.g. ``labels =  [1,0,2,1,1,0...]``).
+      For multi-label classification where each example can belong to multiple classes(e.g. ``labels = [[1,2],[1],[0],..]``),
+      your labels should instead satisfy: ``len(set(k for l in labels for k in l)) == pred_probs.shape[1])``.
 
     pred_probs : np.array, optional
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -155,8 +155,8 @@ def find_overlapping_classes(
       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
       All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
-      len(set(labels)) == pred_probs.shape[1] for single-labeled labels, e.g. [1,0,2,1,1,0...]
-      len(set(k for l in labels for k in l)) == pred_probs.shape[1] for multi_label, e.g. [[1,2],[1],[0],..]
+      ``len(set(labels)) == pred_probs.shape[1]`` for single-labeled labels, e.g. [1,0,2,1,1,0...]
+      ``len(set(k for l in labels for k in l)) == pred_probs.shape[1]`` for multi_label, e.g. [[1,2],[1],[0],..]
 
     pred_probs : np.array, optional
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -303,8 +303,9 @@ def find_label_issues(
       A discrete vector of noisy labels, i.e. some labels may be erroneous.
       *Format requirements*: for dataset with K classes, labels must be in 0, 1, ..., K-1.
       All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
-      ``len(set(labels)) == pred_probs.shape[1]`` for single-labeled labels, e.g. [1,0,2,1,1,0...]
-      ``len(set(k for l in labels for k in l)) == pred_probs.shape[1]`` for multi_label, e.g. [[1,2],[1],[0],..]
+      ``len(set(labels)) == pred_probs.shape[1]`` for standard multi-class classification with single-labeled data (e.g. ``labels =  [1,0,2,1,1,0...]``).
+      For multi-label classification where each example can belong to multiple classes(e.g. ``labels = [[1,2],[1],[0],..]``),
+      your labels should instead satisfy: ``len(set(k for l in labels for k in l)) == pred_probs.shape[1])``.
 
     pred_probs : np.array, optional
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -303,8 +303,8 @@ def find_label_issues(
       A discrete vector of noisy labels, i.e. some labels may be erroneous.
       *Format requirements*: for dataset with K classes, labels must be in 0, 1, ..., K-1.
       All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
-      len(set(labels)) == pred_probs.shape[1] for single-labeled labels, e.g. [1,0,2,1,1,0...]
-      len(set(k for l in labels for k in l)) == pred_probs.shape[1] for multi_label, e.g. [[1,2],[1],[0],..]
+      ``len(set(labels)) == pred_probs.shape[1]`` for single-labeled labels, e.g. [1,0,2,1,1,0...]
+      ``len(set(k for l in labels for k in l)) == pred_probs.shape[1]`` for multi_label, e.g. [[1,2],[1],[0],..]
 
     pred_probs : np.array, optional
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -302,6 +302,9 @@ def find_label_issues(
     labels : np.array
       A discrete vector of noisy labels, i.e. some labels may be erroneous.
       *Format requirements*: for dataset with K classes, labels must be in 0, 1, ..., K-1.
+      All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
+      len(set(labels)) == pred_probs.shape[1] for single-labeled labels, e.g. [1,0,2,1,1,0...]
+      len(set(k for l in labels for k in l)) == pred_probs.shape[1] for multi_label, e.g. [[1,2],[1],[0],..]
 
     pred_probs : np.array, optional
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -124,7 +124,7 @@ def get_label_quality_scores(
       A discrete vector of noisy labels, i.e. some labels may be erroneous.
       *Format requirements*: for dataset with K classes, labels must be in 0, 1, ..., K-1.
       All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that: ``len(set(labels)) == pred_probs.shape[1]``
-      Assumes single-labeled labels, e.g. format: ``np.array([1,0,2,1,1,0...])``
+      Note: multi-label classification is not supported by this method, each example must belong to a single class, e.g. format: ``labels = np.array([1,0,2,1,1,0...])``.
 
     pred_probs : np.array, optional
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -123,6 +123,8 @@ def get_label_quality_scores(
     labels : np.array
       A discrete vector of noisy labels, i.e. some labels may be erroneous.
       *Format requirements*: for dataset with K classes, labels must be in 0, 1, ..., K-1.
+      All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that: len(set(labels)) == pred_probs.shape[1]
+      Assumes single-labeled labels, e.g. format: np.array([1,0,2,1,1,0...])
 
     pred_probs : np.array, optional
       An array of shape ``(N, K)`` of model-predicted probabilities,

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -123,8 +123,8 @@ def get_label_quality_scores(
     labels : np.array
       A discrete vector of noisy labels, i.e. some labels may be erroneous.
       *Format requirements*: for dataset with K classes, labels must be in 0, 1, ..., K-1.
-      All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that: len(set(labels)) == pred_probs.shape[1]
-      Assumes single-labeled labels, e.g. format: np.array([1,0,2,1,1,0...])
+      All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that: ``len(set(labels)) == pred_probs.shape[1]``
+      Assumes single-labeled labels, e.g. format: ``np.array([1,0,2,1,1,0...])``
 
     pred_probs : np.array, optional
       An array of shape ``(N, K)`` of model-predicted probabilities,


### PR DESCRIPTION
* Simple PR that adds descriptions of the `labels` parameter for all major API functions. The following description is added (except for rank.py which does not support multi_label currently).

```
All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
len(set(labels)) == pred_probs.shape[1] for single-labeled labels, e.g. [1,0,2,1,1,0...]
len(set(k for l in labels for k in l)) == pred_probs.shape[1] for multi_label, e.g. [[1,2],[1],[0],..]
```