### PR TITLE
Add termcolor dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         "scikit-learn>=0.18",
         "tqdm>=4.53.0",
         "pandas>=1.0.0",
+        "termcolor>=1.1.0",
     ],
 )
 


### PR DESCRIPTION
Add missing dependency `termcolor` used in [token_classification_utils.py ](https://github.com/cleanlab/cleanlab/blob/23067aa9c6d4cdf479cc997d3b38fbaf9b87ebf3/cleanlab/internal/token_classification_utils.py#L24)