### PR TITLE
Add y argument as alternative to labels in CleanLearning.fit()

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -297,6 +297,10 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
           Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
 
+          Note
+          ----
+          This argument was previously called ``labels`` in some previous versions of cleanlab.
+
         pred_probs : np.array, optional
           An array of shape ``(N, K)`` of model-predicted probabilities,
           ``P(label=k|x)``. Each row of this matrix corresponds
@@ -388,6 +392,15 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           purposes). If you want to pass in validation data even in the final training of `clf.fit()`
           on the cleaned data subset, you should explicitly pass in that data yourself
           (eg. via `clf_final_kwargs` or `clf_kwargs`).
+
+        labels : np.array or pd.Series
+          An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
+          Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
+
+          Note
+          ----
+
+          This argument is kept for API backwards compatibility. You should use now use `y` instead.
 
         Returns
         -------

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -263,7 +263,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
     def fit(
         self,
         X,
-        labels,
+        labels=None,
         *,
         pred_probs=None,
         thresholds=None,
@@ -274,6 +274,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         clf_kwargs={},
         clf_final_kwargs={},
         validation_func=None,
+        y=None,
     ):
         """
         Train the model `clf` with error-prone, noisy labels as if
@@ -388,6 +389,9 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           on the cleaned data subset, you should explicitly pass in that data yourself
           (eg. via `clf_final_kwargs` or `clf_kwargs`).
 
+        y: np.array or pd.Series, optional
+          Alternative argument that can be specified instead of `labels`. Specifying `y` has the same effect as specifying `labels`, and is offered as an alternative for compatibility with sklearn.
+
         Returns
         -------
         CleanLearning
@@ -415,6 +419,13 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             so that the classifier trains as if it had all the true labels,
             not just the subset of cleaned data left after pruning out the label issues.
         """
+
+        if labels is not None and y is not None:
+            raise ValueError("You must specify either `labels` or `y`, but not both.")
+        if y is not None:
+            labels = y
+        if labels is None:
+            raise ValueError("You must specify `labels`.")
 
         self.clf_final_kwargs = {**clf_kwargs, **clf_final_kwargs}
 

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -263,7 +263,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
     def fit(
         self,
         X,
-        y,
+        y=None,
         *,
         pred_probs=None,
         thresholds=None,
@@ -435,11 +435,15 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                 "CleanLearning.fit() received both `y` and `labels` arguments. "
                 "`labels` is deprecated, so please use `y` instead."
             )
-        elif labels is not None:
-            warnings.warn("labels is deprecated; use y", DeprecationWarning, 2)
+        if labels is not None:
+            warnings.warn(
+                "Argument `labels` is deprecated and will be removed in future versions, pass the labels via argument `y` instead.",
+                DeprecationWarning,
+                2,
+            )
             y = labels
-        elif y is None:
-            raise TypeError("CleanLearning.fit() missing `y` argument.")
+        if y is None:
+            raise TypeError("CleanLearning.fit() missing positional argument `y` argument.")
 
         self.clf_final_kwargs = {**clf_kwargs, **clf_final_kwargs}
 

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -89,7 +89,7 @@ model to be sklearn-compatible. This is made easy by inheriting from
 Note
 ----
 
-* `labels` refers to the given labels in the original dataset, which may have errors
+* `y` refers to the given labels in the original dataset, which may have errors
 * labels must be integers in 0, 1, ..., K-1, where K is the total number of classes
 
 Note
@@ -106,9 +106,9 @@ learning across a variety of tasks like multi-class classification, multi-label 
 and PU learning.
 
 Given any classifier having the `predict_proba` method, an input feature
-matrix `X`, and a discrete vector of noisy labels `labels`, confident learning estimates the
+matrix `X`, and a discrete vector of noisy labels `y`, confident learning estimates the
 classifications that would be obtained if the *true labels* had instead been provided
-to the classifier during training. `labels` denotes the noisy labels instead of
+to the classifier during training. `y` denotes the noisy labels instead of
 the :math:`\\tilde{y}` used in confident learning paper.
 """
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -634,13 +634,13 @@ def dimN_data(N):
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("N", [1, 3, 4])
 def test_dimN(N):
-    X, y = dimN_data(N)
+    X, labels = dimN_data(N)
     cl = CleanLearning(clf=ReshapingLogisticRegression())
     # just make sure we don't crash...
-    cl.fit(X, y)
+    cl.fit(X, labels)
     cl.predict(X)
     cl.predict_proba(X)
-    cl.score(X, y)
+    cl.score(X, labels)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -492,6 +492,29 @@ def test_clf_fit_nm_inm(format):
 
 
 @pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
+def test_clf_fit_y_alias(format):
+    data = DATA_FORMATS[format]
+    cl = CleanLearning(seed=SEED)
+
+    # Valid signature
+    cl.fit(data["X_train"], data["labels"])
+
+    # Valid signature for labels/y alias
+    cl.fit(data["X_train"], labels=data["labels"])
+    cl.fit(data["X_train"], y=data["labels"])
+    cl.fit(X=data["X_train"], labels=data["labels"])
+    cl.fit(X=data["X_train"], y=data["labels"])
+
+    # Invalid signatures
+    with pytest.raises(ValueError):
+        cl.fit(data["X_train"])
+    with pytest.raises(ValueError):
+        cl.fit(data["X_train"], data["labels"], y=data["labels"])
+    with pytest.raises(ValueError):
+        cl.fit(X=data["X_train"], labels=data["labels"], y=data["labels"])
+
+
+@pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
 def test_pred_and_pred_proba(format):
     data = DATA_FORMATS[format]
     cl = CleanLearning()

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -634,13 +634,13 @@ def dimN_data(N):
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("N", [1, 3, 4])
 def test_dimN(N):
-    X, labels = dimN_data(N)
+    X, y = dimN_data(N)
     cl = CleanLearning(clf=ReshapingLogisticRegression())
     # just make sure we don't crash...
-    cl.fit(X, labels)
+    cl.fit(X, y)
     cl.predict(X)
     cl.predict_proba(X)
-    cl.score(X, labels)
+    cl.score(X, y)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")


### PR DESCRIPTION
Set `label` as an optional keyword-only argument.
Anyone still using it in this method should get a deprecation warning.

I'd like someone else's input on the same argument in `find_label_issues`, but will leave it be in this PR.

https://github.com/cleanlab/cleanlab/blob/5973a21958f47fd8e7246ccf36c8304ff4f22e3b/cleanlab/classification.py#L606

Fixes #281