### PR TITLE
Clearer code examples on docs main page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,7 +54,7 @@ If you're using a scikit-learn-compatible model (option 1), you don't need to tr
         return_indices_ranked_by='self_confidence',
     )
 
-:py:class:`CleanLearning <cleanlab.classification.CleanLearning>` (Option 1) also works with models from most standard ML frameworks by wrapping the model for scikit-learn compliance, e.g. huggingface (using KerasWrapperModel), Keras (works by default), pytorch (using skorch), etc. 
+:py:class:`CleanLearning <cleanlab.classification.CleanLearning>` (option 1) also works with models from most standard ML frameworks by wrapping the model for scikit-learn compliance, e.g. huggingface/tensorflow/keras (using our KerasWrapperModel), pytorch (using skorch package), etc. 
 
 By default, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` returns a boolean mask of label issues. You can instead return the indices of potential mislabeled examples by setting `return_indices_ranked_by` in :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>`. The indices are ordered by likelihood of a label error (estimated via :py:meth:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`).
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -79,7 +79,7 @@ When the :py:meth:`.fit() <cleanlab.classification.CleanLearning.fit>` method is
    cl = CleanLearning(clf=LogisticRegression())  # any sklearn-compatible classifier
    cl.fit(X=train_data, labels=labels)
 
-   # Estimate the predictions you would have gotten if you trained with error-free labels.
+   # Estimate the predictions you would have gotten if you trained without mislabeled data.
    predictions = cl.predict(test_data)
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,7 +55,7 @@ If you're using a scikit-learn-compatible model (option 1), you don't need to tr
     )
 
 
-By default, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` returns a boolean mask of label issues, but setting `return_indices_ranked_by`, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` will return the indices of potential mislabeled examples ordered by likelihood of a label issue (estimated via :py:meth:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`).
+By default, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` returns a boolean mask of label issues, but setting `return_indices_ranked_by`. :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` will return the indices of potential mislabeled examples ordered by likelihood of a label issue (estimated via :py:meth:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`).
 
 .. important::
    The predicted probabilities, ``pred_probs``, from your model **must be out-of-sample**. Never provide predictions on the same data points used to train the model -- these predictions are overfit and unsuitable for finding label errors. Details on how to compute out-of-sample predicted probabilities for your entire dataset are :ref:`here <pred_probs_cross_val>`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,7 +77,7 @@ When the :py:meth:`.fit() <cleanlab.classification.CleanLearning.fit>` method is
    from cleanlab.classification import CleanLearning
 
    cl = CleanLearning(clf=LogisticRegression())  # any sklearn-compatible classifier
-   cl.fit(X=train_data, labels=labels)
+   cl.fit(train_data, labels)
 
    # Estimate the predictions you would have gotten if you trained without mislabeled data.
    predictions = cl.predict(test_data)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ If you're using a scikit-learn-compatible model (option 1), you don't need to tr
     from cleanlab.filter import find_label_issues
     
     # Option 1 - works with sklearn-compatible models - just input the data and labels ツ
-    issues_df = CleanLearning(clf=sklearn_compatible_model).find_label_issues(data, labels)
+    label_issues_info = CleanLearning(clf=sklearn_compatible_model).find_label_issues(data, labels)
 
     # Option 2 - works with ANY ML model - just input the model's predicted probabilities
     ordered_label_issues = find_label_issues(

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ Setting `return_indices_ranked_by` in this function instructs cleanlab to return
     from cleanlab.filter import find_label_issues
     
     # Option 1 - sklearn-compatible models - just provide the data and labels ツ
-    issues_df = CleanLearning(clf=sklearnCompatibleModel).find_label_issues(data, labels)
+    issues_df = CleanLearning(clf=sklearn_compatible_model).find_label_issues(data, labels)
 
     # Option 2 - ANY ML model - just provide the model's predicted probabilities
     ordered_label_issues = find_label_issues(

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,7 +55,7 @@ If you're using a scikit-learn-compatible model (option 1), you don't need to tr
     )
 
 
-By default, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` returns a boolean mask of label issues, but setting `return_indices_ranked_by`. :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` will return the indices of potential mislabeled examples ordered by likelihood of a label issue (estimated via :py:meth:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`).
+By default, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` returns a boolean mask of label issues. You can instead return the indices of potential mislabeled examples by setting `return_indices_ranked_by` in :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>`. The indices are ordered by likelihood of a label issue (estimated via :py:meth:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`).
 
 .. important::
    The predicted probabilities, ``pred_probs``, from your model **must be out-of-sample**. Never provide predictions on the same data points used to train the model -- these predictions are overfit and unsuitable for finding label errors. Details on how to compute out-of-sample predicted probabilities for your entire dataset are :ref:`here <pred_probs_cross_val>`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,16 +41,21 @@ Setting `return_indices_ranked_by` in this function instructs cleanlab to return
 
 .. code-block:: python
 
-   from cleanlab.filter import find_label_issues
+    from cleanlab.classification import CleanLearning
+    from cleanlab.filter import find_label_issues
+    
+    # Option 1 - sklearn-compatible models - just provide the data and labels ツ
+    issues_df = CleanLearning(clf=sklearnCompatibleModel).find_label_issues(data, labels)
 
-   ordered_label_issues = find_label_issues(
-       labels=labels,
-       pred_probs=pred_probs,
-       return_indices_ranked_by='self_confidence',
-   )
+    # Option 2 - ANY ML model - just provide the model's predicted probabilities
+    ordered_label_issues = find_label_issues(
+        labels=labels,
+        pred_probs=pred_probs,  # out-of-sample predicted probabilities from any model
+        return_indices_ranked_by='self_confidence',
+    )
 
 .. important::
-   The predicted probabilities, ``pred_probs``, from your model **must be out-of-sample**! You should never provide predictions on the same data points used to train the model as these predictions are overfit and  unsuitable for finding label errors. To compute out-of-sample predicted probabilities for your entire dataset, you can use :ref:`cross-validation <pred_probs_cross_val>`.
+   The predicted probabilities, ``pred_probs``, from your model **must be out-of-sample**. Never provide predictions on the same data points used to train the model -- these predictions are overfit and unsuitable for finding label errors. Details on how to compute out-of-sample predicted probabilities for your entire dataset are :ref:`here <pred_probs_cross_val>`.
 
 ..
    TODO - include the url for tf and torch beginner tutorials
@@ -67,9 +72,11 @@ When the :py:meth:`.fit() <cleanlab.classification.CleanLearning.fit>` method is
    from sklearn.linear_model import LogisticRegression
    from cleanlab.classification import CleanLearning
 
-   clf = LogisticRegression() # any classifier implementing the sklearn API
-   cl = CleanLearning(clf=clf)
-   cl.fit(X=X, labels=labels)
+   # Train an ML model with noisy labels - 3 lines of code
+   cl = CleanLearning(clf=LogisticRegression())  # any sklearn-compatible classifier
+   cl.fit(X=train_data, labels=labels)
+   # Estimate the predictions you would have gotten if you trained with error-free labels.
+   predictions = cl.predict(test_data)
 
 
 4. Dataset curation: fix dataset-level issues 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,24 +35,27 @@ Quickstart
 2. Find label errors in your data
 ---------------------------------
 
-cleanlab's :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` function tells you which examples in your dataset are likely mislabeled. At a minimum, it expects two inputs --- your data's given labels, `labels`, and predicted probabilities, `pred_probs`, from some trained classification model. These must be out-of-sample predictions where the data points were held out from the model during training, which can be :ref:`obtained via cross-validation <pred_probs_cross_val>`.
+cleanlab finds issues in *any dataset that a classifier can be trained on*. The cleanlab package *works with any model* by using model outputs (predicted probabilities) as input -- it doesn't depend on which model created those outputs.
 
-Setting `return_indices_ranked_by` in this function instructs cleanlab to return the indices of potential mislabeled examples, ordered by the likelihood of their given label being incorrect. This is estimated via a *label quality score*, which for example can be specified as ``'self_confidence'`` (predicted probability the given label).
+If you're using a scikit-learn-compatible model (option 1), you don't need to train a model -- you can pass the model, data, and labels into :py:meth:`CleanLearning.find_label_issues <cleanlab.classification.CleanLearning.find_label_issues>` and cleanlab will handle model training for you. If you want to use any non-sklearn-compatible model, e.g. from huggingface, keras, pytorch, etc. (option 2), you can input the trained model's out-of-sample predicted probabilities into :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>`. Examples for both options are below.
 
 .. code-block:: python
 
     from cleanlab.classification import CleanLearning
     from cleanlab.filter import find_label_issues
     
-    # Option 1 - sklearn-compatible models - just provide the data and labels ツ
+    # Option 1 - works with sklearn-compatible models - just input the data and labels ツ
     issues_df = CleanLearning(clf=sklearn_compatible_model).find_label_issues(data, labels)
 
-    # Option 2 - ANY ML model - just provide the model's predicted probabilities
+    # Option 2 - works with ANY ML model - just input the model's predicted probabilities
     ordered_label_issues = find_label_issues(
         labels=labels,
         pred_probs=pred_probs,  # out-of-sample predicted probabilities from any model
         return_indices_ranked_by='self_confidence',
     )
+
+
+By default, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` returns a boolean mask of label issues, but setting `return_indices_ranked_by`, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` will return the indices of potential mislabeled examples ordered by likelihood of a label issue (estimated via :py:meth:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`).
 
 .. important::
    The predicted probabilities, ``pred_probs``, from your model **must be out-of-sample**. Never provide predictions on the same data points used to train the model -- these predictions are overfit and unsuitable for finding label errors. Details on how to compute out-of-sample predicted probabilities for your entire dataset are :ref:`here <pred_probs_cross_val>`.
@@ -72,9 +75,9 @@ When the :py:meth:`.fit() <cleanlab.classification.CleanLearning.fit>` method is
    from sklearn.linear_model import LogisticRegression
    from cleanlab.classification import CleanLearning
 
-   # Train an ML model with noisy labels - 3 lines of code
    cl = CleanLearning(clf=LogisticRegression())  # any sklearn-compatible classifier
    cl.fit(X=train_data, labels=labels)
+
    # Estimate the predictions you would have gotten if you trained with error-free labels.
    predictions = cl.predict(test_data)
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,7 +37,7 @@ Quickstart
 
 cleanlab finds issues in *any dataset that a classifier can be trained on*. The cleanlab package *works with any model* by using model outputs (predicted probabilities) as input -- it doesn't depend on which model created those outputs.
 
-If you're using a scikit-learn-compatible model (option 1), you don't need to train a model -- you can pass the model, data, and labels into :py:meth:`CleanLearning.find_label_issues <cleanlab.classification.CleanLearning.find_label_issues>` and cleanlab will handle model training for you. If you want to use any non-sklearn-compatible model, e.g. from huggingface, keras, pytorch, etc. (option 2), you can input the trained model's out-of-sample predicted probabilities into :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>`. Examples for both options are below.
+If you're using a scikit-learn-compatible model (option 1), you don't need to train a model -- you can pass the model, data, and labels into :py:meth:`CleanLearning.find_label_issues <cleanlab.classification.CleanLearning.find_label_issues>` and cleanlab will handle model training for you. If you want to use any non-sklearn-compatible model (option 2), you can input the trained model's out-of-sample predicted probabilities into :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>`. Examples for both options are below.
 
 .. code-block:: python
 
@@ -54,6 +54,7 @@ If you're using a scikit-learn-compatible model (option 1), you don't need to tr
         return_indices_ranked_by='self_confidence',
     )
 
+:py:class:`CleanLearning <cleanlab.classification.CleanLearning>` (Option 1) also works with models from most standard ML frameworks by wrapping the model for scikit-learn compliance, e.g. huggingface (using KerasWrapperModel), Keras (works by default), pytorch (using skorch), etc. 
 
 By default, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` returns a boolean mask of label issues. You can instead return the indices of potential mislabeled examples by setting `return_indices_ranked_by` in :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>`. The indices are ordered by likelihood of a label issue (estimated via :py:meth:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`).
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,7 +56,7 @@ If you're using a scikit-learn-compatible model (option 1), you don't need to tr
 
 :py:class:`CleanLearning <cleanlab.classification.CleanLearning>` (Option 1) also works with models from most standard ML frameworks by wrapping the model for scikit-learn compliance, e.g. huggingface (using KerasWrapperModel), Keras (works by default), pytorch (using skorch), etc. 
 
-By default, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` returns a boolean mask of label issues. You can instead return the indices of potential mislabeled examples by setting `return_indices_ranked_by` in :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>`. The indices are ordered by likelihood of a label issue (estimated via :py:meth:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`).
+By default, :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>` returns a boolean mask of label issues. You can instead return the indices of potential mislabeled examples by setting `return_indices_ranked_by` in :py:meth:`find_label_issues <cleanlab.filter.find_label_issues>`. The indices are ordered by likelihood of a label error (estimated via :py:meth:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`).
 
 .. important::
    The predicted probabilities, ``pred_probs``, from your model **must be out-of-sample**. Never provide predictions on the same data points used to train the model -- these predictions are overfit and unsuitable for finding label errors. Details on how to compute out-of-sample predicted probabilities for your entire dataset are :ref:`here <pred_probs_cross_val>`.


### PR DESCRIPTION
Updated the label errors and learning with noisy labels code examples to better reflect the the generality and usability of the package (with clearer example variable names and comments that help the user understand what's going on).

Also made a few minor tweaks to other language.