### PR TITLE
Standardize naming on K, num_classes and N, num_examples

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -356,7 +356,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           :py:meth:`self.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`,
           e.g. as a ``np.array``, then some functionality like training with sample weights may be disabled.
 
-        sample_weight : array-like of shape (n_samples,), optional
+        sample_weight : array-like of shape (N,), optional
           Array of weights that are assigned to individual samples.
           If not provided, samples may still be weighted by the estimated noise in the class they are labeled as.
 

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -27,16 +27,17 @@ meaning it must define four functions:
 * ``clf.predict(X)``
 * ``clf.score(X, y, sample_weight=None)``
 
-where `X` contains data, `y` contains labels (with elements in 0, 1, ..., K-1,
-where K is the number of classes), and `sample_weight` re-weights examples in
-the loss function while training.
+where `X` contains data (i.e. features), `y` contains labels (with elements in 0, 1, ..., K-1,
+where K is the number of classes). The first index of `X` and of `y` should correspond to the different examples in the dataset,
+such that ``len(X) = len(y) = N`` (sample-size). Here `sample_weight` re-weights examples in
+the loss function while training (supporting `sample_weight` in your classifier is recommended but optional).
 
-Furthermore, the estimator should be correctly clonable via
+Furthermore, your estimator should be correctly clonable via
 `sklearn.base.clone <https://scikit-learn.org/stable/modules/generated/sklearn.base.clone.html>`_:
 cleanlab internally creates multiple instances of the
 estimator, and if you e.g. manually wrap a PyTorch model, you must ensure that
 every call to the estimator's ``__init__()`` creates an independent instance of
-the model.
+the model (for sklearn compatibility, the weights of neural network models should typically be initialized inside of ``clf.fit()``).
 
 Note
 ----
@@ -666,7 +667,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           * *label_quality*: Numeric score that measures the quality of each label (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
           * *given_label*: Integer indices corresponding to the class label originally given for this example (same as `labels` input). Included here for ease of comparison against `clf` predictions, only present if "predicted_label" column is present.
           * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model. Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
-          * *sample_weight*: Numeric values used to weight examples during the final training of `clf` in :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. This column not be present after `self.find_label_issues()` but may be added after call to :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. For more precise definition of sample weights, see documentation of :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`
+          * *sample_weight*: Numeric values used to weight examples during the final training of `clf` in :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. This column may not be present after `self.find_label_issues()` but may be added after call to :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. For more precise definition of sample weights, see documentation of :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`
         """
 
         # Check inputs

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -259,7 +259,7 @@ def _compute_confident_joint_multi_label(
         P(label=k|x) is a matrix with K model-predicted probabilities.
         Each row of this matrix corresponds to an example `x` and contains the model-predicted
         probabilities that `x` belongs to each possible class.
-        The columns must be ordered such that these probabilities correspond to class 0, 1, ..., K-1.
+        The columns must be ordered such that these probabilities correspond to class 0, 1,num_classes ..., K-1.
         `pred_probs` must be out-of-sample (ideally should have been computed using 3+ fold cross-validation).
 
     thresholds : iterable (list or np.array) of shape (K, 1)  or (K,)
@@ -1174,7 +1174,7 @@ def get_confident_thresholds(
     Returns
     -------
     confident_thresholds : np.array
-      An array of shape ``(num_classes, )``."""
+      An array of shape ``(K, )`` where K = number of classes."""
 
     # Assumes all classes are represented in labels: [0, 1, 2, ... num_classes - 1]
     unique_classes = range(

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -259,7 +259,7 @@ def _compute_confident_joint_multi_label(
         P(label=k|x) is a matrix with K model-predicted probabilities.
         Each row of this matrix corresponds to an example `x` and contains the model-predicted
         probabilities that `x` belongs to each possible class.
-        The columns must be ordered such that these probabilities correspond to class 0,1,2,...
+        The columns must be ordered such that these probabilities correspond to class 0, 1, ..., K-1.
         `pred_probs` must be out-of-sample (ideally should have been computed using 3+ fold cross-validation).
 
     thresholds : iterable (list or np.array) of shape (K, 1)  or (K,)

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -259,7 +259,7 @@ def _compute_confident_joint_multi_label(
         P(label=k|x) is a matrix with K model-predicted probabilities.
         Each row of this matrix corresponds to an example `x` and contains the model-predicted
         probabilities that `x` belongs to each possible class.
-        The columns must be ordered such that these probabilities correspond to class 0, 1,num_classes ..., K-1.
+        The columns must be ordered such that these probabilities correspond to class 0, 1, 2,..., K-1.
         `pred_probs` must be out-of-sample (ideally should have been computed using 3+ fold cross-validation).
 
     thresholds : iterable (list or np.array) of shape (K, 1)  or (K,)
@@ -1174,7 +1174,7 @@ def get_confident_thresholds(
     Returns
     -------
     confident_thresholds : np.array
-      An array of shape ``(K, )`` where K = number of classes."""
+      An array of shape ``(K, )`` where K is the number of classes."""
 
     # Assumes all classes are represented in labels: [0, 1, 2, ... num_classes - 1]
     unique_classes = range(

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -156,7 +156,7 @@ def get_label_quality_scores(
       - ``'self_confidence'``: ``P[k]``
       - ``'confidence_weighted_entropy'``: ``entropy(P) / self_confidence``
 
-      Let ``C = {0, 1, ..., K}`` denote the specified set of classes for our classification task.
+      Let ``C = {0, 1, ..., K-1}`` denote the specified set of classes for our classification task.
 
       The normalized_margin score works better for identifying class conditional label errors,
       i.e. examples for which another label in C is appropriate but the given label is not.


### PR DESCRIPTION
Reviewed code to make sure that `num_classes` or `K` is used to refer to number of classes, and `num_examples` or `N` is used to refer to number of examples. 
Minor docstring changes, the rest of the code looks good to me.