### PR TITLE
Update argument given_labels -> labels in token classification module

### DIFF
--- a/cleanlab/token_classification/summary.py
+++ b/cleanlab/token_classification/summary.py
@@ -9,7 +9,7 @@ def display_issues(
     given_words: List[List[str]],
     *,
     pred_probs: Optional[list] = None,
-    given_labels: Optional[list] = None,
+    labels: Optional[list] = None,
     exclude: List[Tuple[int, int]] = [],
     class_names: Optional[List[str]] = None,
     top: int = 20
@@ -33,8 +33,8 @@ def display_issues(
         sentence, and `K` is the number of classes predicted by the model. If provided, also displays the predicted
         label of the token.
 
-    given_labels:
-        list of given labels, such that `given_labels[i]` is a list containing the given labels of the tokens in the
+    labels:
+        list of given labels, such that `labels[i]` is a list containing the given labels of the tokens in the
         i'th sentence, and has length equal to the number of given tokens of the i'th sentence. If provided, also
         displays the given label of the token.
 
@@ -66,24 +66,24 @@ def display_issues(
 
             if pred_probs:
                 prediction = pred_probs[i][j].argmax()
-            if given_labels:
-                given = given_labels[i][j]
-            if pred_probs and given_labels:
+            if labels:
+                given = labels[i][j]
+            if pred_probs and labels:
                 if (given, prediction) in exclude:
                     continue
 
             if pred_probs and class_names:
                 prediction = class_names[prediction]
-            if given_labels and class_names:
+            if labels and class_names:
                 given = class_names[given]
 
             shown += 1
             print("Sentence %d, token %d: \n%s" % (i, j, color_sentence(sentence, word)))
-            if given_labels and not pred_probs:
+            if labels and not pred_probs:
                 print("Given label: %s\n" % str(given))
-            elif not given_labels and pred_probs:
+            elif not labels and pred_probs:
                 print("Predicted label according to provided pred_probs: %s\n" % str(prediction))
-            elif given_labels and pred_probs:
+            elif labels and pred_probs:
                 print(
                     "Given label: %s, predicted label according to provided pred_probs: %s\n"
                     % (str(given), str(prediction))

--- a/docs/source/tutorials/token_classification.ipynb
+++ b/docs/source/tutorials/token_classification.ipynb
@@ -373,7 +373,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display_issues(issues, given_words, pred_probs=pred_probs, given_labels=labels, \n",
+    "display_issues(issues, given_words, pred_probs=pred_probs, labels=labels, \n",
     "               exclude=[(0, 1), (1, 0)], class_names=merged_entities) "
    ]
   },
@@ -435,7 +435,7 @@
    "outputs": [],
    "source": [
     "token_issues = filter_by_token('United', issues, given_words) \n",
-    "display_issues(token_issues, given_words, pred_probs=pred_probs, given_labels=labels, \n",
+    "display_issues(token_issues, given_words, pred_probs=pred_probs, labels=labels, \n",
     "               exclude=[(0, 1), (1, 0)], class_names=merged_entities) "
    ]
   },
@@ -458,7 +458,7 @@
    "source": [
     "scores, token_scores = get_label_quality_scores(labels, pred_probs) \n",
     "issues = issues_from_scores(scores, token_scores=token_scores) \n",
-    "display_issues(issues, given_words, pred_probs=pred_probs, given_labels=labels, \n",
+    "display_issues(issues, given_words, pred_probs=pred_probs, labels=labels, \n",
     "               exclude=[(0, 1), (1, 0)], class_names=merged_entities) "
    ]
   },

--- a/tests/test_token_classification.py
+++ b/tests/test_token_classification.py
@@ -234,9 +234,7 @@ def test_display_issues():
     display_issues(issues, words, labels=labels)
     display_issues(issues, words, pred_probs=pred_probs)
     display_issues(issues, words, pred_probs=pred_probs, labels=labels)
-    display_issues(
-        issues, words, pred_probs=pred_probs, labels=labels, class_names=class_names
-    )
+    display_issues(issues, words, pred_probs=pred_probs, labels=labels, class_names=class_names)
 
     exclude = [(1, 2)]  # Occurs in first token of second sentence "#I"
     display_issues(issues, words, pred_probs=pred_probs, labels=labels, exclude=exclude)

--- a/tests/test_token_classification.py
+++ b/tests/test_token_classification.py
@@ -231,18 +231,18 @@ def test_issues_from_scores(label_quality_scores):
 
 def test_display_issues():
     display_issues(issues, words)
-    display_issues(issues, words, given_labels=labels)
+    display_issues(issues, words, labels=labels)
     display_issues(issues, words, pred_probs=pred_probs)
-    display_issues(issues, words, pred_probs=pred_probs, given_labels=labels)
+    display_issues(issues, words, pred_probs=pred_probs, labels=labels)
     display_issues(
-        issues, words, pred_probs=pred_probs, given_labels=labels, class_names=class_names
+        issues, words, pred_probs=pred_probs, labels=labels, class_names=class_names
     )
 
     exclude = [(1, 2)]  # Occurs in first token of second sentence "#I"
-    display_issues(issues, words, pred_probs=pred_probs, given_labels=labels, exclude=exclude)
+    display_issues(issues, words, pred_probs=pred_probs, labels=labels, exclude=exclude)
 
     top = 1
-    display_issues(issues, words, pred_probs=pred_probs, given_labels=labels, top=top)
+    display_issues(issues, words, pred_probs=pred_probs, labels=labels, top=top)
 
     issues_sentence_only = [i for i, _ in issues]
     display_issues(issues_sentence_only, words)


### PR DESCRIPTION
The only inconsistent use of the (keyword) argument `given_labels` instead of `labels` is in `cleanlab.token_classification.display_issues`.

This PR fixes this argument name and updates any calls to `display_issues` that would be affected by this.

Fixes #418