### PR TITLE
improve use experience remove link to tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ cleanlab.dataset.health_summary(labels, confident_joint=cl.confident_joint)
 
 Get started with: [documentation](https://docs.cleanlab.ai/), [tutorials](https://docs.cleanlab.ai/stable/tutorials/image.html), [examples](https://github.com/cleanlab/examples), and [blogs](https://cleanlab.ai/blog/).
 
- - [Learn how to](https://docs.cleanlab.ai/stable/tutorials/index) run cleanlab on your own data in just 5 minutes!
- - Quickstart with 5-minute tutorials for classification with: [image](https://docs.cleanlab.ai/stable/tutorials/image.html), [text](https://docs.cleanlab.ai/stable/tutorials/text.html), [audio](https://docs.cleanlab.ai/stable/tutorials/audio.html), and [tabular](https://docs.cleanlab.ai/stable/tutorials/tabular.html) data.
+ - Learn how to run cleanlab on your own data in just 5 minutes for classification with: [image](https://docs.cleanlab.ai/stable/tutorials/image.html), [text](https://docs.cleanlab.ai/stable/tutorials/text.html), [audio](https://docs.cleanlab.ai/stable/tutorials/audio.html), and [tabular](https://docs.cleanlab.ai/stable/tutorials/tabular.html) data.
 
 
 [![pypi](https://img.shields.io/pypi/v/cleanlab.svg)](https://pypi.org/pypi/cleanlab/)


### PR DESCRIPTION
The previous link took you to a tutorials page with lots of options including tutorials that were for data-centric AI workflows, and computing cross validated probs, etc. if this is supposed to be the very first thing users click on to get started, we want it to take them straight to a place where they can get started in 5 minutes, not a list of things where they have to figure out what to click next.

Updated to fix this, which also reduced the length :)