### PR TITLE
error for missing classes, consistency on determining num_classes, code cleanup 

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -1174,14 +1174,13 @@ def get_confident_thresholds(
     Returns
     -------
     confident_thresholds : np.array
-      An array of shape ``(num_classes, )``.
-    """
+      An array of shape ``(num_classes, )``."""
 
+    # Assumes all classes are represented in labels: [0, 1, 2, ... num_classes - 1]
+    unique_classes = range(
+        get_num_classes(labels=labels, pred_probs=pred_probs, multi_label=multi_label)
+    )
     if multi_label:
-        # Assumes all classes are represented in labels: [0, 1, 2, ... num_classes - 1]
-        unique_classes = range(
-            get_num_classes(labels=labels, pred_probs=pred_probs, multi_label=multi_label)
-        )
         # Compute thresholds = p(label=k | k in set of given labels)
         k_in_l = np.array([[k in lst for lst in labels] for k in unique_classes])
         # The avg probability of class given that the label is represented.
@@ -1190,6 +1189,6 @@ def get_confident_thresholds(
         )
     else:
         confident_thresholds = np.array(
-            [np.mean(pred_probs[:, k][labels == k]) for k in range(pred_probs.shape[1])]
+            [np.mean(pred_probs[:, k][labels == k]) for k in unique_classes]
         )
     return confident_thresholds

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -34,6 +34,7 @@ from cleanlab.internal.util import (
     round_preserving_row_totals,
     onehot2int,
     int2onehot,
+    get_num_classes,
 )
 
 # tqdm is a module used to print time-to-complete when multiprocessing is used.
@@ -233,8 +234,10 @@ def find_label_issues(
         label_counts = value_counts([i for lst in labels for i in lst])
     else:
         label_counts = value_counts(labels)
-    # Number of classes labels
-    K = len(pred_probs.T)
+    # Number of classes
+    K = get_num_classes(
+        labels=labels, pred_probs=pred_probs, label_matrix=confident_joint, multi_label=multi_label
+    )
     # Boolean set to true if dataset is large
     big_dataset = K * len(labels) > 1e8
     # Ensure labels are of type np.array()

--- a/cleanlab/internal/label_quality_utils.py
+++ b/cleanlab/internal/label_quality_utils.py
@@ -85,11 +85,8 @@ def get_normalized_entropy(pred_probs: np.ndarray, min_allowed_prob: float = 1e-
     Parameters
     ----------
     pred_probs : np.array (shape (N, K))
-      P(label=k|x) is a matrix with K model-predicted probabilities.
       Each row of this matrix corresponds to an example x and contains the model-predicted
-      probabilities that x belongs to each possible class.
-      The columns must be ordered such that these probabilities correspond to class 0,1,2,...
-      `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
+      probabilities that x belongs to each possible class: P(label=k|x)
 
     min_allowed_prob : float, default=1e-6
       Minimum allowed probability value. Entries of `pred_probs` below this value will be clipped to this value.
@@ -97,7 +94,7 @@ def get_normalized_entropy(pred_probs: np.ndarray, min_allowed_prob: float = 1e-
     Returns
     -------
     entropy : np.array (float)
-
+      Each element is the normalized entropy of the corresponding row of ``pred_probs``.
     """
 
     num_classes = pred_probs.shape[1]

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -123,18 +123,10 @@ def clip_values(x, low=0.0, high=1.0, new_sum=None):
         """Clip a into range [low,high]"""
         return min(max(a, low), high)
 
-    # Vectorize clip_range for efficiency with np.arrays.
-    vectorized_clip = np.vectorize(clip_range)
-
-    # Store previous sum
-    prev_sum = sum(x) if new_sum is None else new_sum
-
-    # Clip all values (efficiently).
-    x = vectorized_clip(x)
-
-    # Re-normalized values to sum to previous sum.
-    x = x * prev_sum / float(sum(x))
-
+    vectorized_clip = np.vectorize(clip_range)  # Vectorize clip_range for efficiency with np.arrays
+    prev_sum = sum(x) if new_sum is None else new_sum  # Store previous sum
+    x = vectorized_clip(x)  # Clip all values (efficiently)
+    x = x * prev_sum / float(sum(x))  # Re-normalized values to sum to previous sum
     return x
 
 
@@ -489,7 +481,7 @@ def append_extra_datapoint(to_data, from_data, index):
 
 def get_num_classes(labels=None, pred_probs=None, label_matrix=None, multi_label=None):
     """Determines the number of classes based on information considered in a
-    canonical ordering. label_matrix can be: noise_matrix, inverse_noise_matrix,
+    canonical ordering. label_matrix can be: noise_matrix, inverse_noise_matrix, confident_joint,
     or any other K x K matrix where K = number of classes.
     """
     if pred_probs is not None:  # pred_probs is number 1 source of truth
@@ -500,6 +492,9 @@ def get_num_classes(labels=None, pred_probs=None, label_matrix=None, multi_label
             raise ValueError(f"label matrix must be K x K, not {label_matrix.shape}")
         else:
             return label_matrix.shape[0]
+
+    if labels is None:
+        raise ValueError("Cannot determine number of classes from None input")
 
     return num_unique_classes(labels, multi_label=multi_label)
 

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -67,6 +67,14 @@ def assert_valid_inputs(X, y, pred_probs=None, multi_label=False):
             raise ValueError("Values in pred_probs must be between 0 and 1.")
         if X is not None:
             warnings.warn("When X and pred_probs are both provided, former may be ignored.")
+        if not multi_label:  # TODO: can remove this clause once missing classes are supported
+            num_unique_labels = len(np.unique(y))
+            if num_unique_labels != pred_probs.shape[1]:
+                raise ValueError(
+                    "All classes in (0,1,2,...,K-1) must be present in labels "
+                    f"with K = pred_probs.shape[1] = {pred_probs.shape[1]} in your case, "
+                    f"but your labels only contain {num_unique_labels} unique values."
+                )
 
 
 def assert_valid_class_labels(y):
@@ -78,11 +86,12 @@ def assert_valid_class_labels(y):
 
     unique_classes = np.unique(y)
     if len(unique_classes) < 2:
-        raise ValueEror("Labels must contain at least 2 classes.")
+        raise ValueError("Labels must contain at least 2 classes.")
 
-    if any(unique_classes != np.arange(len(unique_classes))):
-        msg = "cleanlab requires zero-indexed labels (0,1,2,..,K-1), but in "
-        msg += "your case: np.unique(labels) = {}".format(str(unique_classes))
+    if (unique_classes != np.arange(len(unique_classes))).any():
+        msg = "cleanlab requires zero-indexed integer labels (0,1,2,..,K-1), but in "
+        msg += "your case: np.unique(labels) = {}. ".format(str(unique_classes))
+        msg += "Every class in (0,1,2,..,K-1) must be present in labels as well."
         raise TypeError(msg)
 
 
@@ -128,5 +137,5 @@ def labels_to_array(y):
             return np.asarray(y)
         except:
             raise ValueError(
-                "List of labels must be convertable to 1D numpy array via: np.array(labels)"
+                "List of labels must be convertable to 1D numpy array via: np.array(labels)."
             )

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -156,7 +156,7 @@ def get_label_quality_scores(
       - ``'self_confidence'``: ``P[k]``
       - ``'confidence_weighted_entropy'``: ``entropy(P) / self_confidence``
 
-      Let ``C = {0, 1, ..., K}`` denote the classification task's specified set of classes.
+      Let ``C = {0, 1, ..., K}`` denote the specified set of classes for our classification task.
 
       The normalized_margin score works better for identifying class conditional label errors,
       i.e. examples for which another label in C is appropriate but the given label is not.

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -473,3 +473,27 @@ def test_issue_158():
     assert not np.any(np.isnan(py))
     assert not np.any(np.isnan(noise_matrix))
     assert not np.any(np.isnan(inv_noise_matrix))
+
+
+def test_toofew_classes():
+    try:
+        labels = np.array([0, 0])
+        pred_probs = np.array([[0.3, 0.7], [0.2, 0.8]])
+        issues = filter.find_label_issues(labels, pred_probs)
+        assert False
+    except ValueError as e:
+        assert "must contain at least 2 classes" in str(e)
+    else:
+        raise Exception("expected test to raise ValueError")
+
+
+def test_missing_classes():  # TODO: can remove this test once missing classes are supported
+    try:
+        labels = np.array([0, 0, 1, 1])
+        pred_probs = np.array([[0.1, 0.7, 0.2], [0.1, 0.8, 0.1], [0.7, 0.2, 0.1], [0.8, 0.1, 0.1]])
+        issues = filter.find_label_issues(labels, pred_probs)
+        assert False
+    except ValueError as e:
+        assert "All classes" in str(e)
+    else:
+        raise Exception("expected test to raise ValueError")


### PR DESCRIPTION
1.  Adds explicit informative error statements when there is is missing class in labels 
I left # TODO comments in there for this logic so it is easily removed when we support missing classes @cgnorthcutt  (just search for: 'missing classes' in the code).

Addresses issue:  https://github.com/cleanlab/cleanlab/issues/288

2.  Aims to use the `get_num_classes()` helper function to establish the number of classes throughout the codebase. This way we can ensure consistency.  Since `get_num_classes` refers to `pred_probs` as its number 1 source of truth for the number of classes, this addresses issue:
https://github.com/cleanlab/cleanlab/issues/44

3.  Miscellaneous code cleanup.