### PR TITLE
Make CleanLearning work with pandas and other non-numpy feature objects X

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,10 +15,10 @@ exclude_lines =
     def __repr__
     if self\.debug
 
-    # Don't complain if tests don't hit defensive assertion code:
-    raise AssertionError
-    raise NotImplementedError
-    raise ValueError
+    # Don't complain if tests don't hit defensive assertion / error-reporting code:
+    raise
+    except
+    assert
     warnings.warn
     
     # Use print(f"...") for printing out non-pure strings:

--- a/README.md
+++ b/README.md
@@ -498,7 +498,8 @@ cleanlab is based on peer-reviewed research. Here are the relevant papers to cit
 
 * Have an issue with cleanlab? [Search existing issues](https://github.com/cleanlab/cleanlab/issues?q=is%3Aissue) or [submit a new issue](https://github.com/cleanlab/cleanlab/issues/new).
 
-* Need professional help with cleanlab? Set up a 20-minute 1:1 session with one of our core developers, Jonas Mueller, via [Cal](https://cal.com/jonas-mueller-ndevin/20min).
+* Need professional help with cleanlab? 
+Join [our Slack channel](https://join.slack.com/t/cleanlab-community/shared_invite/zt-17lszn4hv-gg2FhZPXYfljq_l01uo92g) and message one of our core developers, Jonas Mueller, or schedule a meeting via email: team@cleanlab.ai
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ cleanlab is based on peer-reviewed research. Here are the relevant papers to cit
 * Have an issue with cleanlab? [Search existing issues](https://github.com/cleanlab/cleanlab/issues?q=is%3Aissue) or [submit a new issue](https://github.com/cleanlab/cleanlab/issues/new).
 
 * Need professional help with cleanlab? 
-Join [our Slack channel](https://join.slack.com/t/cleanlab-community/shared_invite/zt-17lszn4hv-gg2FhZPXYfljq_l01uo92g) and message one of our core developers, Jonas Mueller, or schedule a meeting via email: team@cleanlab.ai
+Join our [\#help Slack channel](https://join.slack.com/t/cleanlab-community/shared_invite/zt-17lszn4hv-gg2FhZPXYfljq_l01uo92g) and message one of our core developers, Jonas Mueller, or schedule a meeting via email: team@cleanlab.ai
 
 ## License
 

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -429,7 +429,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         else:  # set args that may not have been set if `self.find_label_issues()` wasn't called yet
             assert_valid_inputs(X, labels, pred_probs)
             if self.num_classes is None:
-                self.num_classes = len(np.unique(labels))
+                self.num_classes = pred_probs.shape[1]
             if self.verbose:
                 print("Using provided label_issues instead of finding label issues.")
                 if self.label_issues_df is not None:
@@ -656,7 +656,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             raise ValueError("Trace(inverse_noise_matrix) is {}. Must exceed 1.".format(t))
 
         # Number of classes
-        self.num_classes = len(np.unique(labels))
+        self.num_classes = pred_probs.shape[1]
         if len(labels) / self.num_classes < self.cv_n_folds:
             raise ValueError(
                 "Need more data from each class for cross-validation. "

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -895,6 +895,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         Helper method to get the label_issues input arg into a formatted DataFrame.
         """
 
+        labels = labels_to_array(labels)
         if isinstance(label_issues, pd.DataFrame):
             if "is_label_issue" not in label_issues.columns:
                 raise ValueError(

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -119,7 +119,6 @@ import pandas as pd
 import inspect
 import warnings
 from cleanlab.internal.util import (
-    assert_inputs_are_valid,
     value_counts,
     compress_int_array,
 )
@@ -134,6 +133,7 @@ from cleanlab.internal.latent_algebra import (
     compute_py_inv_noise_matrix,
     compute_noise_matrix_from_inverse,
 )
+from cleanlab.internal.validation import assert_valid_inputs
 from cleanlab.rank import get_label_quality_scores
 from cleanlab import filter
 
@@ -276,12 +276,12 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         Parameters
         ----------
-        X : np.array
+        X : np.array or pd.DataFrame
           Input feature matrix of shape ``(N, ...)``, where N is the number of
           examples. The classifier that this instance was initialized with,
-          `clf`, must be able to handle data with this shape.
+          ``clf``, must be able to fit() and predict() data with this format.
 
-        labels : np.array
+        labels : np.array or pd.Series
           An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
           Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
 
@@ -419,6 +419,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             )
 
         else:  # set args that may not have been set if `self.find_label_issues()` wasn't called yet
+            assert_valid_inputs(X, labels, pred_probs)
             if self.num_classes is None:
                 self.num_classes = len(np.unique(labels))
             if self.verbose:
@@ -639,8 +640,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         """
 
         # Check inputs
-        allow_empty_X = False if pred_probs is None else True
-        assert_inputs_are_valid(X, labels, pred_probs, allow_empty_X=allow_empty_X)
+        assert_valid_inputs(X, labels, pred_probs)
         if noise_matrix is not None and np.trace(noise_matrix) <= 1:
             t = np.round(np.trace(noise_matrix), 2)
             raise ValueError("Trace(noise_matrix) is {}, but must exceed 1.".format(t))

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -124,6 +124,7 @@ from cleanlab import filter
 from cleanlab.internal.util import (
     value_counts,
     compress_int_array,
+    subset_X_y,
 )
 from cleanlab.count import (
     estimate_py_noise_matrices_and_cv_pred_proba,
@@ -449,18 +450,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         self.label_issues_mask = self.label_issues_df["is_label_issue"].values
         x_mask = ~self.label_issues_mask
-        x_cleaned = X[x_mask]
-        try:  # filtering labels as if it were array
-            labels_cleaned = labels[x_mask]
-            labels_subsetted = True
-        except:
-            labels_subsetted = False
-        if not labels_subsetted:
-            try:  # filtering labels as if it were list
-                labels_cleaned = [l for idx, l in enumerate(labels) if x_mask[idx]]
-            except:
-                raise TypeError("labels must be 1D np.array, list, or pd.Series.")
-
+        x_cleaned, labels_cleaned = subset_X_y(X, labels, x_mask)
         if self.verbose:
             print(f"Pruning {np.sum(self.label_issues_mask)} examples with label issues ...")
             print(f"Remaining clean data has {len(labels_cleaned)} examples.")

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -277,8 +277,11 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         Parameters
         ----------
         X : np.array or pd.DataFrame
-          Input feature matrix of shape ``(N, ...)``, where N is the number of
-          examples. The classifier that this instance was initialized with,
+          Data features (i.e. training inputs), typically an array of shape ``(N, ...)``,
+          where N is the number of examples. Sparse matrices are supported.
+          If not an array or DataFrame, then ``X`` must support list-based indexing:
+          ``X[index_list]`` to select a subset of training examples.
+          The classifier that this instance was initialized with,
           ``clf``, must be able to fit() and predict() data with this format.
 
         labels : np.array or pd.Series

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -764,11 +764,11 @@ def estimate_confident_joint_and_cv_pred_proba(
                 dup_ind = holdout_inds[0]
                 s_train_cv = np.append(
                     s_train_cv, s_holdout_cv[dup_ind]
-                )  # labels are always np.array
+                )  # labels are always np.array so don't have to consider .iloc
                 if isinstance(X, np.ndarray):
                     X_train_cv = np.vstack([X_train_cv, X_holdout_cv[dup_ind]])
                 else:
-                    try:
+                    try:  # extract single example to add to training set
                         if isinstance(X, pd.DataFrame):
                             X_extra = X_holdout_cv.iloc[dup_ind]
                         elif isinstance(X, pd.Series):
@@ -777,7 +777,7 @@ def estimate_confident_joint_and_cv_pred_proba(
                             X_extra = X_holdout_cv[dup_ind]
                         X_train_cv = X_train_cv.append(X_extra)
                     except:
-                        raise TypeError("Features object X must support: X.append(X[i])")
+                        raise TypeError("Data features X must support: X.append(X[i])")
                 missing_class_inds[missing_class] = dup_ind
 
             if isinstance(X, (pd.DataFrame, pd.Series)):

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -36,6 +36,7 @@ from cleanlab.internal.util import (
     clip_values,
     clip_noise_rates,
     round_preserving_row_totals,
+    csr_vstack,
 )
 from cleanlab.internal.latent_algebra import (
     compute_inv_noise_matrix,
@@ -775,9 +776,15 @@ def estimate_confident_joint_and_cv_pred_proba(
                             X_extra = pd.Series(X_holdout_cv.iloc[dup_ind])
                         else:
                             X_extra = X_holdout_cv[dup_ind]
+                    except:
+                        raise TypeError("Data features X must support: X[i].")
+                    try:
                         X_train_cv = X_train_cv.append(X_extra)
                     except:
-                        raise TypeError("Data features X must support: X.append(X[i])")
+                        try:  # append for sparse matrix
+                            X_train_cv = csr_vstack(X_train_cv, X_extra)
+                        except:
+                            raise TypeError("Data features X must support: X.append(X[i])")
                 missing_class_inds[missing_class] = dup_ind
 
             if isinstance(X, (pd.DataFrame, pd.Series)):

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -735,7 +735,10 @@ def estimate_confident_joint_and_cv_pred_proba(
         clf_copy = sklearn.base.clone(clf)
 
         # Select the training and holdout cross-validated sets.
-        s_train_cv, s_holdout_cv = labels[cv_train_idx], labels[cv_holdout_idx]  # labels are always np.array
+        s_train_cv, s_holdout_cv = (
+            labels[cv_train_idx],
+            labels[cv_holdout_idx],
+        )  # labels are always np.array
         if isinstance(X, (pd.DataFrame, pd.Series)):
             X_train_cv, X_holdout_cv = X.iloc[cv_train_idx], X.iloc[cv_holdout_idx]
         else:
@@ -759,7 +762,9 @@ def estimate_confident_joint_and_cv_pred_proba(
                 holdout_inds = np.where(s_holdout_cv == missing_class)[0]
                 # Duplicate one instance of missing_class from holdout data to the training data:
                 dup_ind = holdout_inds[0]
-                s_train_cv = np.append(s_train_cv, s_holdout_cv[dup_ind])  # labels are always np.array
+                s_train_cv = np.append(
+                    s_train_cv, s_holdout_cv[dup_ind]
+                )  # labels are always np.array
                 if isinstance(X, np.ndarray):
                     X_train_cv = np.vstack([X_train_cv, X_holdout_cv[dup_ind]])
                 else:
@@ -775,9 +780,8 @@ def estimate_confident_joint_and_cv_pred_proba(
                         raise TypeError("Features object X must support: X.append(X[i])")
                 missing_class_inds[missing_class] = dup_ind
 
-            if isinstance(X, (pd.DataFrame, pd.Series)): 
+            if isinstance(X, (pd.DataFrame, pd.Series)):
                 X_train_cv = X_train_cv.reset_index(inplace=True, drop=True)
-
 
         # Fit classifier clf to training set, predict on holdout set, and update pred_probs.
         clf_copy.fit(X_train_cv, s_train_cv, **clf_kwargs)

--- a/cleanlab/internal/latent_algebra.py
+++ b/cleanlab/internal/latent_algebra.py
@@ -236,12 +236,12 @@ def compute_py(
         warnings.warn(w)
 
     if py_method == "marginal" and true_labels_class_counts is None:
-        err = (
+        msg = (
             'py_method == "marginal" requires true_labels_class_counts, '
             "but true_labels_class_counts is None. "
         )
-        err += " Provide parameter true_labels_class_counts."
-        raise ValueError(err)
+        msg += " Provide parameter true_labels_class_counts."
+        raise ValueError(msg)
 
     if py_method == "cnt":
         # Computing py this way avoids dividing by zero noise rates.

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -20,44 +20,6 @@
 # #### Contains ancillary helper functions used throughout this package.
 
 import numpy as np
-from sklearn.utils import check_X_y
-
-
-def assert_inputs_are_valid(X, s, pred_probs=None, allow_empty_X=False):  # pragma: no cover
-    """Checks that X, labels, and pred_probs are correctly formatted"""
-
-    if pred_probs is not None:
-        if not isinstance(pred_probs, (np.ndarray, np.generic)):
-            raise TypeError("pred_probs should be a numpy array.")
-        if len(pred_probs) != len(s):
-            raise ValueError("pred_probs and labels must have same length.")
-        # Check for valid probabilities.
-        if (pred_probs < 0).any() or (pred_probs > 1).any():
-            raise ValueError("Values in pred_probs must be between 0 and 1.")
-
-    if not isinstance(s, (np.ndarray, np.generic)):
-        raise TypeError("labels should be a numpy array.")
-
-    # Check that labels is zero-indexed (first label is 0).
-    unique_classes = np.unique(s)
-    if all(unique_classes != np.arange(len(unique_classes))):
-        msg = "cleanlab requires zero-indexed labels (0,1,2,..,m-1), but in "
-        msg += "your case: np.unique(labels) = {}".format(str(unique_classes))
-        raise TypeError(msg)
-
-    if not allow_empty_X:
-        if X is None:
-            raise ValueError("X cannot be None.")
-
-        check_X_y(
-            X,
-            s,
-            accept_sparse=True,
-            dtype=None,
-            force_all_finite=False,
-            ensure_2d=False,
-            allow_nd=True,
-        )
 
 
 def remove_noise_from_class(noise_matrix, class_without_noise):

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -400,14 +400,32 @@ def print_joint_matrix(joint_matrix, round_places=2):
 
 def compress_int_array(int_array, num_possible_values):
     """Compresses dtype of np.array<int> if num_possible_values is small enough."""
-    compressed_type = None
-    if num_possible_values < np.iinfo(np.dtype("int16")).max:
-        compressed_type = "int16"
-    elif num_possible_values < np.iinfo(np.dtype("int32")).max:  # pragma: no cover
-        compressed_type = "int32"  # pragma: no cover
-    if compressed_type is not None:
-        int_array = int_array.astype(compressed_type)
-    return int_array
+    try:
+        compressed_type = None
+        if num_possible_values < np.iinfo(np.dtype("int16")).max:
+            compressed_type = "int16"
+        elif num_possible_values < np.iinfo(np.dtype("int32")).max:  # pragma: no cover
+            compressed_type = "int32"  # pragma: no cover
+        if compressed_type is not None:
+            int_array = int_array.astype(compressed_type)
+        return int_array
+    except:  # int_array may not even be numpy array, keep as is then
+        return int_array
+
+
+def subset_labels(labels, boolean_mask):
+    """Extracts subset of labels where mask is True"""
+    try:  # filtering labels as if it is array or DataFrame
+        labels_cleaned = labels[x_mask]
+        labels_subsetted = True
+    except:
+        labels_subsetted = False
+        if not labels_subsetted:
+            try:  # filtering labels as if it is list
+                labels_cleaned = [l for idx, l in enumerate(labels) if x_mask[idx]]
+            except:
+                raise TypeError("labels must be 1D np.array, list, or pd.Series.")
+    return labels_cleaned
 
 
 def smart_display_dataframe(df):  # pragma: no cover

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -493,6 +493,22 @@ def append_extra_datapoint(to_data, from_data, index):
     return to_data
 
 
+    def get_num_classes(labels, multi_label=None):
+        """Finds the number of unique classes for both single-labeled
+        and multi-labeled labels. If multi_label is set to None (default)
+        this method will infer if multi_label is True or False based on
+        the format of labels.
+        This allows for a more general form of multiclass labels that looks
+        like this: [1, [1,2], [0], [0, 1], 2, 1]"""
+
+        if multi_label is None:
+            multi_label = any(isinstance(l, list) for l in labels)
+        if multi_label:
+            return len(set(l for grp in labels for l in list(grp)))
+        else:
+            return len(set(labels))
+
+
 def smart_display_dataframe(df):  # pragma: no cover
     """Display a pandas dataframe if in a jupyter notebook, otherwise print it to console."""
     try:

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -416,16 +416,23 @@ def compress_int_array(int_array, num_possible_values):
 def subset_labels(labels, boolean_mask):
     """Extracts subset of labels where mask is True"""
     try:  # filtering labels as if it is array or DataFrame
-        labels_cleaned = labels[x_mask]
-        labels_subsetted = True
+        return labels[x_mask]
     except:
-        labels_subsetted = False
-        if not labels_subsetted:
-            try:  # filtering labels as if it is list
-                labels_cleaned = [l for idx, l in enumerate(labels) if x_mask[idx]]
-            except:
-                raise TypeError("labels must be 1D np.array, list, or pd.Series.")
-    return labels_cleaned
+        try:  # filtering labels as if it is list
+            return [l for idx, l in enumerate(labels) if x_mask[idx]]
+        except:
+            raise TypeError("labels must be 1D np.array, list, or pd.Series.")
+
+
+def csr_vstack(a, b):
+    """Takes in 2 csr_matrices and appends the second one to the bottom of the first one.
+    Alternative to scipy.sparse.vstack.
+    """
+    a.data = np.hstack((a.data, b.data))
+    a.indices = np.hstack((a.indices, b.indices))
+    a.indptr = np.hstack((a.indptr, (b.indptr + a.nnz)[1:]))
+    a._shape = (a.shape[0] + b.shape[0], b.shape[1])
+    return a
 
 
 def smart_display_dataframe(df):  # pragma: no cover

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -414,15 +414,39 @@ def compress_int_array(int_array, num_possible_values):
         return int_array
 
 
-def subset_labels(labels, boolean_mask):
+def subset_X_y(X, labels, mask):
+    """Extracts subset of features/labels where mask is True"""
+    labels = subset_labels(labels, mask)
+    try:
+        X = X[mask]
+    except:
+        raise TypeError("Data features X must be subsettable with boolean mask: X[mask]")
+    return X, labels
+
+
+def subset_labels(labels, mask):
     """Extracts subset of labels where mask is True"""
     try:  # filtering labels as if it is array or DataFrame
-        return labels[x_mask]
+        return labels[mask]
     except:
         try:  # filtering labels as if it is list
-            return [l for idx, l in enumerate(labels) if x_mask[idx]]
+            return [l for idx, l in enumerate(labels) if mask[idx]]
         except:
             raise TypeError("labels must be 1D np.array, list, or pd.Series.")
+
+
+"""
+try:  # filtering labels as if it were array
+            labels_cleaned = labels[x_mask]
+            labels_subsetted = True
+        except:
+            labels_subsetted = False
+        if not labels_subsetted:
+            try:  # filtering labels as if it were list
+                labels_cleaned = [l for idx, l in enumerate(labels) if x_mask[idx]]
+            except:
+                raise TypeError("labels must be 1D np.array, list, or pd.Series.")
+"""
 
 
 def csr_vstack(a, b):

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -34,26 +34,28 @@ def assert_valid_inputs(X, y, pred_probs=None):
     if not allow_empty_X:
         assert_nonempty_input(X)
         try:
-            n = len(X)
+            num_examples = len(X)
             len_supported = True
         except:
             len_supported = False
         if not len_supported:
             try:
-                n = X.shape[0]
+                num_examples = X.shape[0]
                 shape_supported = True
             except:
                 shape_supported = False
         if (not len_supported) and (not shape_supported):
-            raise TypeError("Features object X must support either: len(X) or X.shape[0]")
+            raise TypeError("Data features X must support either: len(X) or X.shape[0]")
 
-        if n != len(y):
-            raise ValueError("length of X must match length of labels.")
+        if num_examples != len(y):
+            raise ValueError(
+                f"X and labels must be same length, but X is length {num_examples} and labels is length {len(y)}."
+            )
 
-        if n < 2:
-            raise ValueError("length of X must be at least 2.")
+        if num_examples < 2:
+            raise ValueError("Length of X (i.e. number of examples) must be at least 2.")
 
-        assert_indexing_works(X, length_X=n)
+        assert_indexing_works(X, length_X=num_examples)
 
     if pred_probs is not None:
         if not isinstance(pred_probs, (np.ndarray, np.generic)):
@@ -81,11 +83,14 @@ def assert_valid_class_labels(y):
 
 def assert_nonempty_input(X):
     if X is None:
-        raise ValueError("X cannot be None.")
+        raise ValueError("Data features X cannot be None. Currently X is None.")
 
 
 def assert_indexing_works(X, idx=None, length_X=None):
-    """Ensures we can do list-based indexing into X and y"""
+    """Ensures we can do list-based indexing into ``X`` and ``y``.
+    length_X is argument passed in since sparse matrix ``X``
+    does not support: ``len(X)``.
+    """
     if idx is None:
         if length_X is None:
             length_X = 2
@@ -97,7 +102,7 @@ def assert_indexing_works(X, idx=None, length_X=None):
         else:
             _ = X[idx]
     except:
-        msg = "Features object X must support list-based indexing; i.e. one of these must work: \n"
+        msg = "Data features X must support list-based indexing; i.e. one of these must work: \n"
         msg += "1)  X[index_list] where say index_list = [0,1,3,10], or \n"
         msg += "2)  X.iloc[index_list] if X is pandas DataFrame."
         raise TypeError(msg)

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -34,17 +34,26 @@ def assert_valid_inputs(X, y, pred_probs=None):
     if not allow_empty_X:
         assert_nonempty_input(X)
         try:
-            _ = len(X)
+            n = len(X)
+            len_supported = True
         except:
-            raise TypeError("len(X) must be supported operation for input features object.")
+            len_supported = False
+        if not len_supported:
+            try:
+                n = X.shape[0]
+                shape_supported = True
+            except:
+                shape_supported = False
+        if (not len_supported) and (not shape_supported):
+            raise TypeError("Features object X must support either: len(X) or X.shape[0]")
 
-        if len(X) != len(y):
-            raise ValueError("len(X) must match length of labels.")
+        if n != len(y):
+            raise ValueError("length of X must match length of labels.")
 
-        if len(X) < 2:
-            raise ValueError("len(X) must be at least 2.")
+        if n < 2:
+            raise ValueError("length of X must be at least 2.")
 
-        assert_indexing_works(X)
+        assert_indexing_works(X, length_X=n)
 
     if pred_probs is not None:
         if not isinstance(pred_probs, (np.ndarray, np.generic)):
@@ -75,10 +84,13 @@ def assert_nonempty_input(X):
         raise ValueError("X cannot be None.")
 
 
-def assert_indexing_works(X, idx=None):
+def assert_indexing_works(X, idx=None, length_X=None):
     """Ensures we can do list-based indexing into X and y"""
     if idx is None:
-        idx = [0, len(X) - 1]
+        if length_X is None:
+            length_X = 2
+
+        idx = [0, length_X - 1]
     try:
         if isinstance(X, (pd.DataFrame, pd.Series)):
             _ = X.iloc[idx]

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -59,7 +59,7 @@ def assert_valid_inputs(X, y, pred_probs=None):
 
 
 def assert_valid_class_labels(y):
-    """ Check that labels is zero-indexed (first label is 0) and all classes present"""
+    """Check that labels is zero-indexed (first label is 0) and all classes present"""
     if y.ndim != 1:
         raise ValueError("labels must by 1D numpy array.")
 
@@ -76,13 +76,13 @@ def assert_nonempty_input(X):
 
 
 def assert_indexing_works(X, idx=None):
-    """ Ensures we can do list-based indexing into X and y"""
+    """Ensures we can do list-based indexing into X and y"""
     if idx is None:
-        idx = [0, len(X)-1]
+        idx = [0, len(X) - 1]
     try:
         if isinstance(X, (pd.DataFrame, pd.Series)):
             _ = X.iloc[idx]
-        else:   
+        else:
             _ = X[idx]
     except:
         msg = "Features object X must support list-based indexing; i.e. one of these must work: \n"
@@ -104,6 +104,8 @@ def labels_to_array(y):
         try:
             y = np.array(y)
         except:
-            raise ValueError("List of labels must be convertable to 1D numpy array via: np.array(labels)")
-    
+            raise ValueError(
+                "List of labels must be convertable to 1D numpy array via: np.array(labels)"
+            )
+
     return y

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -106,18 +106,16 @@ def assert_indexing_works(X, idx=None, length_X=None):
 def labels_to_array(y):
     """Converts different types of label objects to 1D numpy array and checks validity"""
     if isinstance(y, pd.Series):
-        y = y.values
+        return y.values
     elif isinstance(y, pd.DataFrame):
         y = y.values
         if y.shape[1] != 1:
             raise ValueError("labels must be one dimensional.")
-        y = y.flatten()
-    elif isinstance(y, list):
+        return y.flatten()
+    else:  # y is list, np.array, or some other tuple-like object
         try:
-            y = np.array(y)
+            return np.asarray(y)
         except:
             raise ValueError(
                 "List of labels must be convertable to 1D numpy array via: np.array(labels)"
             )
-
-    return y

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -93,7 +93,7 @@ def assert_indexing_works(X, idx=None, length_X=None):
     """
     if idx is None:
         if length_X is None:
-            length_X = 2
+            length_X = 2  # pragma: no cover
 
         idx = [0, length_X - 1]
     try:

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -52,9 +52,6 @@ def assert_valid_inputs(X, y, pred_probs=None):
                 f"X and labels must be same length, but X is length {num_examples} and labels is length {len(y)}."
             )
 
-        if num_examples < 2:
-            raise ValueError("Length of X (i.e. number of examples) must be at least 2.")
-
         assert_indexing_works(X, length_X=num_examples)
 
     if pred_probs is not None:
@@ -75,6 +72,9 @@ def assert_valid_class_labels(y):
         raise ValueError("labels must by 1D numpy array.")
 
     unique_classes = np.unique(y)
+    if len(unique_classes) < 2:
+        raise ValueEror("Labels must contain at least 2 classes.")
+
     if all(unique_classes != np.arange(len(unique_classes))):
         msg = "cleanlab requires zero-indexed labels (0,1,2,..,K-1), but in "
         msg += "your case: np.unique(labels) = {}".format(str(unique_classes))
@@ -89,7 +89,8 @@ def assert_nonempty_input(X):
 def assert_indexing_works(X, idx=None, length_X=None):
     """Ensures we can do list-based indexing into ``X`` and ``y``.
     length_X is argument passed in since sparse matrix ``X``
-    does not support: ``len(X)``.
+    does not support: ``len(X)`` and we want this method to work for sparse ``X``
+    (in addition to many other types of ``X``).
     """
     if idx is None:
         if length_X is None:

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2017-2022  Cleanlab Inc.
+# This file is part of cleanlab.
+#
+# cleanlab is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cleanlab is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Checks to ensure valid inputs for various methods.
+"""
+
+import warnings
+import numpy as np
+import pandas as pd
+from sklearn.utils import check_X_y
+
+
+def assert_valid_inputs(X, y, pred_probs=None):
+    """Checks that X, labels, and pred_probs are correctly formatted"""
+    if not isinstance(y, (list, np.ndarray, np.generic, pd.Series, pd.DataFrame)):
+        raise TypeError("labels should be a numpy array or pandas Series.")
+    y = labels_to_array(y)
+    assert_valid_class_labels(y)
+    allow_empty_X = False if pred_probs is None else True
+    if not allow_empty_X:
+        assert_nonempty_input(X)
+        try:
+            _ = len(X)
+        except:
+            raise TypeError("len(X) must be supported operation for input features object.")
+
+        if len(X) != len(y):
+            raise ValueError("len(X) must match length of labels.")
+
+        if len(X) < 2:
+            raise ValueError("len(X) must be at least 2.")
+
+        assert_indexing_works(X)
+
+    if pred_probs is not None:
+        if not isinstance(pred_probs, (np.ndarray, np.generic)):
+            raise TypeError("pred_probs must be a numpy array.")
+        if len(pred_probs) != len(y):
+            raise ValueError("pred_probs and labels must have same length.")
+        # Check for valid probabilities.
+        if (pred_probs < 0).any() or (pred_probs > 1).any():
+            raise ValueError("Values in pred_probs must be between 0 and 1.")
+        if X is not None:
+            warnings.warn("When X and pred_probs are both provided, former may be ignored.")
+
+
+def assert_valid_class_labels(y):
+    """ Check that labels is zero-indexed (first label is 0) and all classes present"""
+    if y.ndim != 1:
+        raise ValueError("labels must by 1D numpy array.")
+
+    unique_classes = np.unique(y)
+    if all(unique_classes != np.arange(len(unique_classes))):
+        msg = "cleanlab requires zero-indexed labels (0,1,2,..,K-1), but in "
+        msg += "your case: np.unique(labels) = {}".format(str(unique_classes))
+        raise TypeError(msg)
+
+
+def assert_nonempty_input(X):
+    if X is None:
+        raise ValueError("X cannot be None.")
+
+
+def assert_indexing_works(X, idx=None):
+    """ Ensures we can do list-based indexing into X and y"""
+    if idx is None:
+        idx = [0, len(X)-1]
+    try:
+        if isinstance(X, (pd.DataFrame, pd.Series)):
+            _ = X.iloc[idx]
+        else:   
+            _ = X[idx]
+    except:
+        msg = "Features object X must support list-based indexing; i.e. one of these must work: \n"
+        msg += "1)  X[index_list] where say index_list = [0,1,3,10], or \n"
+        msg += "2)  X.iloc[index_list] if X is pandas DataFrame."
+        raise TypeError(msg)
+
+
+def labels_to_array(y):
+    """Converts different types of label objects to 1D numpy array and checks validity"""
+    if isinstance(y, pd.Series):
+        y = y.values
+    elif isinstance(y, pd.DataFrame):
+        y = y.values
+        if y.shape[1] != 1:
+            raise ValueError("labels must be one dimensional.")
+        y = y.flatten()
+    elif isinstance(y, list):
+        try:
+            y = np.array(y)
+        except:
+            raise ValueError("List of labels must be convertable to 1D numpy array via: np.array(labels)")
+    
+    return y

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -35,13 +35,16 @@ SEED = 1
 
 
 def make_data(
-    sparse,
+    format="numpy",
     means=[[3, 2], [7, 7], [0, 8]],
     covs=[[[5, -1.5], [-1.5, 1]], [[1, 0.5], [0.5, 4]], [[5, 1], [1, 5]]],
     sizes=[100, 50, 50],
     avg_trace=0.8,
     seed=SEED,  # set to None for non-reproducible randomness
 ):
+    """format specifies what X (and y) looks like, one of:
+    'numpy', 'sparse', 'dataframe', or 'series'.
+    """
     np.random.seed(seed=seed)
 
     K = len(means)  # number of classes
@@ -62,9 +65,21 @@ def make_data(
     X_test = np.vstack(test_data)
     true_labels_test = np.hstack(test_labels)
 
-    if sparse:
+    if format == "sparse":
         X_train = scipy.sparse.csr_matrix(X_train)
         X_test = scipy.sparse.csr_matrix(X_test)
+    elif format == "dataframe":
+        X_train = pd.DataFrame(X_train)
+        X_test = pd.DataFrame(X_test)
+        # true_labels_train = list(true_labels_train)
+        # true_labels_test = list(true_labels_test)
+    elif format == "series":
+        X_train = pd.Series(X_train[:, 0])
+        X_test = pd.Series(X_test[:, 0])
+        # true_labels_train = pd.Series(true_labels_train)
+        # true_labels_test = pd.Series(true_labels_test)
+    elif format != "numpy":
+        raise ValueError("invalid value specified for: `format`.")
 
     # Compute p(true_label=k)
     py = np.bincount(true_labels_train) / float(len(true_labels_train))
@@ -107,11 +122,18 @@ def make_rare_label(data):
     return data
 
 
-DATA = make_data(sparse=False, seed=SEED)
-SPARSE_DATA = make_data(sparse=False, seed=SEED)
+DATA = make_data(format="numpy", seed=SEED)
+SPARSE_DATA = make_data(format="sparse", seed=SEED)
+DATAFRAME_DATA = make_data(format="dataframe", seed=SEED)
+SERIES_DATA = make_data(format="series", seed=SEED)  # special case not checked in most tests
+DATA_FORMATS = {
+    "numpy": DATA,
+    "sparse": SPARSE_DATA,
+    "dataframe": DATAFRAME_DATA,
+}
 
 
-@pytest.mark.parametrize("data", [DATA, SPARSE_DATA])
+@pytest.mark.parametrize("data", list(DATA_FORMATS.values()))
 def test_cl(data):
     cl = CleanLearning(
         clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED)
@@ -119,7 +141,6 @@ def test_cl(data):
     cl.fit(data["X_train"], data["labels"])
     score = cl.score(data["X_test"], data["true_labels_test"])
     print(score)
-    # Check that this runs without error.
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
@@ -129,7 +150,7 @@ def test_rare_label():
 
 
 def test_invalid_inputs():
-    data = make_data(sparse=False, sizes=[1, 1, 1])
+    data = make_data(sizes=[1, 1, 1])
     try:
         test_cl(data)
     except Exception as e:
@@ -151,6 +172,7 @@ def test_invalid_inputs():
         raise Exception("expected test to raise Exception")
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_aux_inputs():
     data = DATA
     K = len(np.unique(data["labels"]))
@@ -348,13 +370,13 @@ def test_clf_fit_inm():
             cl.fit(X=np.arange(3), labels=np.array([0, 0, 1]), inverse_noise_matrix=inm)
 
 
-@pytest.mark.parametrize("sparse", [True, False])
+@pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
 def test_fit_with_nm(
-    sparse,
+    format,
     seed=SEED,
     used_by_another_test=False,
 ):
-    data = SPARSE_DATA if sparse else DATA
+    data = DATA_FORMATS[format]
     cl = CleanLearning(
         seed=seed,
     )
@@ -377,13 +399,13 @@ def test_fit_with_nm(
         assert score < score_nm + 1e-4
 
 
-@pytest.mark.parametrize("sparse", [True, False])
+@pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
 def test_fit_with_inm(
-    sparse,
+    format,
     seed=SEED,
     used_by_another_test=False,
 ):
-    data = SPARSE_DATA if sparse else DATA
+    data = DATA_FORMATS[format]
     cl = CleanLearning(
         seed=seed,
     )
@@ -410,9 +432,9 @@ def test_fit_with_inm(
         assert score < score_inm + 1e-4
 
 
-@pytest.mark.parametrize("sparse", [True, False])
-def test_clf_fit_nm_inm(sparse):
-    data = SPARSE_DATA if sparse else DATA
+@pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
+def test_clf_fit_nm_inm(format):
+    data = DATA_FORMATS[format]
     cl = CleanLearning(seed=SEED)
     nm = data["noise_matrix"]
     inm = compute_inv_noise_matrix(
@@ -438,9 +460,9 @@ def test_clf_fit_nm_inm(sparse):
     assert score < score_nm_inm + 1e-4
 
 
-@pytest.mark.parametrize("sparse", [True, False])
-def test_pred_and_pred_proba(sparse):
-    data = SPARSE_DATA if sparse else DATA
+@pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
+def test_pred_and_pred_proba(format):
+    data = DATA_FORMATS[format]
     cl = CleanLearning()
     cl.fit(data["X_train"], data["labels"])
     n = np.shape(data["true_labels_test"])[0]
@@ -452,9 +474,9 @@ def test_pred_and_pred_proba(sparse):
     assert np.shape(probs) == (n, m)
 
 
-@pytest.mark.parametrize("sparse", [True, False])
-def test_score(sparse):
-    data = SPARSE_DATA if sparse else DATA
+@pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
+def test_score(format):
+    data = DATA_FORMATS[format]
     phrase = "cleanlab is dope"
 
     class Struct:
@@ -475,9 +497,9 @@ def test_score(sparse):
     assert score == phrase
 
 
-@pytest.mark.parametrize("sparse", [True, False])
-def test_no_score(sparse):
-    data = SPARSE_DATA if sparse else DATA
+@pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
+def test_no_score(format):
+    data = DATA_FORMATS[format]
 
     class Struct:
         def fit(self):
@@ -494,9 +516,10 @@ def test_no_score(sparse):
     assert abs(score - 1) < 1e-6
 
 
-@pytest.mark.parametrize("sparse", [True, False])
-def test_no_fit_sample_weight(sparse):
-    data = SPARSE_DATA if sparse else DATA
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
+def test_no_fit_sample_weight(format):
+    data = DATA_FORMATS[format]
 
     class Struct:
         def fit(self, X, y):
@@ -521,9 +544,10 @@ def test_no_fit_sample_weight(sparse):
     # If we make it here, without any error:
 
 
-@pytest.mark.parametrize("sparse", [True, False])
-def test_fit_pred_probs(sparse):
-    data = SPARSE_DATA if sparse else DATA
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
+def test_fit_pred_probs(format):
+    data = DATA_FORMATS[format]
 
     cl = CleanLearning()
     pred_probs = estimate_cv_predicted_probabilities(
@@ -542,6 +566,7 @@ def test_fit_pred_probs(sparse):
 
 
 def make_2d(X):
+    X = np.asarray(X)
     return X.reshape(X.shape[0], -1)
 
 
@@ -550,6 +575,7 @@ class ReshapingLogisticRegression(BaseEstimator):
         self.clf = LogisticRegression()
 
     def fit(self, X, y):
+        y = np.asarray(y)
         self.clf.fit(make_2d(X), y)
 
     def predict(self, X):
@@ -562,10 +588,7 @@ class ReshapingLogisticRegression(BaseEstimator):
         return self.clf.score(make_2d(X), y, sample_weight=sample_weight)
 
 
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
-@pytest.mark.parametrize("N", [1, 2, 3, 4])
-def test_dimN(N):
-    cl = CleanLearning(clf=ReshapingLogisticRegression())
+def dimN_data(N):
     size = [100] + [3 for _ in range(N - 1)]
     X = np.random.normal(size=size)
     labels = np.random.randint(0, 4, size=100)
@@ -574,8 +597,38 @@ def test_dimN(N):
     labels[11:20] = 1
     labels[21:30] = 2
     labels[31:40] = 3
+    return X, labels
+
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.parametrize("N", [1, 3, 4])
+def test_dimN(N):
+    X, labels = dimN_data(N)
+    cl = CleanLearning(clf=ReshapingLogisticRegression())
     # just make sure we don't crash...
     cl.fit(X, labels)
+    cl.predict(X)
+    cl.predict_proba(X)
+    cl.score(X, labels)
+
+
+def test_1D_formats():
+    X, labels = dimN_data(1)
+    X_series = pd.Series(X)
+    labels_series = pd.Series(labels)
+    idx = list(np.random.choice(len(labels), size=len(labels), replace=False))
+    X_series.index = idx
+    labels_series.index = idx
+    cl = CleanLearning(clf=ReshapingLogisticRegression())
+    # just make sure we don't crash...
+    cl.fit(X_series, labels_series)
+    cl.predict(X_series)
+    cl.predict_proba(X_series)
+    cl.score(X_series, labels)
+    # Repeat with list labels:
+    labels_list = list(labels)
+    cl = CleanLearning(clf=ReshapingLogisticRegression())
+    cl.fit(X, labels_list)
     cl.predict(X)
     cl.predict_proba(X)
     cl.score(X, labels)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -144,8 +144,9 @@ def test_cl(data):
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_rare_label():
-    data = make_rare_label(DATA)
+@pytest.mark.parametrize("data", [DATA, SPARSE_DATA])
+def test_rare_label(data):
+    data = make_rare_label(data)
     test_cl(data)
 
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -613,6 +613,7 @@ def test_dimN(N):
     cl.score(X, labels)
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_1D_formats():
     X, labels = dimN_data(1)
     X_series = pd.Series(X)
@@ -623,6 +624,16 @@ def test_1D_formats():
     cl = CleanLearning(clf=ReshapingLogisticRegression())
     # just make sure we don't crash...
     cl.fit(X_series, labels_series)
+    cl.predict(X_series)
+    cl.predict_proba(X_series)
+    cl.score(X_series, labels)
+    # Repeat with rare labels:
+    labels_rare = deepcopy(labels)
+    class0_inds = np.where(labels_rare == 0)[0]
+    class0_inds_remove = class0_inds[1:]
+    labels_rare[class0_inds_remove] = 1
+    cl = CleanLearning(clf=ReshapingLogisticRegression())
+    cl.fit(X_series, labels_rare)
     cl.predict(X_series)
     cl.predict_proba(X_series)
     cl.score(X_series, labels)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -144,7 +144,7 @@ def test_cl(data):
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
-@pytest.mark.parametrize("data", [DATA, SPARSE_DATA])
+@pytest.mark.parametrize("data", list(DATA_FORMATS.values()))
 def test_rare_label(data):
     data = make_rare_label(data)
     test_cl(data)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -575,7 +575,7 @@ class ReshapingLogisticRegression(BaseEstimator):
         self.clf = LogisticRegression()
 
     def fit(self, X, y):
-        y = np.asarray(y)
+        y = np.asarray(y).flatten()
         self.clf.fit(make_2d(X), y)
 
     def predict(self, X):
@@ -625,6 +625,13 @@ def test_1D_formats():
     cl.predict(X_series)
     cl.predict_proba(X_series)
     cl.score(X_series, labels)
+    # Repeat with DataFrame labels:
+    labels_df = pd.DataFrame({"colname": labels})
+    cl = CleanLearning(clf=ReshapingLogisticRegression())
+    cl.fit(X, labels_df)
+    cl.predict(X)
+    cl.predict_proba(X)
+    cl.score(X, labels)
     # Repeat with list labels:
     labels_list = list(labels)
     cl = CleanLearning(clf=ReshapingLogisticRegression())

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -138,9 +138,15 @@ def test_cl(data):
     cl = CleanLearning(
         clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED)
     )
+    X_train_og = deepcopy(data["X_train"])
     cl.fit(data["X_train"], data["labels"])
     score = cl.score(data["X_test"], data["true_labels_test"])
     print(score)
+    # ensure data has not been altered:
+    if isinstance(X_train_og, np.ndarray):
+        assert (data["X_train"] == X_train_og).all()
+    elif isinstance(X_train_og, pd.DataFrame):
+        assert data["X_train"].equals(X_train_og)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")


### PR DESCRIPTION
First level of making CleanLearning class be able to work with non-array feature types, most importantly `pd.DataFrame`, which many popular models support out-of-the-box (sklearn, xgboost, lightgbm etc). 

The documentation in this PR states X must be np.array or pd.DataFrame, but actually CleanLearning will now work for some more exotic X as well (eg. pd.Series, certain text/image datasets, etc).  Documenting the most general forms of X that are supported will be left for future PR, as the underlying code can be generalized a bit further.

Partially addresses:  https://github.com/cleanlab/cleanlab/issues/252