### PR TITLE
Allow missing classes in assert_valid_class_labels

### DIFF
--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -101,8 +101,9 @@ def assert_valid_class_labels(
     y: np.ndarray,
     allow_missing_classes: bool = False,
 ) -> None:
-    """Check that labels is zero-indexed (first label is 0) and all classes present.
-    Assumes labels is 1D numpy array (not multi-label).
+    """Check that labels is properly formatted, i.e. a 1D array that is
+       zero-indexed (first label is 0) and all classes present (if ``allow_missing_classes is False``).
+       Assumes labels is 1D numpy array (not multi-label).
     """
     if y.ndim != 1:
         raise ValueError("labels must be 1D numpy array.")

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -25,6 +25,7 @@ import numpy as np
 import pandas as pd
 
 
+# TODO: remove allow_missing_classes once supported
 def assert_valid_inputs(
     X: DatasetLike,
     y: LabelLike,
@@ -37,7 +38,7 @@ def assert_valid_inputs(
         raise TypeError("labels should be a numpy array or pandas Series.")
     if not multi_label:
         y = labels_to_array(y)
-        assert_valid_class_labels(y)
+        assert_valid_class_labels(y=y, allow_missing_classes=allow_missing_classes)
 
     allow_empty_X = True
     if pred_probs is None:
@@ -96,7 +97,10 @@ def assert_valid_inputs(
                 )
 
 
-def assert_valid_class_labels(y: np.ndarray) -> None:
+def assert_valid_class_labels(
+    y: np.ndarray,
+    allow_missing_classes: bool = False,
+) -> None:
     """Check that labels is zero-indexed (first label is 0) and all classes present.
     Assumes labels is 1D numpy array (not multi-label).
     """
@@ -107,11 +111,13 @@ def assert_valid_class_labels(y: np.ndarray) -> None:
     if len(unique_classes) < 2:
         raise ValueError("Labels must contain at least 2 classes.")
 
-    if (unique_classes != np.arange(len(unique_classes))).any():
-        msg = "cleanlab requires zero-indexed integer labels (0,1,2,..,K-1), but in "
-        msg += "your case: np.unique(labels) = {}. ".format(str(unique_classes))
-        msg += "Every class in (0,1,2,..,K-1) must be present in labels as well."
-        raise TypeError(msg)
+    # TODO: remove allow_missing_classes check once supported
+    if not allow_missing_classes:
+        if (unique_classes != np.arange(len(unique_classes))).any():
+            msg = "cleanlab requires zero-indexed integer labels (0,1,2,..,K-1), but in "
+            msg += "your case: np.unique(labels) = {}. ".format(str(unique_classes))
+            msg += "Every class in (0,1,2,..,K-1) must be present in labels as well."
+            raise TypeError(msg)
 
 
 def assert_nonempty_input(X: Any) -> None:

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -107,12 +107,12 @@ def assert_valid_class_labels(
     if y.ndim != 1:
         raise ValueError("labels must be 1D numpy array.")
 
-    unique_classes = np.unique(y)
-    if len(unique_classes) < 2:
-        raise ValueError("Labels must contain at least 2 classes.")
-
-    # TODO: remove allow_missing_classes check once supported
+    # TODO: can remove this clause once missing classes are supported
     if not allow_missing_classes:
+        unique_classes = np.unique(y)
+        if len(unique_classes) < 2:
+            raise ValueError("Labels must contain at least 2 classes.")
+
         if (unique_classes != np.arange(len(unique_classes))).any():
             msg = "cleanlab requires zero-indexed integer labels (0,1,2,..,K-1), but in "
             msg += "your case: np.unique(labels) = {}. ".format(str(unique_classes))

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -102,8 +102,8 @@ def assert_valid_class_labels(
     allow_missing_classes: bool = False,
 ) -> None:
     """Check that labels is properly formatted, i.e. a 1D array that is
-       zero-indexed (first label is 0) and all classes present (if ``allow_missing_classes is False``).
-       Assumes labels is 1D numpy array (not multi-label).
+    zero-indexed (first label is 0) and all classes present (if ``allow_missing_classes is False``).
+    Assumes labels is 1D numpy array (not multi-label).
     """
     if y.ndim != 1:
         raise ValueError("labels must be 1D numpy array.")

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -183,6 +183,7 @@ def get_label_quality_scores(
 
     """
 
+    # TODO: remove allow_missing_classes once supported
     assert_valid_inputs(
         X=None, y=labels, pred_probs=pred_probs, multi_label=False, allow_missing_classes=True
     )


### PR DESCRIPTION
Allowing `assert_valid_class_labels` to take in optional arg `allow_missing_classes` to skip checks for missing classes in `labels`. 
A follow up to #334 which missed a helper function call that also checks for missing classes.