### PR TITLE
Add static type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,19 @@ jobs:
       - name: Test with coverage
         run: pytest --verbose --cov=cleanlab/ --cov-config .coveragerc --cov-report=xml
       - uses: codecov/codecov-action@v2
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .  # install dependencies
+          pip install -r requirements-dev.txt  # install development dependencies and type stubs
+      - name: Type check
+        run: mypy --install-types --non-interactive cleanlab
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,22 @@
+[mypy]
+
+[mypy-sklearn.*]
+ignore_missing_imports = True
+
+[mypy-scikeras.*]
+ignore_missing_imports = True
+
+[mypy-tensorflow.*]
+ignore_missing_imports = True
+
+[mypy-fasttext.*]
+ignore_missing_imports = True
+
+[mypy-IPython.display.*]
+ignore_missing_imports = True
+
+[mypy-torchvision.*]
+ignore_missing_imports = True
+
+[mypy-tqdm.*]
+ignore_missing_imports = True

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -1131,10 +1131,10 @@ def _converge_estimates(
 
 
 def get_confident_thresholds(
-    labels: np.array,
-    pred_probs: np.array,
+    labels: np.ndarray,
+    pred_probs: np.ndarray,
     multi_label: bool = False,
-) -> np.array:
+) -> np.ndarray:
     """Returns expected (average) "self-confidence" for each class.
 
     The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
@@ -1181,7 +1181,9 @@ def get_confident_thresholds(
         # Compute thresholds = p(label=k | k in set of given labels)
         k_in_l = np.array([[k in lst for lst in labels] for k in unique_classes])
         # The avg probability of class given that the label is represented.
-        confident_thresholds = [np.mean(pred_probs[:, k][k_in_l[k]]) for k in unique_classes]
+        confident_thresholds = np.array(
+            [np.mean(pred_probs[:, k][k_in_l[k]]) for k in unique_classes]
+        )
     else:
         confident_thresholds = np.array(
             [np.mean(pred_probs[:, k][labels == k]) for k in range(pred_probs.shape[1])]

--- a/cleanlab/internal/label_quality_utils.py
+++ b/cleanlab/internal/label_quality_utils.py
@@ -21,10 +21,10 @@ from cleanlab.count import get_confident_thresholds
 
 
 def _subtract_confident_thresholds(
-    labels: np.array,
-    pred_probs: np.array,
+    labels: np.ndarray,
+    pred_probs: np.ndarray,
     multi_label: bool = False,
-) -> np.array:
+) -> np.ndarray:
     """Returns adjusted predicted probabilities by subtracting the class confident thresholds and renormalizing.
 
     The confident class threshold for a class j is the expected (average) "self-confidence" for class j.
@@ -71,7 +71,7 @@ def _subtract_confident_thresholds(
     return pred_probs_adj
 
 
-def get_normalized_entropy(pred_probs: np.array, min_allowed_prob=1e-6) -> np.array:
+def get_normalized_entropy(pred_probs: np.ndarray, min_allowed_prob: float = 1e-6) -> np.ndarray:
     """Returns the normalized entropy of pred_probs.
 
     Normalized entropy is between 0 and 1. Higher values of entropy indicate higher uncertainty in the model's prediction of the correct label.

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -49,13 +49,13 @@ from cleanlab.internal.label_quality_utils import (
 
 
 def order_label_issues(
-    label_issues_mask: np.array,
-    labels: np.array,
-    pred_probs: np.array,
+    label_issues_mask: np.ndarray,
+    labels: np.ndarray,
+    pred_probs: np.ndarray,
     *,
     rank_by: str = "self_confidence",
     rank_by_kwargs: dict = {},
-) -> np.array:
+) -> np.ndarray:
     """Sorts label issues by label quality score.
 
     Default label quality score is "self_confidence".
@@ -107,12 +107,12 @@ def order_label_issues(
 
 
 def get_label_quality_scores(
-    labels: np.array,
-    pred_probs: np.array,
+    labels: np.ndarray,
+    pred_probs: np.ndarray,
     *,
     method: str = "self_confidence",
     adjust_pred_probs: bool = False,
-) -> np.array:
+) -> np.ndarray:
     """Returns label quality scores for each datapoint.
 
     This is a function to compute label-quality scores for classification datasets,
@@ -223,16 +223,16 @@ def get_label_quality_scores(
 
 
 def get_label_quality_ensemble_scores(
-    labels: np.array,
-    pred_probs_list: List[np.array],
+    labels: np.ndarray,
+    pred_probs_list: List[np.ndarray],
     *,
     method: str = "self_confidence",
     adjust_pred_probs: bool = False,
     weight_ensemble_members_by: str = "accuracy",
-    custom_weights: np.array = None,
+    custom_weights: np.ndarray = None,
     log_loss_search_T_values: List[float] = [1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 2e2],
     verbose: bool = True,
-) -> np.array:
+) -> np.ndarray:
     """Returns label quality scores based on predictions from an ensemble of models.
 
     This is a function to compute label-quality scores for classification datasets,
@@ -352,14 +352,13 @@ def get_label_quality_ensemble_scores(
             pred_probs_avg_log_loss_weighted_temp = sum(
                 [neg_log_loss_weights_temp[i] * p for i, p in enumerate(pred_probs_list)]
             )
-
             # evaluate log loss with this weighted average pred_probs
             eval_log_loss = log_loss(labels, pred_probs_avg_log_loss_weighted_temp)
 
             # check if eval_log_loss is the best so far (lower the better)
             if best_eval_log_loss > eval_log_loss:
                 best_eval_log_loss = eval_log_loss
-                pred_probs_avg_log_loss_weighted = pred_probs_avg_log_loss_weighted_temp.copy()
+                pred_probs_avg_log_loss_weighted = pred_probs_avg_log_loss_weighted_temp
                 neg_log_loss_weights = neg_log_loss_weights_temp.copy()
 
     # Generate scores for each model's pred_probs
@@ -403,6 +402,7 @@ def get_label_quality_ensemble_scores(
         label_quality_scores = (scores_ensemble * weights).sum(axis=1)
 
     elif weight_ensemble_members_by == "log_loss_search":
+        assert neg_log_loss_weights is not None
         weights = neg_log_loss_weights  # Weight by exp(t * -log_loss) where t is found by searching through log_loss_search_T_values
         if verbose:
             print(
@@ -440,9 +440,9 @@ def get_label_quality_ensemble_scores(
 
 
 def get_self_confidence_for_each_label(
-    labels: np.array,
-    pred_probs: np.array,
-) -> np.array:
+    labels: np.ndarray,
+    pred_probs: np.ndarray,
+) -> np.ndarray:
     """Returns the self-confidence label-quality score for each datapoint.
 
     This is a function to compute label-quality scores for classification datasets,
@@ -476,9 +476,9 @@ def get_self_confidence_for_each_label(
 
 
 def get_normalized_margin_for_each_label(
-    labels: np.array,
-    pred_probs: np.array,
-) -> np.array:
+    labels: np.ndarray,
+    pred_probs: np.ndarray,
+) -> np.ndarray:
     """Returns the "normalized margin" label-quality score for each datapoint.
 
     This is a function to compute label-quality scores for classification datasets,
@@ -518,8 +518,8 @@ def get_normalized_margin_for_each_label(
 
 
 def get_confidence_weighted_entropy_for_each_label(
-    labels: np.array, pred_probs: np.array
-) -> np.array:
+    labels: np.ndarray, pred_probs: np.ndarray
+) -> np.ndarray:
     """Returns the "confidence weighted entropy" label-quality score for each datapoint.
 
     This is a function to compute label-quality scores for classification datasets,
@@ -547,7 +547,7 @@ def get_confidence_weighted_entropy_for_each_label(
     self_confidence = np.clip(self_confidence, a_min=MIN_ALLOWED, a_max=None)
 
     # Divide entropy by self confidence
-    label_quality_scores = get_normalized_entropy(**{"pred_probs": pred_probs}) / self_confidence
+    label_quality_scores = get_normalized_entropy(pred_probs) / self_confidence
 
     # Rescale
     clipped_scores = np.clip(label_quality_scores, a_min=MIN_ALLOWED, a_max=None)
@@ -557,8 +557,8 @@ def get_confidence_weighted_entropy_for_each_label(
 
 
 def get_knn_distance_ood_scores(
-    features: np.array, nbrs: NearestNeighbors, k: int = None
-) -> np.array:
+    features: np.ndarray, nbrs: NearestNeighbors, k: int = None
+) -> np.ndarray:
     """Returns the KNN distance out-of-distribution (OOD) score for each datapoint.
 
     This is a function to compute OOD scores where higher scores indicate the datapoint is more likely to be OOD.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,11 @@
 # Python dependencies for development
 coverage != 6.3, != 6.3.*
+mypy
+pandas-stubs
 pre-commit
 pytest
 pytest-cov
+requests
 scipy
 torch
 torchvision
-requests


### PR DESCRIPTION
Our package doesn't have type annotations everywhere, so we can't use
mypy in strict mode just yet. Still, adding type checking in CI is
valuable, so we don't have unchecked annotations in our code.

This patch includes basic fixes to make type checking pass, including
switching the incorrect `np.array` type annotation for `np.ndarray` and
adding some assertions for flow-sensitive typing.