### PR TITLE
Allow CleanLearning to use validation data in each fold

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -372,9 +372,20 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           than during cross-validation.
 
         validation_func : callable, optional
-          Optional callable function that takes two arguments, `X_val`, `y_val`.
-          Specifies how to map the validation data split in the cross validation
-          step into the appropriate format to pass into `clf`'s ``fit()`` method.
+          Optional callable function that takes two arguments, `X_val`, `y_val`, and returns a dict
+          of keyword arguments passed into to `clf.fit()` which may be functions of the validation
+          data in each cross-validation fold. Specifies how to map the validation data split in each
+          cross-validation fold into the appropriate format to pass into `clf`'s ``fit()`` method.
+          e.g. if your model's ``fit()`` method is call using `clf.fit(X, y, X_validation, y_validation)`,
+          then you could set `validation_func = f` where
+          `def f(X_val, y_val): return {"X_validation": X_val, "y_validation": y_val}`
+
+          Note that `validation_func` will be ignored in the final call to `clf.fit()` on the
+          cleaned subset of the data. This argument is only for allowing `clf` to access the
+          validation data in each cross-validation fold (eg. for early-stopping or hyperparameter-selection
+          purposes). If you want to pass in validation data even in the final training of `clf.fit()`
+          on the cleaned data subset, you should explicitly pass in that data yourself
+          (eg. via `clf_final_kwargs` or `clf_kwargs`).
 
         Returns
         -------

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -272,6 +272,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         sample_weight=None,
         clf_kwargs={},
         clf_final_kwargs={},
+        validation_func=None,
     ):
         """
         Train the model `clf` with error-prone, noisy labels as if
@@ -370,6 +371,11 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           This can be useful for training differently in the final ``fit()``
           than during cross-validation.
 
+        validation_func : callable, optional
+          Optional callable function that takes two arguments, `X_val`, `y_val`.
+          Specifies how to map the validation data split in the cross validation 
+          step into the appropriate format to pass into `clf`'s ``fit()`` method.
+
         Returns
         -------
         CleanLearning
@@ -425,6 +431,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                 noise_matrix=noise_matrix,
                 inverse_noise_matrix=inverse_noise_matrix,
                 clf_kwargs=clf_kwargs,
+                validation_func=validation_func,
             )
 
         else:  # set args that may not have been set if `self.find_label_issues()` wasn't called yet
@@ -592,6 +599,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         inverse_noise_matrix=None,
         save_space=False,
         clf_kwargs={},
+        validation_func=None,
     ):
         """
         Identifies potential label issues in the dataset using confident learning.
@@ -723,6 +731,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                     converge_latent_estimates=self.converge_latent_estimates,
                     seed=self.seed,
                     clf_kwargs=self.clf_kwargs,
+                    validation_func=validation_func,
                 )
             else:  # pred_probs is provided by user (assumed holdout probabilities)
                 if self.verbose:
@@ -753,6 +762,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                 cv_n_folds=self.cv_n_folds,
                 seed=self.seed,
                 clf_kwargs=self.clf_kwargs,
+                validation_func=validation_func,
             )
         # If needed, compute the confident_joint (e.g. occurs if noise_matrix was given)
         if self.confident_joint is None:

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -373,7 +373,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         validation_func : callable, optional
           Optional callable function that takes two arguments, `X_val`, `y_val`.
-          Specifies how to map the validation data split in the cross validation 
+          Specifies how to map the validation data split in the cross validation
           step into the appropriate format to pass into `clf`'s ``fit()`` method.
 
         Returns

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -648,6 +648,7 @@ def estimate_confident_joint_and_cv_pred_proba(
     seed=None,
     calibrate=True,
     clf_kwargs={},
+    validation_func=None,
 ):
     """Estimates ``P(labels, y)``, the confident counts of the latent
     joint distribution of true and noisy labels
@@ -712,6 +713,10 @@ def estimate_confident_joint_and_cv_pred_proba(
     clf_kwargs : dict, optional
       Optional keyword arguments to pass into `clf`'s ``fit()`` method.
 
+    validation_func : callable, optional
+      Optional callable function that takes two arguments, `X_val`, `y_val`. 
+      Specifies how to map the validation data split in the cross validation 
+      step into the appropriate format to pass into `clf`'s ``fit()`` method.
 
     Returns
     ------
@@ -764,8 +769,14 @@ def estimate_confident_joint_and_cv_pred_proba(
                 )
                 missing_class_inds[missing_class] = dup_idx
 
+        # Map validation data into appropriate format to pass into classifier clf
+        if validation_func is None:
+            validation_kwargs = {}
+        elif callable(validation_func):
+            validation_kwargs = validation_func(X_holdout_cv, s_holdout_cv)
+
         # Fit classifier clf to training set, predict on holdout set, and update pred_probs.
-        clf_copy.fit(X_train_cv, s_train_cv, **clf_kwargs)
+        clf_copy.fit(X_train_cv, s_train_cv, **clf_kwargs, **validation_kwargs)
         pred_probs_cv = clf_copy.predict_proba(X_holdout_cv)  # P(labels = k|x) # [:,1]
 
         # Replace predictions for duplicated indices with dummy predictions:
@@ -799,6 +810,7 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
     py_method="cnt",
     seed=None,
     clf_kwargs={},
+    validation_func=None,
 ):
     """This function computes the out-of-sample predicted
     probability ``P(label=k|x)`` for every example x in `X` using cross
@@ -862,6 +874,11 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
     clf_kwargs : dict, optional
       Optional keyword arguments to pass into `clf`'s ``fit()`` method.
 
+    validation_func : callable, optional
+      Optional callable function that takes two arguments, `X_val`, `y_val`.
+      Specifies how to map the validation data split in the cross validation 
+      step into the appropriate format to pass into `clf`'s ``fit()`` method.
+
     Returns
     ------
     tuple
@@ -876,6 +893,7 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
         thresholds=thresholds,
         seed=seed,
         clf_kwargs=clf_kwargs,
+        validation_func=validation_func,
     )
 
     py, noise_matrix, inv_noise_matrix = estimate_latent(
@@ -896,6 +914,7 @@ def estimate_cv_predicted_probabilities(
     cv_n_folds=5,
     seed=None,
     clf_kwargs={},
+    validation_func=None,
 ):
     """This function computes the out-of-sample predicted
     probability [P(label=k|x)] for every example in X using cross
@@ -928,6 +947,11 @@ def estimate_cv_predicted_probabilities(
     clf_kwargs : dict, optional
       Optional keyword arguments to pass into `clf`'s ``fit()`` method.
 
+    validation_func : callable, optional
+      Optional callable function that takes two arguments, `X_val`, `y_val`.
+      Specifies how to map the validation data split in the cross validation 
+      step into the appropriate format to pass into `clf`'s ``fit()`` method.
+
     Returns
     --------
     pred_probs : np.array
@@ -943,6 +967,7 @@ def estimate_cv_predicted_probabilities(
         cv_n_folds=cv_n_folds,
         seed=seed,
         clf_kwargs=clf_kwargs,
+        validation_func=validation_func,
     )[-1]
 
 
@@ -956,6 +981,7 @@ def estimate_noise_matrices(
     converge_latent_estimates=True,
     seed=None,
     clf_kwargs={},
+    validation_func=None,
 ):
     """Estimates the `noise_matrix` of shape ``(K, K)``. This is the
     fraction of examples in every class, labeled as every other class. The
@@ -1008,6 +1034,11 @@ def estimate_noise_matrices(
     clf_kwargs : dict, optional
       Optional keyword arguments to pass into `clf`'s ``fit()`` method.
 
+    validation_func : callable, optional
+      Optional callable function that takes two arguments, `X_val`, `y_val`.
+      Specifies how to map the validation data split in the cross validation 
+      step into the appropriate format to pass into `clf`'s ``fit()`` method.
+
     Returns
     ------
     tuple
@@ -1022,6 +1053,7 @@ def estimate_noise_matrices(
         converge_latent_estimates=converge_latent_estimates,
         seed=seed,
         clf_kwargs=clf_kwargs,
+        validation_func=validation_func,
     )[1:-2]
 
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -714,9 +714,8 @@ def estimate_confident_joint_and_cv_pred_proba(
       Optional keyword arguments to pass into `clf`'s ``fit()`` method.
 
     validation_func : callable, optional
-      Optional callable function that takes two arguments, `X_val`, `y_val`.
-      Specifies how to map the validation data split in the cross validation
-      step into the appropriate format to pass into `clf`'s ``fit()`` method.
+      Specifies how to map the validation data split in cross-validation as input for ``clf.fit()``.
+      For details, see the documentation of :py:meth:`CleanLearning.fit<cleanlab.classification.CleanLearning.fit>`
 
     Returns
     ------
@@ -774,6 +773,8 @@ def estimate_confident_joint_and_cv_pred_proba(
             validation_kwargs = {}
         elif callable(validation_func):
             validation_kwargs = validation_func(X_holdout_cv, s_holdout_cv)
+        else:
+            raise TypeError("validation_func must be callable function with args: X_val, y_val")
 
         # Fit classifier clf to training set, predict on holdout set, and update pred_probs.
         clf_copy.fit(X_train_cv, s_train_cv, **clf_kwargs, **validation_kwargs)
@@ -875,9 +876,8 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
       Optional keyword arguments to pass into `clf`'s ``fit()`` method.
 
     validation_func : callable, optional
-      Optional callable function that takes two arguments, `X_val`, `y_val`.
-      Specifies how to map the validation data split in the cross validation
-      step into the appropriate format to pass into `clf`'s ``fit()`` method.
+      Specifies how to map the validation data split in cross-validation as input for ``clf.fit()``.
+      For details, see the documentation of :py:meth:`CleanLearning.fit<cleanlab.classification.CleanLearning.fit>`
 
     Returns
     ------
@@ -948,9 +948,8 @@ def estimate_cv_predicted_probabilities(
       Optional keyword arguments to pass into `clf`'s ``fit()`` method.
 
     validation_func : callable, optional
-      Optional callable function that takes two arguments, `X_val`, `y_val`.
-      Specifies how to map the validation data split in the cross validation
-      step into the appropriate format to pass into `clf`'s ``fit()`` method.
+      Specifies how to map the validation data split in cross-validation as input for ``clf.fit()``.
+      For details, see the documentation of :py:meth:`CleanLearning.fit<cleanlab.classification.CleanLearning.fit>`
 
     Returns
     --------
@@ -1035,9 +1034,8 @@ def estimate_noise_matrices(
       Optional keyword arguments to pass into `clf`'s ``fit()`` method.
 
     validation_func : callable, optional
-      Optional callable function that takes two arguments, `X_val`, `y_val`.
-      Specifies how to map the validation data split in the cross validation
-      step into the appropriate format to pass into `clf`'s ``fit()`` method.
+      Specifies how to map the validation data split in cross-validation as input for ``clf.fit()``.
+      For details, see the documentation of :py:meth:`CleanLearning.fit<cleanlab.classification.CleanLearning.fit>`
 
     Returns
     ------

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -714,8 +714,8 @@ def estimate_confident_joint_and_cv_pred_proba(
       Optional keyword arguments to pass into `clf`'s ``fit()`` method.
 
     validation_func : callable, optional
-      Optional callable function that takes two arguments, `X_val`, `y_val`. 
-      Specifies how to map the validation data split in the cross validation 
+      Optional callable function that takes two arguments, `X_val`, `y_val`.
+      Specifies how to map the validation data split in the cross validation
       step into the appropriate format to pass into `clf`'s ``fit()`` method.
 
     Returns
@@ -876,7 +876,7 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
 
     validation_func : callable, optional
       Optional callable function that takes two arguments, `X_val`, `y_val`.
-      Specifies how to map the validation data split in the cross validation 
+      Specifies how to map the validation data split in the cross validation
       step into the appropriate format to pass into `clf`'s ``fit()`` method.
 
     Returns
@@ -949,7 +949,7 @@ def estimate_cv_predicted_probabilities(
 
     validation_func : callable, optional
       Optional callable function that takes two arguments, `X_val`, `y_val`.
-      Specifies how to map the validation data split in the cross validation 
+      Specifies how to map the validation data split in the cross validation
       step into the appropriate format to pass into `clf`'s ``fit()`` method.
 
     Returns
@@ -1036,7 +1036,7 @@ def estimate_noise_matrices(
 
     validation_func : callable, optional
       Optional callable function that takes two arguments, `X_val`, `y_val`.
-      Specifies how to map the validation data split in the cross validation 
+      Specifies how to map the validation data split in the cross validation
       step into the appropriate format to pass into `clf`'s ``fit()`` method.
 
     Returns

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -293,6 +293,30 @@ def test_aux_inputs():
     )
 
 
+class LogisticRegressionWithValidationData(LogisticRegression):
+    def fit(self, X, y, X_val=None, y_val=None):
+        super().fit(X, y)
+
+        # Final fit() call does not use validation data
+        # Checks to prevent arg missing error
+        if X_val is not None or y_val is not None:
+            print(self.score(X_val, y_val))
+
+
+def val_func(X_val, y_val):
+    return {"X_val": X_val, "y_val": y_val}
+
+
+def test_validation_data():
+    data = DATA
+    cl = CleanLearning(clf=LogisticRegressionWithValidationData())
+    cl.fit(
+        data["X_train"],
+        data["labels"],
+        validation_func=val_func,
+    )
+
+
 def test_raise_error_no_clf_fit():
     class struct(object):
         def predict(self):


### PR DESCRIPTION
Added an arg in CleanLearning.fit() which allows users to pass in a callable function to map the validation data into a format that is accepted by `clf`'s `fit()` method.