### PR TITLE
Ignore UserWarning on test_get_outlier_scores

### DIFF
--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -381,6 +381,7 @@ def test_unsupported_method_for_adjust_pred_probs():
         _ = rank.get_label_quality_scores(labels, pred_probs, adjust_pred_probs=True, method=method)
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_get_outlier_scores():
     X_train = data["X_train"]
     X_test = data["X_test"]


### PR DESCRIPTION
Running the test_rank.py tests currently gives a `UserWarning`:

```
$ pytest tests/test_rank.py 
========================================================================================================================== test session starts ==========================================================================================================================
platform linux -- Python 3.7.9, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/elias/projects/cleanlab
plugins: cov-3.0.0
collected 38 items                                                                                                                                                                                                                                                      

tests/test_rank.py ......................................                                                                                                                                                                                                         [100%]

=========================================================================================================================== warnings summary ============================================================================================================================
tests/test_rank.py::test_get_outlier_scores
  /home/elias/projects/cleanlab/cleanlab/rank.py:629: UserWarning: Chosen k=5 cannot be greater than n_neighbors=5 which was used when fitting NearestNeighbors object! Value of k changed to k=5.
    UserWarning,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================================== 38 passed, 1 warning in 0.47s =====================================================================================================================
```

I've added a warning filter for the offending test.