### PR TITLE
validation.py: Annotate function args and return values

### DIFF
--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -131,7 +131,7 @@ def assert_indexing_works(
         raise TypeError(msg)
 
 
-def labels_to_array(y: Union[list, np.ndarray, pd.Series, pd.DataFrame]) -> np.ndarray:
+def labels_to_array(y: Union[list, np.ndarray, np.generic, pd.Series, pd.DataFrame]) -> np.ndarray:
     """Converts different types of label objects to 1D numpy array and checks validity
 
     Parameters

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -122,9 +122,9 @@ def assert_indexing_works(
         idx = [0, length_X - 1]
     try:
         if isinstance(X, (pd.DataFrame, pd.Series)):
-            _ = X.iloc[idx]
+            _ = X.iloc[idx]  # type: ignore
         else:
-            _ = X[idx]
+            _ = X[idx]  # type: ignore
     except:
         msg = "Data features X must support list-based indexing; i.e. one of these must work: \n"
         msg += "1)  X[index_list] where say index_list = [0,1,3,10], or \n"

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -18,7 +18,7 @@
 Checks to ensure valid inputs for various methods.
 """
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 import warnings
 import numpy as np
 import pandas as pd
@@ -26,7 +26,7 @@ import pandas as pd
 
 def assert_valid_inputs(
     X: Any,
-    y: np.ndarray,
+    y: Union[list, np.ndarray, pd.Series, pd.DataFrame],
     pred_probs: Optional[np.ndarray] = None,
     multi_label: bool = False,
 ) -> None:
@@ -88,7 +88,7 @@ def assert_valid_class_labels(y: np.ndarray) -> None:
     Assumes labels is 1D numpy array (not multi-label).
     """
     if y.ndim != 1:
-        raise ValueError("labels must by 1D numpy array.")
+        raise ValueError("labels must be 1D numpy array.")
 
     unique_classes = np.unique(y)
     if len(unique_classes) < 2:
@@ -131,10 +131,21 @@ def assert_indexing_works(
         raise TypeError(msg)
 
 
-def labels_to_array(y: np.ndarray) -> Any:
-    """Converts different types of label objects to 1D numpy array and checks validity"""
+def labels_to_array(y: Union[list, np.ndarray, pd.Series, pd.DataFrame]) -> np.ndarray:
+    """Converts different types of label objects to 1D numpy array and checks validity
+
+    Parameters
+    ----------
+    y : Union[list, np.ndarray, pd.Series, pd.DataFrame]
+        Labels to convert to 1D numpy array. Can be a list, numpy array, pandas Series, or pandas DataFrame.
+
+    Returns
+    -------
+    np.ndarray
+        1D numpy array of labels.
+    """
     if isinstance(y, pd.Series):
-        return y.values
+        return np.asarray(y.values)
     elif isinstance(y, pd.DataFrame):
         y = y.values
         if y.shape[1] != 1:

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -21,7 +21,6 @@ Checks to ensure valid inputs for various methods.
 from typing import Any, List, Optional
 import warnings
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
 
 

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -18,6 +18,7 @@
 Checks to ensure valid inputs for various methods.
 """
 
+from cleanlab.typing import LabelLike, DatasetLike
 from typing import Any, List, Optional, Union
 import warnings
 import numpy as np
@@ -25,8 +26,8 @@ import pandas as pd
 
 
 def assert_valid_inputs(
-    X: Any,
-    y: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+    X: DatasetLike,
+    y: LabelLike,
     pred_probs: Optional[np.ndarray] = None,
     multi_label: bool = False,
 ) -> None:
@@ -107,7 +108,7 @@ def assert_nonempty_input(X: Any) -> None:
 
 
 def assert_indexing_works(
-    X: Any, idx: Optional[List[int]] = None, length_X: Optional[int] = None
+    X: DatasetLike, idx: Optional[List[int]] = None, length_X: Optional[int] = None
 ) -> None:
     """Ensures we can do list-based indexing into ``X`` and ``y``.
     length_X is argument passed in since sparse matrix ``X``
@@ -131,12 +132,12 @@ def assert_indexing_works(
         raise TypeError(msg)
 
 
-def labels_to_array(y: Union[list, np.ndarray, np.generic, pd.Series, pd.DataFrame]) -> np.ndarray:
+def labels_to_array(y: Union[LabelLike, np.generic]) -> np.ndarray:
     """Converts different types of label objects to 1D numpy array and checks validity
 
     Parameters
     ----------
-    y : Union[list, np.ndarray, pd.Series, pd.DataFrame]
+    y : Union[LabelLike, np.generic]
         Labels to convert to 1D numpy array. Can be a list, numpy array, pandas Series, or pandas DataFrame.
 
     Returns

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -18,12 +18,19 @@
 Checks to ensure valid inputs for various methods.
 """
 
+from typing import Any, List, Optional
 import warnings
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 
-def assert_valid_inputs(X, y, pred_probs=None, multi_label=False):
+def assert_valid_inputs(
+    X: npt.NDArray,
+    y: npt.NDArray,
+    pred_probs: Optional[npt.NDArray] = None,
+    multi_label: bool = False,
+) -> None:
     """Checks that X, labels, and pred_probs are correctly formatted"""
     if not isinstance(y, (list, np.ndarray, np.generic, pd.Series, pd.DataFrame)):
         raise TypeError("labels should be a numpy array or pandas Series.")
@@ -77,7 +84,7 @@ def assert_valid_inputs(X, y, pred_probs=None, multi_label=False):
                 )
 
 
-def assert_valid_class_labels(y):
+def assert_valid_class_labels(y: npt.NDArray) -> None:
     """Check that labels is zero-indexed (first label is 0) and all classes present.
     Assumes labels is 1D numpy array (not multi-label).
     """
@@ -95,12 +102,14 @@ def assert_valid_class_labels(y):
         raise TypeError(msg)
 
 
-def assert_nonempty_input(X):
+def assert_nonempty_input(X: Optional[npt.NDArray]) -> None:
     if X is None:
         raise ValueError("Data features X cannot be None. Currently X is None.")
 
 
-def assert_indexing_works(X, idx=None, length_X=None):
+def assert_indexing_works(
+    X: npt.NDArray, idx: Optional[List[int]] = None, length_X: Optional[int] = None
+) -> None:
     """Ensures we can do list-based indexing into ``X`` and ``y``.
     length_X is argument passed in since sparse matrix ``X``
     does not support: ``len(X)`` and we want this method to work for sparse ``X``
@@ -123,7 +132,7 @@ def assert_indexing_works(X, idx=None, length_X=None):
         raise TypeError(msg)
 
 
-def labels_to_array(y):
+def labels_to_array(y: npt.NDArray) -> Any:
     """Converts different types of label objects to 1D numpy array and checks validity"""
     if isinstance(y, pd.Series):
         return y.values

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -25,7 +25,7 @@ import pandas as pd
 
 
 def assert_valid_inputs(
-    X: np.ndarray,
+    X: Any,
     y: np.ndarray,
     pred_probs: Optional[np.ndarray] = None,
     multi_label: bool = False,
@@ -101,13 +101,13 @@ def assert_valid_class_labels(y: np.ndarray) -> None:
         raise TypeError(msg)
 
 
-def assert_nonempty_input(X: Optional[np.ndarray]) -> None:
+def assert_nonempty_input(X: Any) -> None:
     if X is None:
         raise ValueError("Data features X cannot be None. Currently X is None.")
 
 
 def assert_indexing_works(
-    X: np.ndarray, idx: Optional[List[int]] = None, length_X: Optional[int] = None
+    X: Any, idx: Optional[List[int]] = None, length_X: Optional[int] = None
 ) -> None:
     """Ensures we can do list-based indexing into ``X`` and ``y``.
     length_X is argument passed in since sparse matrix ``X``

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -146,7 +146,8 @@ def labels_to_array(y: Union[LabelLike, np.generic]) -> np.ndarray:
         1D numpy array of labels.
     """
     if isinstance(y, pd.Series):
-        return np.asarray(y.values)
+        y_series: np.ndarray = y.to_numpy()
+        return y_series
     elif isinstance(y, pd.DataFrame):
         y = y.values
         if y.shape[1] != 1:

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -122,9 +122,9 @@ def assert_indexing_works(
         idx = [0, length_X - 1]
     try:
         if isinstance(X, (pd.DataFrame, pd.Series)):
-            _ = X.iloc[idx]  # type: ignore
+            _ = X.iloc[idx]  # type: ignore[call-overload]
         else:
-            _ = X[idx]  # type: ignore
+            _ = X[idx]  # type: ignore[call-overload]
     except:
         msg = "Data features X must support list-based indexing; i.e. one of these must work: \n"
         msg += "1)  X[index_list] where say index_list = [0,1,3,10], or \n"

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -26,9 +26,9 @@ import pandas as pd
 
 
 def assert_valid_inputs(
-    X: npt.NDArray,
-    y: npt.NDArray,
-    pred_probs: Optional[npt.NDArray] = None,
+    X: np.ndarray,
+    y: np.ndarray,
+    pred_probs: Optional[np.ndarray] = None,
     multi_label: bool = False,
 ) -> None:
     """Checks that X, labels, and pred_probs are correctly formatted"""
@@ -84,7 +84,7 @@ def assert_valid_inputs(
                 )
 
 
-def assert_valid_class_labels(y: npt.NDArray) -> None:
+def assert_valid_class_labels(y: np.ndarray) -> None:
     """Check that labels is zero-indexed (first label is 0) and all classes present.
     Assumes labels is 1D numpy array (not multi-label).
     """
@@ -102,13 +102,13 @@ def assert_valid_class_labels(y: npt.NDArray) -> None:
         raise TypeError(msg)
 
 
-def assert_nonempty_input(X: Optional[npt.NDArray]) -> None:
+def assert_nonempty_input(X: Optional[np.ndarray]) -> None:
     if X is None:
         raise ValueError("Data features X cannot be None. Currently X is None.")
 
 
 def assert_indexing_works(
-    X: npt.NDArray, idx: Optional[List[int]] = None, length_X: Optional[int] = None
+    X: np.ndarray, idx: Optional[List[int]] = None, length_X: Optional[int] = None
 ) -> None:
     """Ensures we can do list-based indexing into ``X`` and ``y``.
     length_X is argument passed in since sparse matrix ``X``
@@ -132,7 +132,7 @@ def assert_indexing_works(
         raise TypeError(msg)
 
 
-def labels_to_array(y: npt.NDArray) -> Any:
+def labels_to_array(y: np.ndarray) -> Any:
     """Converts different types of label objects to 1D numpy array and checks validity"""
     if isinstance(y, pd.Series):
         return y.values

--- a/cleanlab/typing.py
+++ b/cleanlab/typing.py
@@ -1,0 +1,10 @@
+from typing import Any, Union
+import numpy as np
+import pandas as pd
+
+LabelLike = Union[list, np.ndarray, pd.Series, pd.DataFrame]
+"""Type for objects that behave like collections of labels."""
+
+
+DatasetLike = Any
+"""Type for objects that behave like datasets."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,29 @@
+# coding: utf-8
+
+from cleanlab.internal import validation
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize("y_list", [["a", "b", "a"], [0, 1, 2]])
+@pytest.mark.parametrize("format", [list, np.array, pd.Series, pd.DataFrame])
+def test_labels_to_array_return_types(y_list, format):
+    y = format(y_list)
+    labels = validation.labels_to_array(y)
+    assert isinstance(labels, np.ndarray)
+
+
+@pytest.mark.parametrize("y_list", [["a", "b", "a"], [0, 1, 2]])
+@pytest.mark.parametrize("format", [list, np.array, pd.Series])
+def test_labels_to_array_return_values(y_list, format):
+    y = format(y_list)
+    labels = validation.labels_to_array(y)
+    assert np.array_equal(y, labels)
+
+
+def test_label_to_array_raises_error():
+    # Pandas DataFrame should have only one column
+    y = pd.DataFrame({"a": [0, 1], "b": [2, 3]})
+    with pytest.raises(ValueError):
+        validation.labels_to_array(y)


### PR DESCRIPTION
Starting to fix strict mypy errors as discussed in #307.

This PR handles the internal.validation module:

I ran:
```bash
mypy --install-types --non-interactive --strict --allow-untyped-defs --allow-untyped-calls --allow-any-generics --show-error-codes --exclude cleanlab/experimental cleanlab/internal/validation.py
```

### Errors before PR

```
cleanlab/internal/validation.py:61: error: Argument 1 to "len" has incompatible type "Union[ndarray[Any, Any], generic]"; expected "Sized"  [arg-type]
cleanlab/internal/validation.py:72: error: Tuple index out of range  [misc]
cleanlab/internal/validation.py:74: error: Tuple index out of range  [misc]
Found 3 errors in 1 file (checked 1 source file)
```

### After PR

```
Success: no issues found in 1 source file
```

## Some thoughts

- I think (X, y) might need some custom Union type to handle both numpy arrays and pandas dataframe, etc.
- All of the "assert" functions return None.