### PR TITLE
Add tutorial notebook to docs.cleanlab.ai

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,6 +104,7 @@ The example below shows how to view all dataset-level issues in one line of code
    tutorials/pred_probs_cross_val
    tutorials/outliers
    tutorials/multiannotator
+   tutorials/token_classification
    tutorials/faq
 
 .. toctree::

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -13,4 +13,5 @@ Tutorials
    pred_probs_cross_val
    outliers
    multiannotator
+   token_classification
    faq


### PR DESCRIPTION
This PR only deploys the tutorial to the docs.
Changes to the tutorial notebook are in #410.

Resolves #401