### PR TITLE
Fix typing for find_label_issues

### DIFF
--- a/cleanlab/token_classification/filter.py
+++ b/cleanlab/token_classification/filter.py
@@ -1,22 +1,24 @@
 import numpy as np
 from cleanlab.filter import find_label_issues as find_label_issues_main
-from typing import Optional, Union, Tuple
+from typing import List, Tuple
 
 
 def find_label_issues(
-    labels: list, pred_probs: list, return_indices_ranked_by: str = "self_confidence"
-) -> list:
+    labels: List[List[int]],
+    pred_probs: List[np.ndarray],  # type: ignore[type-arg]
+    return_indices_ranked_by: str = "self_confidence",
+) -> List[Tuple[int, int]]:
     """Returns issues identified by cleanlab
 
     This is a function to find the label issues for token classification datasets
 
     Parameters
     ----------
-    labels: list
+    labels: List[List[int]]
         noisy token labels in nested list format, such that `labels[i]` is a list of token labels of the i'th
         sentence. For datasets with `K` classes, each label must be in 0, 1, ..., K-1. All classes must be present.
 
-    pred_probs: list
+    pred_probs: List[np.ndarray]
         list of np.arrays, such that `pred_probs[i]` is the model-predicted probabilities for the tokens in
         the i'th sentence, and has shape `(N, K)`. Each row of the matrix corresponds to a token `t` and contains
         the model-predicted probabilities that `t` belongs to each possible class, for each of the K classes. The
@@ -28,20 +30,20 @@ def find_label_issues(
 
     Returns
     ----------
-    issues: list
+    issues: List[Tuple[int, int]]
         a list containing all potential issues identified by cleanlab, such that each element is a tuple (i, j), which
         corresponds to the j'th token of the i'th sentence.
     """
     labels_flatten = [l for label in labels for l in label]
     pred_probs_flatten = np.array([pred for pred_prob in pred_probs for pred in pred_prob])
 
-    issues = find_label_issues_main(
+    issues_main = find_label_issues_main(
         labels_flatten, pred_probs_flatten, return_indices_ranked_by=return_indices_ranked_by
-    )
+    )  # type: ignore[no-untyped-call]
 
     lengths = [len(label) for label in labels]
     mapping = [[(i, j) for j in range(length)] for i, length in enumerate(lengths)]
     mapping_flatten = [index for indicies in mapping for index in indicies]
 
-    issues = [mapping_flatten[issue] for issue in issues]
+    issues = [mapping_flatten[issue] for issue in issues_main]
     return issues

--- a/cleanlab/token_classification/filter.py
+++ b/cleanlab/token_classification/filter.py
@@ -4,8 +4,8 @@ from typing import List, Tuple
 
 
 def find_label_issues(
-    labels: List[List[int]],
-    pred_probs: List[np.ndarray],
+    labels: list,
+    pred_probs: list,
     return_indices_ranked_by: str = "self_confidence",
 ) -> List[Tuple[int, int]]:
     """Returns issues identified by cleanlab
@@ -14,7 +14,7 @@ def find_label_issues(
 
     Parameters
     ----------
-    labels: List[List[int]]
+    labels:
         noisy token labels in nested list format, such that `labels[i]` is a list of token labels of the i'th
         sentence. For datasets with `K` classes, each label must be in 0, 1, ..., K-1. All classes must be present.
 
@@ -30,7 +30,7 @@ def find_label_issues(
 
     Returns
     ----------
-    issues: List[Tuple[int, int]]
+    issues:
         a list containing all potential issues identified by cleanlab, such that each element is a tuple (i, j), which
         corresponds to the j'th token of the i'th sentence.
     """

--- a/cleanlab/token_classification/filter.py
+++ b/cleanlab/token_classification/filter.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 
 def find_label_issues(
     labels: List[List[int]],
-    pred_probs: List[np.ndarray],  # type: ignore[type-arg]
+    pred_probs: List[np.ndarray],
     return_indices_ranked_by: str = "self_confidence",
 ) -> List[Tuple[int, int]]:
     """Returns issues identified by cleanlab
@@ -18,7 +18,7 @@ def find_label_issues(
         noisy token labels in nested list format, such that `labels[i]` is a list of token labels of the i'th
         sentence. For datasets with `K` classes, each label must be in 0, 1, ..., K-1. All classes must be present.
 
-    pred_probs: List[np.ndarray]
+    pred_probs:
         list of np.arrays, such that `pred_probs[i]` is the model-predicted probabilities for the tokens in
         the i'th sentence, and has shape `(N, K)`. Each row of the matrix corresponds to a token `t` and contains
         the model-predicted probabilities that `t` belongs to each possible class, for each of the K classes. The
@@ -39,7 +39,7 @@ def find_label_issues(
 
     issues_main = find_label_issues_main(
         labels_flatten, pred_probs_flatten, return_indices_ranked_by=return_indices_ranked_by
-    )  # type: ignore[no-untyped-call]
+    )
 
     lengths = [len(label) for label in labels]
     mapping = [[(i, j) for j in range(length)] for i, length in enumerate(lengths)]

--- a/tests/test_token_classification.py
+++ b/tests/test_token_classification.py
@@ -70,8 +70,15 @@ def test_color_sentence():
 issues = find_label_issues(labels, pred_probs)
 
 
+@pytest.mark.parametrize(
+    "test_labels",
+    [labels, [np.array(l) for l in labels]],
+    ids=["list labels", "np.array labels"],
+)
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_find_label_issues():
+def test_find_label_issues(test_labels):
+    issues = find_label_issues(test_labels, pred_probs)
+    assert isinstance(issues, list)
     assert len(issues) == 1
     assert issues[0] == (1, 0)
 


### PR DESCRIPTION
In relation to #384 where code introduced in cleanlab/token_classification/filter.py is reviewed/modified for release.

This PR only addresses typing of one function, `find_label_issues`.