### PR TITLE
Drop dependency on SciPy

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ coverage != 6.3, != 6.3.*
 pre-commit
 pytest
 pytest-cov
+scipy
 torch
 torchvision
 requests

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,6 @@ setup(
     install_requires=[
         "numpy>=1.11.3",
         "scikit-learn>=0.18",
-        "scipy>=1.1.0",
         "tqdm>=4.53.0",
         "pandas>=1.0.0",
     ],


### PR DESCRIPTION
We aren't actually using SciPy within the cleanlab package, only in tests.