### PR TITLE
Fixed relative linking for outlier example

### DIFF
--- a/docs/source/tutorials/outliers.ipynb
+++ b/docs/source/tutorials/outliers.ipynb
@@ -503,7 +503,7 @@
     "[Back to the Basics: Revisiting Out-of-Distribution Detection Baselines](https://arxiv.org/abs/2207.03061)\n",
     "\n",
     "\n",
-    "Internally, cleanlab uses the `sklearn.neighbors.NearestNeighbor` class (with *cosine* distance) to find the K nearest neighbors, but you can easily use [another KNN estimator](https://github.com/cleanlab/examples/blob/master/9_outlier_detection_cifar10/outlier_detection.ipynb) with cleanlab's `OutOfDistribution` class."
+    "Internally, cleanlab uses the `sklearn.neighbors.NearestNeighbor` class (with *cosine* distance) to find the K nearest neighbors, but you can easily use [another KNN estimator](https://github.com/cleanlab/examples/blob/master/9_cifar10_outlier_detection/outlier_detection.ipynb) with cleanlab's `OutOfDistribution` class."
    ]
   },
   {
@@ -515,7 +515,7 @@
     "\n",
     "We sometimes wish to find outliers in classification datasets for which we do not have meaningful numeric feature representations. In this case, cleanlab can detect unusual examples in the data solely using predicted probabilities from a trained classifier.\n",
     "\n",
-    "To get `pred_probs` here, a Logistic Regression classifier is fit using cross-validation on the already generated `train_feature_embeddings` (from our pretrained timm network) and the given label for each training image. We use a simple classifier here to quickly generate `pred_probs`, but in practice [fine-tuning the entire neural network for classification](https://github.com/cleanlab/examples/blob/master/9_outlier_detection_cifar10/outlier_detection.ipynb) will be more effective (our approach here is equivalent to only training an extra output layer appended  on top of the pretrained network). Cross-validation allows us to generate out-of-sample `pred_probs` for every example in the dataset. These are less biased reflections of the classifier's outputs on previously unseen data.  "
+    "To get `pred_probs` here, a Logistic Regression classifier is fit using cross-validation on the already generated `train_feature_embeddings` (from our pretrained timm network) and the given label for each training image. We use a simple classifier here to quickly generate `pred_probs`, but in practice [fine-tuning the entire neural network for classification](https://github.com/cleanlab/examples/blob/master/9_cifar10_outlier_detection/outlier_detection.ipynb) will be more effective (our approach here is equivalent to only training an extra output layer appended  on top of the pretrained network). Cross-validation allows us to generate out-of-sample `pred_probs` for every example in the dataset. These are less biased reflections of the classifier's outputs on previously unseen data.  "
    ]
   },
   {
@@ -658,7 +658,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- renamed outlier example in cleanlab/examples
- fixed all relative linking

Ref cleanlab/examples#18
