### PR TITLE
Cleanup token_classification.rank module

### DIFF
--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -125,7 +125,7 @@ def get_label_quality_scores(
 
 
 def issues_from_scores(
-    sentence_scores: np.ndarray, token_scores: list, threshold: float = 0.1
+    sentence_scores: np.ndarray, token_scores: Optional[list] = None, threshold: float = 0.1
 ) -> Union[list, np.ndarray]:
     """
     Converts output from `get_label_quality_score` to list of issues. Only includes issues with label quality score
@@ -136,7 +136,7 @@ def issues_from_scores(
     sentence_scores: np.array
         np.array of shape `(N, )`, where `N` is the number of sentences.
 
-    token_scores: list
+    token_scores: list, optional, default=None
         token scores in nested list, such that `token_scores[i]` contains the tokens scores for the i'th sentence
 
     threshold: int, default=0.1

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -28,6 +28,8 @@ def softmin_sentence_score(
         np.array of shape `(N, )`, where `N` is the number of sentences. Contains score for each sentence.
 
     """
+    if temperature == 0:
+        return np.array([np.min(scores) for scores in token_scores])
     softmax = lambda scores: np.exp(scores / temperature) / np.sum(np.exp(scores / temperature))
     fun = lambda scores: np.dot(scores, softmax(1 - np.array(scores)))
     sentence_scores = list(map(fun, token_scores))

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -1,12 +1,10 @@
 import pandas as pd
 import numpy as np
 from cleanlab.rank import get_label_quality_scores as main_get_label_quality_scores
-from typing import Optional, Union, Tuple
+from typing import List, Optional, Union, Tuple
 
 
-def softmin_sentence_score(
-    token_scores: list, temperature: float = 0.05, **kwargs: dict
-) -> np.ndarray:
+def softmin_sentence_score(token_scores: List[np.ndarray], temperature: float = 0.05) -> np.ndarray:
     """
     sentence scoring using the "softmin" scoring method.
 
@@ -16,11 +14,8 @@ def softmin_sentence_score(
         token scores in nested list format, where `token_scores[i]` is a list of token scores of the i'th
         sentence
 
-    temperate: int, default=0.05
+    temperature: float, default=0.05
         temperature of the softmax function
-
-    **kwargs: dict
-        dictionary for additional arguments
 
     Returns
     ---------
@@ -30,8 +25,14 @@ def softmin_sentence_score(
     """
     if temperature == 0:
         return np.array([np.min(scores) for scores in token_scores])
-    softmax = lambda scores: np.exp(scores / temperature) / np.sum(np.exp(scores / temperature))
-    fun = lambda scores: np.dot(scores, softmax(1 - np.array(scores)))
+
+    def softmax(scores: np.ndarray) -> np.ndarray:
+        exp_scores = np.exp(scores / temperature)
+        return exp_scores / np.sum(exp_scores)
+
+    def fun(scores: np.ndarray) -> float:
+        return np.dot(scores, softmax(1 - np.array(scores)))
+
     sentence_scores = list(map(fun, token_scores))
     return np.array(sentence_scores)
 

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -46,7 +46,6 @@ def get_label_quality_scores(
     tokens: Optional[list] = None,
     token_score_method: str = "self_confidence",
     sentence_score_method: str = "min",
-    return_scores_per_token: bool = True,
     sentence_score_kwargs: dict = {},
     token_score_kwargs: dict = {},
 ) -> Union[np.ndarray, Tuple[np.ndarray, list]]:
@@ -58,7 +57,6 @@ def get_label_quality_scores(
     1 - clean label (given label is likely correct).
     0 - dirty label (given label is likely incorrect).
 
-    If `return_scores_per_token` is set to True, also return label score per token
     Parameters
     ----------
     labels: list
@@ -84,15 +82,13 @@ def get_label_quality_scores(
         label quality scoring method. See `cleanlab.rank.get_label_quality_scores` for more info.
     param: float, default=0.04
         temperature of softmax. If sentence_score_method == "min", `param` is ignored.
-    return_scores_per_token: bool, default=True
-        If set to True, returns additional token information. See return value `token_info` for more info.
     Returns
     ----------
     sentence_scores: np.array
         A vector of sentence scores between 0 and 1, where lower scores indicate sentence is more likely to contain at
         least one label issue.
     token_info: list
-        Returns only if `return_scores_per_token=True`. A list of pandas.Series, such that token_info[i] contains the
+        A list of pandas.Series, such that token_info[i] contains the
         token scores for the i'th sentence. If tokens are provided, the series is indexed by the tokens.
     ----------
     """
@@ -118,11 +114,8 @@ def get_label_quality_scores(
 
     if sentence_score_method == "min":
         sentence_scores = np.array(list(map(np.min, scores_nl)))
-
     elif sentence_score_method == "softmin":
-        temperature = (
-            sentence_score_kwargs["temperature"] if "temperature" in sentence_score_kwargs else 0.05
-        )
+        temperature = sentence_score_kwargs.get("temperature", 0.05)
         sentence_scores = softmin_sentence_score(scores_nl, temperature=temperature)
 
     if not return_scores_per_token:

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -21,10 +21,12 @@ def softmin_sentence_score(token_scores: List[np.ndarray], temperature: float = 
     ---------
     sentence_scores: np.array
         np.array of shape `(N, )`, where `N` is the number of sentences. Contains score for each sentence.
-
     """
     if temperature == 0:
         return np.array([np.min(scores) for scores in token_scores])
+
+    if temperature == np.inf:
+        return np.array([np.mean(scores) for scores in token_scores])
 
     def softmax(scores: np.ndarray) -> np.ndarray:
         exp_scores = np.exp(scores / temperature)

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -113,7 +113,8 @@ def get_label_quality_scores(
 
     if sentence_score_method == "min":
         sentence_scores = np.array(list(map(np.min, scores_nl)))
-    elif sentence_score_method == "softmin":
+    else:
+        assert sentence_score_method == "softmin"
         temperature = sentence_score_kwargs.get("temperature", 0.05)
         sentence_scores = softmin_sentence_score(scores_nl, temperature=temperature)
 

--- a/tests/test_token_classification.py
+++ b/tests/test_token_classification.py
@@ -112,6 +112,12 @@ def test_get_label_quality_scores(label_quality_scores):
     assert len(sentence_scores_softmin) == 3
     assert np.allclose(sentence_scores_softmin, [0.600741787, 1.8005624e-7, 0.8])
 
+    with pytest.raises(AssertionError) as excinfo:
+        get_label_quality_scores(
+            labels, pred_probs, sentence_score_method="unsupported_method", tokens=words
+        )
+    assert "Select from the following methods:" in str(excinfo.value)
+
 
 def test_issues_from_scores(label_quality_scores):
     sentence_scores, token_info = label_quality_scores

--- a/tests/test_token_classification.py
+++ b/tests/test_token_classification.py
@@ -76,22 +76,27 @@ def test_find_label_issues():
     assert issues[0] == (1, 0)
 
 
-sentence_scores, token_info = get_label_quality_scores(labels, pred_probs)
+@pytest.fixture(name="label_quality_scores")
+def fixture_label_quality_scores():
+    sentence_scores, token_info = get_label_quality_scores(labels, pred_probs)
+    return sentence_scores, token_info
 
 
-def test_get_label_quality_scores():
+def test_get_label_quality_scores(label_quality_scores):
+    sentence_scores, token_info = label_quality_scores
     assert len(sentence_scores) == 3
     assert np.allclose(sentence_scores, [0.6, 0, 0.8])
     assert len(token_info) == 3
     assert np.allclose(token_info[0], [0.9, 0.6])
-    sentence_scores_softmin, token_info_softmin = get_label_quality_scores(
+    sentence_scores_softmin, _ = get_label_quality_scores(
         labels, pred_probs, sentence_score_method="softmin", tokens=words
     )
     assert len(sentence_scores_softmin) == 3
     assert np.allclose(sentence_scores_softmin, [0.600741787, 1.8005624e-7, 0.8])
 
 
-def test_issues_from_scores():
+def test_issues_from_scores(label_quality_scores):
+    sentence_scores, token_info = label_quality_scores
     issues = issues_from_scores(sentence_scores, token_info)
     assert len(issues) == 1
     assert issues[0] == (1, 0)

--- a/tests/test_token_classification.py
+++ b/tests/test_token_classification.py
@@ -118,7 +118,7 @@ def test_issues_from_scores(label_quality_scores):
     issues = issues_from_scores(sentence_scores, token_info)
     assert len(issues) == 1
     assert issues[0] == (1, 0)
-    issues_without = issues_from_scores(sentence_scores, token_scores=None)
+    issues_without = issues_from_scores(sentence_scores)
     assert len(issues_without) == 1
     assert issues_without[0] == 1
 

--- a/tests/test_token_classification.py
+++ b/tests/test_token_classification.py
@@ -7,7 +7,11 @@ from cleanlab.internal.token_classification_utils import (
     color_sentence,
 )
 from cleanlab.token_classification.filter import find_label_issues
-from cleanlab.token_classification.rank import get_label_quality_scores, issues_from_scores
+from cleanlab.token_classification.rank import (
+    get_label_quality_scores,
+    issues_from_scores,
+    softmin_sentence_score,
+)
 from cleanlab.token_classification.summary import (
     display_issues,
     common_label_issues,
@@ -74,6 +78,20 @@ issues = find_label_issues(labels, pred_probs)
 def test_find_label_issues():
     assert len(issues) == 1
     assert issues[0] == (1, 0)
+
+
+def test_softmin_sentence_score():
+    token_scores = [[0.9, 0.6], [0.0, 0.8, 0.8], [0.8]]
+    sentence_scores = softmin_sentence_score(token_scores)
+    assert isinstance(sentence_scores, np.ndarray)
+    assert np.allclose(sentence_scores, [0.60074, 1.8e-07, 0.8])
+
+    # Temperature limits
+    sentence_scores = softmin_sentence_score(token_scores, temperature=0)
+    assert np.allclose(sentence_scores, [0.6, 0.0, 0.8])
+
+    sentence_scores = softmin_sentence_score(token_scores, temperature=np.inf)
+    assert np.allclose(sentence_scores, [0.75, 1.6 / 3, 0.8])
 
 
 @pytest.fixture(name="label_quality_scores")


### PR DESCRIPTION
More work related to #384, specifically for cleanlab/token_classification/rank.py.

## This PR adds:
- Unit tests and specialized edge cases for `softmin_sentence_score`.
- Make a test fixture for `get_label_quality_score`.

### Some notes

- Calling `get_label_quality_scores(..., sentence_score_method="min", ...)` should give similar results to calling `get_label_quality_scores(..., sentence_score_method="softmin", sentence_score_kwargs={"temperature": 0}`.
  - It might be useful when testing the "softmin" function for both extremes in `temperature`.
- `issues_from_scores` should be split into two separate functions for each return option.
  - I'd say it's outside the scope of this PR.