### PR TITLE
Allow missing classes in get_label_quality_scores

### DIFF
--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -30,6 +30,7 @@ def assert_valid_inputs(
     y: LabelLike,
     pred_probs: Optional[np.ndarray] = None,
     multi_label: bool = False,
+    allow_missing_classes: bool = False,
 ) -> None:
     """Checks that X, labels, and pred_probs are correctly formatted"""
     if not isinstance(y, (list, np.ndarray, np.generic, pd.Series, pd.DataFrame)):
@@ -84,7 +85,8 @@ def assert_valid_inputs(
             raise ValueError("Values in pred_probs must be between 0 and 1.")
         if X is not None:
             warnings.warn("When X and pred_probs are both provided, former may be ignored.")
-        if not multi_label:  # TODO: can remove this clause once missing classes are supported
+        # TODO: can remove this clause once missing classes are supported
+        if not allow_missing_classes and not multi_label:
             num_unique_labels = len(np.unique(y))
             if num_unique_labels != pred_probs.shape[1]:
                 raise ValueError(

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -183,7 +183,9 @@ def get_label_quality_scores(
 
     """
 
-    assert_valid_inputs(X=None, y=labels, pred_probs=pred_probs, multi_label=False)
+    assert_valid_inputs(
+        X=None, y=labels, pred_probs=pred_probs, multi_label=False, allow_missing_classes=True
+    )
 
     # Available scoring functions to choose from
     scoring_funcs = {


### PR DESCRIPTION
Updated `assert_valid_inputs` to take in optional arg `allow_missing_classes`, which will skip the check for missing classes in `labels`. `get_label_quality_scores` will no longer check input labels for missing classes.