### PR TITLE
Add stable check in version warning banner

### DIFF
--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -29,7 +29,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="{{ DOCS_SITE_URL }}">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>


### PR DESCRIPTION
Tagging+releasing this commit with an incremented patch version number, i.e.
```
v2.0.1
```
should remove the warning banner on the stable/ url.

## Note
In order for this PR to work as intended, it needs a base branch that is in sync with the release tag (`v2.0.0`).





Refs. #300