### PR TITLE
Escape special regex characters

### DIFF
--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -173,7 +173,7 @@ def color_sentence(sentence: str, word: str) -> str:
     """
     colored_word = colored(word, "red")
     colored_sentence, number_of_substitions = re.subn(
-        r"\b{}\b".format(word), colored_word, sentence
+        r"\b{}\b".format(re.escape(word)), colored_word, sentence
     )
     if number_of_substitions == 0:
         # Use basic string manipulation if regex fails

--- a/tests/test_token_classification.py
+++ b/tests/test_token_classification.py
@@ -141,6 +141,11 @@ C_L, C_R = "\x1b[31m", "\x1b[0m"
         ("A good reason for a test", "a", f"A good reason for {C_L}a{C_R} test"),
         ("ab ab a b ab", "ab a", f"ab {C_L}ab a{C_R} b ab"),
         ("ab ab ab ab", "ab a", f"{C_L}ab a{C_R}b {C_L}ab a{C_R}b"),
+        (
+            "Alan John Percivale (A.j.p.) Taylor died",
+            "(",
+            f"Alan John Percivale {C_L}({C_R}A.j.p.) Taylor died",
+        ),
     ],
     ids=[
         "single_word",
@@ -151,6 +156,7 @@ C_L, C_R = "\x1b[31m", "\x1b[0m"
         "case_sensitive",
         "only_word_boundary",
         "non_overlapping_substrings",
+        "issue_403-escape_special_regex_characters",
     ],
 )
 def test_color_sentence(sentence, word, expected):


### PR DESCRIPTION
In this PR:

- In `color_sentence`: Wrap regex search pattern in `re.escape` 
- Include test case from notebook that was broken before this PR.

Fixes #403