### PR TITLE
Format return docstrings and add typing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           pip install .  # install dependencies
           pip install -r requirements-dev.txt  # install development dependencies and type stubs
       - name: Type check
-        run: mypy --install-types --non-interactive cleanlab
+        run: mypy --install-types --non-interactive --allow-redefinition cleanlab
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/cleanlab/benchmarking/noise_generation.py
+++ b/cleanlab/benchmarking/noise_generation.py
@@ -25,6 +25,7 @@ generating noisy labels given a noise matrix, generating valid noise matrices wi
 import numpy as np
 from cleanlab.internal.util import value_counts
 import warnings
+from typing import Optional
 
 
 def noise_matrix_is_valid(noise_matrix, py, *, verbose=False) -> bool:
@@ -200,7 +201,7 @@ def generate_noise_matrix_from_trace(
     frac_zero_noise_rates=0.0,
     seed=0,
     max_iter=10000,
-) -> np.ndarray:
+) -> Optional[np.ndarray]:
     """Generates a ``K x K`` noise matrix ``P(label=k_s|true_label=k_y)`` with
     ``np.sum(np.diagonal(noise_matrix))`` equal to the given `trace`.
 

--- a/cleanlab/benchmarking/noise_generation.py
+++ b/cleanlab/benchmarking/noise_generation.py
@@ -27,7 +27,7 @@ from cleanlab.internal.util import value_counts
 import warnings
 
 
-def noise_matrix_is_valid(noise_matrix, py, *, verbose=False):
+def noise_matrix_is_valid(noise_matrix, py, *, verbose=False) -> bool:
     """Given a prior `py` representing ``p(true_label=k)``, checks if the given `noise_matrix` is a
     learnable matrix. Learnability means that it is possible to achieve
     better than random performance, on average, for the amount of noise in
@@ -47,7 +47,7 @@ def noise_matrix_is_valid(noise_matrix, py, *, verbose=False):
 
     Returns
     -------
-    bool
+    is_valid : bool
       Whether the noise matrix is a learnable matrix.
     """
 
@@ -105,7 +105,7 @@ def noise_matrix_is_valid(noise_matrix, py, *, verbose=False):
     return True
 
 
-def generate_noisy_labels(true_labels, noise_matrix):
+def generate_noisy_labels(true_labels, noise_matrix) -> np.ndarray:
     """Generates noisy `labels` from perfect labels `true_labels`,
     "exactly" yielding the provided `noise_matrix` between `labels` and `true_labels`.
 
@@ -200,7 +200,7 @@ def generate_noise_matrix_from_trace(
     frac_zero_noise_rates=0.0,
     seed=0,
     max_iter=10000,
-):
+) -> np.ndarray:
     """Generates a ``K x K`` noise matrix ``P(label=k_s|true_label=k_y)`` with
     ``np.sum(np.diagonal(noise_matrix))`` equal to the given `trace`.
 
@@ -358,7 +358,7 @@ def generate_n_rand_probabilities_that_sum_to_m(
     *,
     max_prob=1.0,
     min_prob=0.0,
-):
+) -> np.ndarray:
     """
     Generates `n` random probabilities that sum to `m`.
 
@@ -378,6 +378,11 @@ def generate_n_rand_probabilities_that_sum_to_m(
 
     min_prob : float, default=0.0
       Minimum probability of any entry in the returned array. Must be between 0 and 1.
+
+    Returns
+    -------
+    probabilities : np.ndarray
+      An array of probabilities.
     """
 
     epsilon = 1e-6  # Imprecision allowed for inequalities with floats
@@ -447,9 +452,9 @@ def randomly_distribute_N_balls_into_K_bins(
     *,
     max_balls_per_bin=None,
     min_balls_per_bin=None,
-):
-    """Returns a uniformly random numpy integer array of length N that sums
-    to K.
+) -> np.ndarray:
+    """Returns a uniformly random numpy integer array of length `N` that sums
+    to `K`.
 
     Parameters
     ----------
@@ -464,7 +469,8 @@ def randomly_distribute_N_balls_into_K_bins(
 
     Returns
     -------
-    np.array
+    int_array : np.array
+      Length `N` array that sums to `K`.
     """
 
     if N == 0:

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -510,8 +510,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                 labels, pred_probs, **self.label_quality_scores_kwargs
             )
 
-        self.label_issues_mask = self.label_issues_df["is_label_issue"].values
-        assert isinstance(self.label_issues_df, np.ndarray)
+        self.label_issues_mask = self.label_issues_df["is_label_issue"].to_numpy()
         x_mask = ~self.label_issues_mask
         x_cleaned, labels_cleaned = subset_X_y(X, labels, x_mask)
         if self.verbose:
@@ -983,7 +982,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             if len(label_issues) != len(labels):
                 raise ValueError("label_issues and labels must have same length")
             if "given_label" in label_issues.columns and np.any(
-                label_issues["given_label"].values != labels
+                label_issues["given_label"].to_numpy() != labels
             ):
                 raise ValueError("labels must match label_issues['given_label']")
             return label_issues

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -119,7 +119,7 @@ import numpy as np
 import pandas as pd
 import inspect
 import warnings
-from typing import TypeVar
+from typing import TypeVar, Optional
 
 from cleanlab.rank import get_label_quality_scores
 from cleanlab import filter
@@ -511,6 +511,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             )
 
         self.label_issues_mask = self.label_issues_df["is_label_issue"].values
+        assert isinstance(self.label_issues_df, np.ndarray)
         x_mask = ~self.label_issues_mask
         x_cleaned, labels_cleaned = subset_X_y(X, labels, x_mask)
         if self.verbose:
@@ -890,7 +891,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         return label_issues_df
 
-    def get_label_issues(self) -> pd.DataFrame:
+    def get_label_issues(self) -> Optional[pd.DataFrame]:
         """
         Accessor. Returns `label_issues_df` attribute if previously already computed.
         This ``pd.DataFrame`` describes the label issues identified for each example

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -119,6 +119,7 @@ import numpy as np
 import pandas as pd
 import inspect
 import warnings
+from typing import TypeVar
 
 from cleanlab.rank import get_label_quality_scores
 from cleanlab import filter
@@ -143,6 +144,9 @@ from cleanlab.internal.validation import (
     assert_valid_inputs,
     labels_to_array,
 )
+
+
+TCleanLearning = TypeVar("TCleanLearning", bound="CleanLearning")  # self type for the class
 
 
 class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
@@ -275,7 +279,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         clf_final_kwargs={},
         validation_func=None,
         y=None,
-    ):
+    ) -> TCleanLearning:
         """
         Train the model `clf` with error-prone, noisy labels as if
         the model had been instead trained on a dataset with the correct labels.
@@ -292,8 +296,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           ``pd.DataFrame``, ``scipy.sparse.csr_matrix``, ``torch.utils.data.Dataset``, ``tensorflow.data.Dataset``,
           or any dataset object ``X`` that supports list-based indexing:
           ``X[index_list]`` to select a subset of training examples.
-          The classifier that this instance was initialized with,
-          ``clf``, must be able to fit() and predict() data of this format.
+          Your classifier that this instance was initialized with,
+          ``clf``, must be able to ``fit()`` and ``predict()`` data of this format.
 
           Note
           ----
@@ -584,41 +588,60 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             )
         return self
 
-    def predict(self, *args, **kwargs):
-        """Returns a vector of predictions.
+    def predict(self, *args, **kwargs) -> np.ndarray:
+        """Predict class labels using your wrapped classifier `clf`.
+        Works just like ``clf.predict()``.
 
         Parameters
         ----------
-        X : np.ndarray
-          An array of shape ``(N, ...)`` of test data."""
+        X : np.ndarray or DatasetLike
+          Test data in the same format expected by your wrapped classifier.
+
+        Returns
+        -------
+        class_predictions : np.ndarray
+          Vector of class predictions for the test examples.
+        """
 
         return self.clf.predict(*args, **kwargs)
 
-    def predict_proba(self, *args, **kwargs):
-        """Returns a vector of predicted probabilities for each example in X,
-        ``P(true label=k)``.
+    def predict_proba(self, *args, **kwargs) -> np.ndarray:
+        """Predict class probabilities ``P(true label=k)`` using your wrapped classifier `clf`.
+        Works just like ``clf.predict_proba()``.
 
         Parameters
         ----------
-        X : np.ndarray
-          An array of shape ``(N, ...)`` of test data."""
+        X : np.ndarray or DatasetLike
+          Test data in the same format expected by your wrapped classifier.
+
+        Returns
+        -------
+        pred_probs : np.ndarray
+          ``(N x K)`` array of predicted class probabilities, one row for each test example.
+        """
 
         return self.clf.predict_proba(*args, **kwargs)
 
-    def score(self, X, y, sample_weight=None):
-        """Returns the `clf`'s score on a test set `X` with labels `y`.
-        Uses the model's default scoring function.
+    def score(self, X, y, sample_weight=None) -> float:
+        """Evaluates your wrapped classifier `clf`'s score on a test set `X` with labels `y`.
+        Uses your model's default scoring function, or simply accuracy if your model as no ``"score"`` attribute.
 
         Parameters
         ----------
-        X : np.ndarray
-          An array of shape ``(N, ...)`` of test data.
+        X : np.ndarray or DatasetLike
+          Test data in the same format expected by your wrapped classifier.
 
-        y : np.ndarray
-          An array of shape ``(N,)`` or ``(N, 1)`` of test labels.
+        y : array_like
+          Test labels in the same format as labels previously used in ``fit()``.
 
         sample_weight : np.ndarray, optional
-          An array of shape ``(N,)`` or ``(N, 1)`` used to weight each example when computing the score."""
+          An array of shape ``(N,)`` or ``(N, 1)`` used to weight each test example when computing the score.
+
+        Returns
+        -------
+        score: float
+          Number quantifying the performance of this classifier on the test data.
+        """
 
         if hasattr(self.clf, "score"):
 
@@ -646,7 +669,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         save_space=False,
         clf_kwargs={},
         validation_func=None,
-    ):
+    ) -> pd.DataFrame:
         """
         Identifies potential label issues in the dataset using confident learning.
 
@@ -689,8 +712,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         Returns
         -------
-        pd.DataFrame
-          pandas DataFrame of label issues for each example.
+        label_issues_df : pd.DataFrame
+          DataFrame with info about label issues for each example.
           Unless `save_space` argument is specified, same DataFrame is also stored as
           `self.label_issues_df` attribute accessible via
           :py:meth:`get_label_issues<cleanlab.classification.CleanLearning.get_label_issues>`.
@@ -867,7 +890,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         return label_issues_df
 
-    def get_label_issues(self):
+    def get_label_issues(self) -> pd.DataFrame:
         """
         Accessor. Returns `label_issues_df` attribute if previously already computed.
         This ``pd.DataFrame`` describes the label issues identified for each example
@@ -877,7 +900,8 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
         Returns
         -------
-        pd.DataFrame
+        label_issues_df : pd.DataFrame
+          DataFrame with (precomputed) info about label issues for each example.
         """
 
         if self.label_issues_df is None:
@@ -943,7 +967,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             self.confident_joint = find_label_issues_kwargs["confident_joint"]
         self.find_label_issues_kwargs = find_label_issues_kwargs
 
-    def _process_label_issues_arg(self, label_issues, labels):
+    def _process_label_issues_arg(self, label_issues, labels) -> pd.DataFrame:
         """
         Helper method to get the label_issues input arg into a formatted DataFrame.
         """

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -228,6 +228,7 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
     else:
         calibrated_cj = calibrate_confident_joint(confident_joint, labels, multi_label=multi_label)
 
+    assert isinstance(calibrated_cj, np.ndarray)
     return calibrated_cj / float(np.sum(calibrated_cj))
 
 
@@ -238,7 +239,7 @@ def _compute_confident_joint_multi_label(
     thresholds=None,
     calibrate=True,
     return_indices_of_off_diagonals=False,
-) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+) -> Union[np.ndarray, Tuple[np.ndarray, list]]:
     """Computes the confident joint for multi_labeled data. Thus,
     input `labels` is a list of lists (or list of iterable).
     This is intended as a helper function. You should probably
@@ -306,9 +307,11 @@ def _compute_confident_joint_multi_label(
             np.any(np.delete(pred_probs_bool, k, axis=1)[k_in_l[k]], axis=1) for k in unique_classes
         ]
         # Map boolean mask to the indices of the examples, for each class k
-        indices_of_issues = [indices_k_in_l[k][issues_mask[k]] for k in unique_classes]
+        indices_of_issues_list = [indices_k_in_l[k][issues_mask[k]] for k in unique_classes]
         # Combine error indices for each class k into a single set of all the indices of errors
-        indices_of_issues = np.asarray(list(set([z for lst in indices_of_issues for z in lst])))
+        indices_of_issues = np.asarray(
+            list(set([z for lst in indices_of_issues_list for z in lst]))
+        )
         return confident_joint, sorted(indices_of_issues)
 
     return confident_joint
@@ -322,7 +325,7 @@ def compute_confident_joint(
     calibrate=True,
     multi_label=False,
     return_indices_of_off_diagonals=False,
-) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+) -> Union[np.ndarray, Tuple[np.ndarray, list]]:
     """Estimates the confident counts of latent true vs observed noisy labels
     for the examples in our dataset. This array of shape ``(K, K)`` is called the **confident joint**
     and contains counts of examples in every class, confidently labeled as every other class.
@@ -638,6 +641,7 @@ def estimate_py_and_noise_matrices_from_probabilities(
         py_method=py_method,
         converge_latent_estimates=converge_latent_estimates,
     )
+    assert isinstance(confident_joint, np.ndarray)
 
     return py, noise_matrix, inv_noise_matrix, confident_joint
 
@@ -813,6 +817,8 @@ def estimate_confident_joint_and_cv_pred_proba(
         thresholds=thresholds,
         calibrate=calibrate,
     )
+    assert isinstance(confident_joint, np.ndarray)
+    assert isinstance(pred_probs, np.ndarray)
 
     return confident_joint, pred_probs
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -30,6 +30,7 @@ import sklearn.base
 import numpy as np
 import pandas as pd
 import warnings
+from typing import Tuple, Union
 
 from cleanlab.internal.util import (
     value_counts,
@@ -58,7 +59,7 @@ def num_label_issues(
     labels,
     pred_probs,
     confident_joint=None,
-):
+) -> int:
     """Estimates the number of label issues in the `labels` of a dataset.
 
     This method is **more accurate** than ``sum(find_label_issues())`` because its computed using only
@@ -99,8 +100,8 @@ def num_label_issues(
 
     Returns
     -------
-    int
-      An estimate of the number of label issues.
+    num_issues : int
+      The estimated number of examples with label issues in the dataset.
     """
 
     if confident_joint is None:
@@ -113,7 +114,7 @@ def num_label_issues(
     return num_issues
 
 
-def calibrate_confident_joint(confident_joint, labels, *, multi_label=False):
+def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> np.ndarray:
     """Calibrates any confident joint estimate ``P(label=i, true_label=j)`` such that
     ``np.sum(cj) == len(labels)`` and ``np.sum(cj, axis = 1) == np.bincount(labels)``.
 
@@ -171,7 +172,7 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False):
     return round_preserving_row_totals(calibrated_cj)
 
 
-def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=False):
+def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=False) -> np.ndarray:
     """
     Estimates the joint distribution of label noise ``P(label=i, true_label=j)`` guaranteed to:
 
@@ -212,9 +213,9 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
 
     Returns
     -------
-    confident_joint : np.ndarray
+    confident_joint_distribution : np.ndarray
       An array of shape ``(K, K)`` representing an
-      estimate of the true joint of noisy and true labels.
+      estimate of the true joint distribution of noisy and true labels.
     """
 
     if confident_joint is None:
@@ -237,7 +238,7 @@ def _compute_confident_joint_multi_label(
     thresholds=None,
     calibrate=True,
     return_indices_of_off_diagonals=False,
-):
+) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
     """Computes the confident joint for multi_labeled data. Thus,
     input `labels` is a list of lists (or list of iterable).
     This is intended as a helper function. You should probably
@@ -321,25 +322,16 @@ def compute_confident_joint(
     calibrate=True,
     multi_label=False,
     return_indices_of_off_diagonals=False,
-):
-    """Estimates ``P(labels,y)``, the confident counts of the latent
-    joint distribution of true and noisy labels
-    using observed labels and predicted probabilities pred_probs.
-
-    This estimate is called the confident joint.
-
-    When ``calibrate=True``, this method returns an estimate of
-    the latent true joint counts of noisy and true labels.
+) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+    """Estimates the confident counts of latent true vs observed noisy labels
+    for the examples in our dataset. This array of shape ``(K, K)`` is called the **confident joint**
+    and contains counts of examples in every class, confidently labeled as every other class.
+    These counts may subsequently be used to estimate the joint distribution of true and noisy labels
+    (by normalizing them to frequencies).
 
     Important: this function assumes that `pred_probs` are out-of-sample
     holdout probabilities. This can be :ref:`done with cross validation <pred_probs_cross_val>`. If
     the probabilities are not computed out-of-sample, overfitting may occur.
-
-    This function estimates the joint of shape ``(K, K)``. This is the
-    confident counts of examples in every class, labeled as every other class.
-
-    Under certain conditions, estimates are exact, and in most
-    conditions, the estimate is within 1 percent of the truth.
 
     Parameters
     ----------
@@ -375,6 +367,8 @@ def compute_confident_joint(
     calibrate : bool, default=True
         Calibrates confident joint estimate ``P(label=i, true_label=j)`` such that
         ``np.sum(cj) == len(labels)`` and ``np.sum(cj, axis = 1) == np.bincount(labels)``.
+        When ``calibrate=True``, this method returns an estimate of
+        the latent true joint counts of noisy and true labels.
 
     multi_label : bool, optional
       If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
@@ -391,6 +385,13 @@ def compute_confident_joint(
       of confident joint as a baseline proxy for the label issues. This
       sometimes works as well as ``filter.find_label_issues(confident_joint)``.
 
+    Returns
+    -------
+    confident_joint_counts : np.ndarray
+      An array of shape ``(K, K)`` representing counts of examples
+      for which we are confident about their given and true label.
+      If `return_indices_of_off_diagonals` is ``True``, `confident_joint_counts` is the first element of returned tuple
+      and second element is another array of indices counted in off-diagonals of confident joint.
 
     Note
     ----
@@ -485,7 +486,7 @@ def estimate_latent(
     *,
     py_method="cnt",
     converge_latent_estimates=False,
-):
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Computes the latent prior ``p(y)``, the noise matrix ``P(labels|y)`` and the
     inverse noise matrix ``P(y|labels)`` from the `confident_joint` ``count(labels, y)``. The
     `confident_joint` can be estimated by `compute_confident_joint <cleanlab.count.compute_confident_joint>`
@@ -562,7 +563,7 @@ def estimate_py_and_noise_matrices_from_probabilities(
     converge_latent_estimates=True,
     py_method="cnt",
     calibrate=True,
-):
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Computes the confident counts
     estimate of latent variables `py` and the noise rates
     using observed labels and predicted probabilities, `pred_probs`.
@@ -622,8 +623,8 @@ def estimate_py_and_noise_matrices_from_probabilities(
 
     Returns
     ------
-    tuple
-        A tuple of (py, noise_matrix, inverse_noise_matrix, confident_joint)."""
+    estimates : tuple
+        A tuple of arrays: (`py`, `noise_matrix`, `inverse_noise_matrix`, `confident_joint`)."""
 
     confident_joint = compute_confident_joint(
         labels=labels,
@@ -652,7 +653,7 @@ def estimate_confident_joint_and_cv_pred_proba(
     calibrate=True,
     clf_kwargs={},
     validation_func=None,
-):
+) -> Tuple[np.ndarray, np.ndarray]:
     """Estimates ``P(labels, y)``, the confident counts of the latent
     joint distribution of true and noisy labels
     using observed `labels` and predicted probabilities `pred_probs`.
@@ -723,7 +724,7 @@ def estimate_confident_joint_and_cv_pred_proba(
 
     Returns
     ------
-    tuple
+    estimates : tuple
       Tuple of two numpy arrays in the form:
       (joint counts matrix, predicted probability matrix)"""
 
@@ -828,7 +829,7 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
     seed=None,
     clf_kwargs={},
     validation_func=None,
-):
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """This function computes the out-of-sample predicted
     probability ``P(label=k|x)`` for every example x in `X` using cross
     validation while also computing the confident counts noise
@@ -897,8 +898,8 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
 
     Returns
     ------
-    tuple
-      A tuple of five arrays (py, noise_matrix, inverse_noise_matrix, confident joint, predicted probability matrix).
+    estimates: tuple
+      A tuple of five arrays (py, noise matrix, inverse noise matrix, confident joint, predicted probability matrix).
     """
 
     confident_joint, pred_probs = estimate_confident_joint_and_cv_pred_proba(
@@ -931,7 +932,7 @@ def estimate_cv_predicted_probabilities(
     seed=None,
     clf_kwargs={},
     validation_func=None,
-):
+) -> np.ndarray:
     """This function computes the out-of-sample predicted
     probability [P(label=k|x)] for every example in X using cross
     validation. Output is a np.ndarray of shape (N, K) where N is
@@ -997,7 +998,7 @@ def estimate_noise_matrices(
     seed=None,
     clf_kwargs={},
     validation_func=None,
-):
+) -> Tuple[np.ndarray, np.ndarray]:
     """Estimates the `noise_matrix` of shape ``(K, K)``. This is the
     fraction of examples in every class, labeled as every other class. The
     `noise_matrix` is a conditional probability matrix for ``P(label=k_s|true_label=k_y)``.
@@ -1055,8 +1056,8 @@ def estimate_noise_matrices(
 
     Returns
     ------
-    tuple
-      A tuple containing (noise_matrix, inv_noise_matrix)."""
+    estimates : tuple
+      A tuple containing arrays (`noise_matrix`, `inv_noise_matrix`)."""
 
     return estimate_py_noise_matrices_and_cv_pred_proba(
         X=X,
@@ -1079,7 +1080,7 @@ def _converge_estimates(
     *,
     inv_noise_matrix_iterations=5,
     noise_matrix_iterations=3,
-):
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Updates py := P(true_label=k) and both `noise_matrix` and `inverse_noise_matrix`
     to be numerically consistent with each other, by iteratively updating their estimates based on
     the mathematical relationships between them.
@@ -1132,7 +1133,8 @@ def _converge_estimates(
 
     Returns
     ------
-        Three np.ndarrays of the form (py, noise_matrix, inverse_noise_matrix) all
+    estimates: tuple
+        Three arrays of the form (`py`, `noise_matrix`, `inverse_noise_matrix`) all
         having numerical agreement in terms of their mathematical relations."""
 
     for j in range(noise_matrix_iterations):

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -260,10 +260,10 @@ def find_overlapping_classes(
     num_overlapping = (df["Joint Probability"] * num_examples).round().astype(int)
     df.insert(loc=2, column="Num Overlapping Examples", value=num_overlapping)
     if class_names is not None:
-        df.insert(
+        df.insert(  # type: ignore
             loc=0, column="Class Name A", value=df["Class Index A"].apply(lambda x: class_names[x])
         )
-        df.insert(
+        df.insert(  # type: ignore
             loc=1, column="Class Name B", value=df["Class Index B"].apply(lambda x: class_names[x])
         )
     return df.sort_values(by="Joint Probability", ascending=False).reset_index(drop=True)

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -33,7 +33,7 @@ def rank_classes_by_label_quality(
     joint=None,
     confident_joint=None,
     multi_label=False,
-):
+) -> pd.DataFrame:
     """
     Returns a Pandas DataFrame with all classes and three overall class label quality scores
     (details about each score are listed in the Returns parameter). By default, classes are ordered
@@ -54,8 +54,8 @@ def rank_classes_by_label_quality(
 
     Returns
     -------
-    pd.DataFrame
-        A Pandas DataFrame with cols "Class Index", "Label Issues", "Inverse Label Issues",
+    overall_label_quality : pd.DataFrame
+        Pandas DataFrame with cols "Class Index", "Label Issues", "Inverse Label Issues",
         "Label Issues", "Inverse Label Noise", "Label Quality Score",
         with a description of each of these columns below.
         The length of the DataFrame is ``num_classes`` (one row per class).
@@ -112,7 +112,7 @@ def find_overlapping_classes(
     joint=None,
     confident_joint=None,
     multi_label=False,
-):
+) -> pd.DataFrame:
     """Returns the pairs of classes that are often mislabeled as one another.
     Consider merging the top pairs of classes returned by this method each into a single class.
     If the dataset is labeled by human annotators, consider clearly defining the
@@ -208,8 +208,8 @@ def find_overlapping_classes(
 
     Returns
     -------
-    pd.DataFrame
-        A Pandas DataFrame with columns "Class Index A", "Class Index B",
+    overlapping_classes : pd.DataFrame
+        Pandas DataFrame with columns "Class Index A", "Class Index B",
         "Num Overlapping Examples", "Joint Probability" and a description of each below.
         Each row corresponds to a pair of classes.
 
@@ -278,7 +278,7 @@ def overall_label_health_score(
     confident_joint=None,
     multi_label=False,
     verbose=True,
-):
+) -> float:
     """Returns a single score between 0 and 1 measuring the overall quality of all labels in a dataset.
     Intuitively, the score is the average correctness of the given labels across all examples in the
     dataset. So a score of 1 suggests your data is perfectly labeled and a score of 0.5 suggests
@@ -333,7 +333,7 @@ def health_summary(
     confident_joint=None,
     multi_label=False,
     verbose=True,
-):
+) -> dict:
     """Prints a health summary of your datasets including useful statistics like:
 
     * The classes with the most and least label issues
@@ -352,7 +352,7 @@ def health_summary(
 
     Returns
     -------
-    dict
+    summary : dict
         A dictionary containing keys (see the corresponding functions' documentation to understand the values):
 
         - ``"overall_label_health_score"``, corresponding to :py:func:`overall_label_health_score <cleanlab.dataset.overall_label_health_score>`
@@ -441,7 +441,7 @@ def health_summary(
     }
 
 
-def _get_num_examples(labels=None):
+def _get_num_examples(labels=None) -> int:
     """Helper method that finds the number of examples from the parameters or throws an error
     if neither parameter is provided.
 

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -25,6 +25,7 @@ import multiprocessing
 from multiprocessing.sharedctypes import RawArray
 import sys
 import warnings
+from typing import Any
 
 from cleanlab.count import calibrate_confident_joint
 from cleanlab.rank import order_label_issues
@@ -65,7 +66,7 @@ def find_label_issues(
     confident_joint=None,
     n_jobs=None,
     verbose=False,
-):
+) -> np.ndarray:
     """
     Identifies potentially bad labels in a dataset (with `N` examples) using confident learning.
 
@@ -188,13 +189,15 @@ def find_label_issues(
     Returns
     -------
     label_issues : np.ndarray
-      A boolean mask for the entire dataset where ``True`` represents a
-      label issue and ``False`` represents an example that is accurately
-      labeled with high confidence.
+      If `return_indices_ranked_by` left unspecified, returns a boolean **mask** for the entire dataset
+      where ``True`` represents a label issue and ``False`` represents an example that is
+      accurately labeled with high confidence.
+      If `return_indices_ranked_by` is specified, returns a shorter array of **indices** of examples identified to have
+      label issues (i.e. those indices where the mask would be ``True``), sorted by likelihood that the corresponding label is correct.
 
       Note
       ----
-      You can also return the *indices* of the label issues in your dataset by setting
+      Obtain the *indices* of label issues in your dataset by setting
       `return_indices_ranked_by`.
     """
 
@@ -395,7 +398,7 @@ def find_label_issues(
     return label_issues_mask
 
 
-def _keep_at_least_n_per_class(prune_count_matrix, n, *, frac_noise=1.0):
+def _keep_at_least_n_per_class(prune_count_matrix, n, *, frac_noise=1.0) -> np.ndarray:
     """Make sure every class has at least n examples after removing noise.
     Functionally, increase each column, increases the diagonal term #(true_label=k,label=k)
     of prune_count_matrix until it is at least n, distributing the amount
@@ -461,7 +464,7 @@ def _keep_at_least_n_per_class(prune_count_matrix, n, *, frac_noise=1.0):
     return round_preserving_row_totals(new_mat).astype(int)
 
 
-def _reduce_prune_counts(prune_count_matrix, frac_noise=1.0):
+def _reduce_prune_counts(prune_count_matrix, frac_noise=1.0) -> np.ndarray:
     """Reduce (multiply) all prune counts (non-diagonal) by frac_noise and
     increase diagonal by the total amount reduced in each column to
     preserve column counts.
@@ -492,7 +495,7 @@ def _reduce_prune_counts(prune_count_matrix, frac_noise=1.0):
     return new_mat.astype(int)
 
 
-def find_predicted_neq_given(labels, pred_probs, *, multi_label=False):
+def find_predicted_neq_given(labels, pred_probs, *, multi_label=False) -> np.ndarray:
     """A simple baseline approach that considers ``argmax(pred_probs) != labels`` as a label error.
 
     Parameters
@@ -529,7 +532,7 @@ def find_label_issues_using_argmax_confusion_matrix(
     *,
     calibrate=True,
     filter_by="prune_by_noise_rate",
-):
+) -> np.ndarray:
     """This is a baseline approach that uses the confusion matrix
     of ``argmax(pred_probs)`` and labels as the confident joint and then uses cleanlab
     (confident learning) to find the label issues using this matrix.
@@ -588,7 +591,7 @@ def find_label_issues_using_argmax_confusion_matrix(
 mp_params = {}  # Globals to be shared across threads in multiprocessing
 
 
-def _to_np_array(mp_arr, dtype="int32", shape=None):  # pragma: no cover
+def _to_np_array(mp_arr, dtype="int32", shape=None) -> np.ndarray:  # pragma: no cover
     """multipropecessing Helper function to convert a multiprocessing
     RawArray to a numpy array."""
     arr = np.frombuffer(mp_arr, dtype=dtype)
@@ -620,7 +623,7 @@ def _init(
     mp_params["min_examples_per_class"] = __min_examples_per_class
 
 
-def _get_shared_data():  # pragma: no cover
+def _get_shared_data() -> Any:  # pragma: no cover
     """multiprocessing helper function to extract numpy arrays from
     shared RawArray types used to shared data across process."""
 
@@ -655,7 +658,7 @@ def _get_shared_data():  # pragma: no cover
     )
 
 
-def _prune_by_class(k, args=None):
+def _prune_by_class(k, args=None) -> np.ndarray:
     """multiprocessing Helper function for find_label_issues()
     that assumes globals and produces a mask for class k for each example by
     removing the examples with *smallest probability* of
@@ -699,7 +702,7 @@ def _prune_by_class(k, args=None):
         return np.zeros(len(labels), dtype=bool)
 
 
-def _prune_by_count(k, args=None):
+def _prune_by_count(k, args=None) -> np.ndarray:
     """multiprocessing Helper function for find_label_issues() that assumes
     globals and produces a mask for class k for each example by
     removing the example with noisy label k having *largest margin*,
@@ -751,17 +754,7 @@ def _prune_by_count(k, args=None):
     return label_issues_mask
 
 
-def _self_confidence(args, _pred_probs):  # pragma: no cover
-    """multiprocessing Helper function for find_label_issues() that assumes
-    global pred_probs and computes the self-confidence (prob of given label)
-    for an example (row in pred_probs) given the example index idx
-    and its label l.
-    np.mean(pred_probs[]) enables this code to work for multi-class l."""
-    (idx, l) = args
-    return np.mean(_pred_probs[idx, l])
-
-
-def _multiclass_crossval_predict(labels, pyx):
+def _multiclass_crossval_predict(labels, pyx) -> np.ndarray:
     """Returns a numpy 2D array of one-hot encoded
     multiclass predictions. Each row in the array
     provides the predictions for a particular example.

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -279,7 +279,7 @@ def find_label_issues(
             if multi_label:
                 _labels = RawArray("I", int2onehot(labels).flatten())  # type: ignore
             else:
-                _labels = RawArray("I", labels)
+                _labels = RawArray("I", labels)  # type: ignore
             _label_counts = RawArray("I", label_counts)
             _prune_count_matrix = RawArray("I", prune_count_matrix.flatten())  # type: ignore
             _pred_probs = RawArray("f", pred_probs.flatten())

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -277,11 +277,11 @@ def find_label_issues(
         # Prepare multiprocessing shared data
         if n_jobs > 1:
             if multi_label:
-                _labels = RawArray("I", int2onehot(labels).flatten())
+                _labels = RawArray("I", int2onehot(labels).flatten())  # type: ignore
             else:
                 _labels = RawArray("I", labels)
             _label_counts = RawArray("I", label_counts)
-            _prune_count_matrix = RawArray("I", prune_count_matrix.flatten())
+            _prune_count_matrix = RawArray("I", prune_count_matrix.flatten())  # type: ignore
             _pred_probs = RawArray("f", pred_probs.flatten())
         else:  # Multiprocessing is turned off. Create tuple with all parameters
             args = (
@@ -647,7 +647,7 @@ def _get_shared_data() -> Any:  # pragma: no cover
             )
         )
     else:
-        labels = _to_np_array(mp_params["labels"])
+        labels = _to_np_array(mp_params["labels"])  # type: ignore
     return (
         labels,
         label_counts,

--- a/cleanlab/internal/label_quality_utils.py
+++ b/cleanlab/internal/label_quality_utils.py
@@ -103,6 +103,7 @@ def get_normalized_entropy(pred_probs: np.ndarray, min_allowed_prob: float = 1e-
     min_allowed_prob : float, default=1e-6
       Minimum allowed probability value. Entries of `pred_probs` below this value will be clipped to this value.
       Ensures entropy remains well-behaved even when `pred_probs` contains zeros.
+
     Returns
     -------
     entropy : np.ndarray (float)

--- a/cleanlab/internal/latent_algebra.py
+++ b/cleanlab/internal/latent_algebra.py
@@ -17,49 +17,52 @@
 
 """
 Contains mathematical functions relating the latent terms,
-P(given_label), P(given_label | true_label), P(true_label | given_label), P(true_label), etc. together.
+``P(given_label)``, ``P(given_label | true_label)``, ``P(true_label | given_label)``, ``P(true_label)``, etc. together.
 For every function here, if the inputs are exact, the output is guaranteed to be exact. 
 Every function herein is the computational equivalent of a mathematical equation having a closed, exact form. 
 If the inputs are inexact, the error will of course propagate.
+Throughout `K` denotes the number of classes in the classification task.
 """
 
 import warnings
 import numpy as np
+from typing import Any, Tuple
 
 from cleanlab.internal.util import value_counts, clip_values, clip_noise_rates
 
 
-def compute_ps_py_inv_noise_matrix(labels, noise_matrix):
-    """Compute ps := P(labels=k), py := P(true_labels=k), and the inverse noise matrix.
+def compute_ps_py_inv_noise_matrix(
+    labels, noise_matrix
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute ``ps := P(labels=k), py := P(true_labels=k)``, and the inverse noise matrix.
 
     Parameters
     ----------
     labels : np.ndarray
           A discrete vector of noisy labels, i.e. some labels may be erroneous.
-          *Format requirements*: for dataset with K classes, labels must be in {0,1,...,K-1}.
+          *Format requirements*: for dataset with `K` classes, labels must be in ``{0,1,...,K-1}``.
 
-    noise_matrix : np.ndarray of shape (K, K), K = number of classes
-        A conditional probability matrix of the form P(label=k_s|true_label=k_y) containing
+    noise_matrix : np.ndarray
+        A conditional probability matrix (of shape ``(K, K)``) of the form ``P(label=k_s|true_label=k_y)`` containing
         the fraction of examples in every class, labeled as every other class.
         Assumes columns of noise_matrix sum to 1."""
 
-    # 'ps' is p(labels=k)
-    ps = value_counts(labels) / float(len(labels))
-
+    ps = value_counts(labels) / float(len(labels))  # p(labels=k)
     py, inverse_noise_matrix = compute_py_inv_noise_matrix(ps, noise_matrix)
     return ps, py, inverse_noise_matrix
 
 
-def compute_py_inv_noise_matrix(ps, noise_matrix):
+def compute_py_inv_noise_matrix(ps, noise_matrix) -> Tuple[np.ndarray, np.ndarray]:
     """Compute py := P(true_label=k), and the inverse noise matrix.
 
     Parameters
     ----------
-    ps : np.ndarray (shape (K, ) or (1, K))
-        The fraction (prior probability) of each observed, NOISY class P(labels = k).
+    ps : np.ndarray
+        Array of shape ``(K, )`` or ``(1, K)``.
+        The fraction (prior probability) of each observed, NOISY class ``P(labels = k)``.
 
-    noise_matrix : np.ndarray of shape (K, K), K = number of classes
-        A conditional probability matrix of the form P(label=k_s|true_label=k_y) containing
+    noise_matrix : np.ndarray
+        A conditional probability matrix (of shape ``(K, K)``) of the form ``P(label=k_s|true_label=k_y)`` containing
         the fraction of examples in every class, labeled as every other class.
         Assumes columns of noise_matrix sum to 1."""
 
@@ -76,7 +79,7 @@ def compute_py_inv_noise_matrix(ps, noise_matrix):
     return py, compute_inv_noise_matrix(py=py, noise_matrix=noise_matrix, ps=ps)
 
 
-def compute_inv_noise_matrix(py, noise_matrix, *, ps=None):
+def compute_inv_noise_matrix(py, noise_matrix, *, ps=None) -> np.ndarray:
     """Compute the inverse noise matrix if py := P(true_label=k) is given.
 
     Parameters
@@ -84,15 +87,14 @@ def compute_inv_noise_matrix(py, noise_matrix, *, ps=None):
     py : np.ndarray (shape (K, 1))
         The fraction (prior probability) of each TRUE class label, P(true_label = k)
 
-    noise_matrix : np.ndarray of shape (K, K), K = number of classes
-        A conditional probability matrix of the form P(label=k_s|true_label=k_y) containing
+    noise_matrix : np.ndarray
+        A conditional probability matrix (of shape ``(K, K)``) of the form ``P(label=k_s|true_label=k_y)`` containing
         the fraction of examples in every class, labeled as every other class.
         Assumes columns of noise_matrix sum to 1.
 
-    ps : np.ndarray (shape (K, 1))
-        The fraction (prior probability) of each NOISY given label, P(labels = k).
-        ps is easily computable from py and should only be provided if it has
-        already been precomputed, to increase code efficiency.
+    ps : np.ndarray
+        Array of shape ``(K, 1)`` containing the fraction (prior probability) of each NOISY given label, ``P(labels = k)``.
+        `ps` is easily computable from py and should only be provided if it has already been precomputed, to increase code efficiency.
 
     Examples
     --------
@@ -127,32 +129,31 @@ def compute_inv_noise_matrix(py, noise_matrix, *, ps=None):
     return clip_noise_rates(inverse_noise_matrix)
 
 
-def compute_noise_matrix_from_inverse(ps, inverse_noise_matrix, *, py=None):
-    """Compute the noise matrix P(label=k_s|true_label=k_y).
+def compute_noise_matrix_from_inverse(ps, inverse_noise_matrix, *, py=None) -> np.ndarray:
+    """Compute the noise matrix ``P(label=k_s|true_label=k_y)``.
 
     Parameters
     ----------
-    py : np.ndarray (shape (K, 1))
-        The fraction (prior probability) of each TRUE class label, P(true_label = k)
+    py : np.ndarray
+        Array of shape ``(K, 1)`` containing the fraction (prior probability) of each TRUE class label, ``P(true_label = k)``.
 
-    inverse_noise_matrix : np.ndarray of shape (K, K), K = number of classes
-        A conditional probability matrix of the form P(true_label=k_y|label=k_s) representing
+    inverse_noise_matrix : np.ndarray
+        A conditional probability matrix (of shape ``(K, K)``) of the form P(true_label=k_y|label=k_s) representing
         the estimated fraction observed examples in each class k_s, that are
         mislabeled examples from every other class k_y. If None, the
         inverse_noise_matrix will be computed from pred_probs and labels.
         Assumes columns of inverse_noise_matrix sum to 1.
 
-    ps : np.ndarray (shape (K, 1))
-        The fraction (prior probability) of each observed NOISY label, P(labels = k).
-        ps is easily computable from py and should only be provided if it has
-        already been precomputed, to increase code efficiency.
+    ps : np.ndarray
+        Array of shape ``(K, 1)`` containing the fraction (prior probability) of each observed NOISY label, P(labels = k).
+        `ps` is easily computable from `py` and should only be provided if it has already been precomputed, to increase code efficiency.
 
     Returns
     -------
-    noise_matrix : np.ndarray of shape (K, K), K = number of classes
-        A conditional probability matrix of the form P(label=k_s|true_label=k_y) containing
+    noise_matrix : np.ndarray 
+        Array of shape ``(K, K)``, where `K` = number of classes, whose columns sum to 1.
+        A conditional probability matrix of the form ``P(label=k_s|true_label=k_y)`` containing
         the fraction of examples in every class, labeled as every other class.
-        Columns of noise_matrix sum to 1.
 
     Examples
     --------
@@ -190,44 +191,46 @@ def compute_noise_matrix_from_inverse(ps, inverse_noise_matrix, *, py=None):
 
 def compute_py(
     ps, noise_matrix, inverse_noise_matrix, *, py_method="cnt", true_labels_class_counts=None
-):
-    """Compute py := P(true_labels=k) from ps := P(labels=k), noise_matrix, and the
-    inverse noise matrix.
+) -> np.ndarray:
+    """Compute ``py := P(true_labels=k)`` from ``ps := P(labels=k)``, `noise_matrix`, and
+    `inverse_noise_matrix`.
 
-    This method is ** ROBUST ** when py_method = 'cnt'
+    This method is ** ROBUST ** when ``py_method = 'cnt'``
     It may work well even when the noise matrices are estimated
     poorly by using the diagonals of the matrices
     instead of all the probabilities in the entire matrix.
 
     Parameters
     ----------
-    ps : np.ndarray (shape (K, ) or (1, K))
-        The fraction (prior probability) of each observed, noisy label, P(labels = k)
+    ps : np.ndarray
+        Array of shape ``(K, )`` or ``(1, K)`` containing the fraction (prior probability) of each observed, noisy label, P(labels = k)
 
-    noise_matrix : np.ndarray of shape (K, K), K = number of classes
-        A conditional probability matrix of the form P(label=k_s|true_label=k_y) containing
+    noise_matrix : np.ndarray
+        A conditional probability matrix ( of shape ``(K, K)``) of the form ``P(label=k_s|true_label=k_y)`` containing
         the fraction of examples in every class, labeled as every other class.
         Assumes columns of noise_matrix sum to 1.
 
     inverse_noise_matrix : np.ndarray of shape (K, K), K = number of classes
-        A conditional probability matrix of the form P(true_label=k_y|label=k_s) representing
-        the estimated fraction observed examples in each class k_s, that are
-        mislabeled examples from every other class k_y. If None, the
-        inverse_noise_matrix will be computed from pred_probs and labels.
-        Assumes columns of inverse_noise_matrix sum to 1.
+        A conditional probability matrix ( of shape ``(K, K)``) of the form ``P(true_label=k_y|label=k_s)`` representing
+        the estimated fraction observed examples in each class `k_s`, that are
+        mislabeled examples from every other class `k_y`. If ``None``, the
+        inverse_noise_matrix will be computed from `pred_probs` and `labels`.
+        Assumes columns of `inverse_noise_matrix` sum to 1.
 
     py_method : str (Options: ["cnt", "eqn", "marginal", "marginal_ps"])
-        How to compute the latent prior p(true_label=k). Default is "cnt" as it often
+        How to compute the latent prior ``p(true_label=k)``. Default is "cnt" as it often
         works well even when the noise matrices are estimated poorly by using
         the matrix diagonals instead of all the probabilities.
 
-    true_labels_class_counts : np.ndarray (shape (K, ) or (1, K))
-        The marginal counts of the confident joint (like cj.sum(axis = 0))
+    true_labels_class_counts : np.ndarray
+        Array of shape ``(K, )`` or ``(1, K)`` containing the marginal counts of the confident joint
+        (like ``cj.sum(axis = 0)``).
 
     Returns
     -------
-    py : np.ndarray (shape (K, ) or (1, K))
-        The fraction (prior probability) of each TRUE class label, P(true_label = k)."""
+    py : np.ndarray
+        Array of shape ``(K, )`` or ``(1, K)``.
+        The fraction (prior probability) of each TRUE class label, ``P(true_label = k)``."""
 
     if len(np.shape(ps)) > 2 or (len(np.shape(ps)) == 2 and np.shape(ps)[0] != 1):
         w = "Input parameter np.ndarray ps has shape " + str(np.shape(ps))
@@ -265,8 +268,8 @@ def compute_py(
 
 
 def compute_pyx(pred_probs, noise_matrix, inverse_noise_matrix):
-    """Compute pyx := P(true_label=k|x) from pred_probs := P(label=k|x), and the noise_matrix and
-    inverse noise matrix.
+    """Compute ``pyx := P(true_label=k|x)`` from ``pred_probs := P(label=k|x)``, `noise_matrix` and
+    `inverse_noise_matrix`.
 
     This method is ROBUST - meaning it works well even when the
     noise matrices are estimated poorly by only using the diagonals of the
@@ -274,29 +277,29 @@ def compute_pyx(pred_probs, noise_matrix, inverse_noise_matrix):
 
     Parameters
     ----------
-    pred_probs : np.ndarray (shape (N, K))
-        P(label=k|x) is a matrix with K model-predicted probabilities.
+    pred_probs : np.ndarray
+        ``P(label=k|x)`` is a ``(N x K)`` matrix with K model-predicted probabilities.
         Each row of this matrix corresponds to an example `x` and contains the model-predicted
         probabilities that `x` belongs to each possible class.
         The columns must be ordered such that these probabilities correspond to class 0,1,2,...
         `pred_probs` should have been computed using 3 (or higher) fold cross-validation.
 
-    noise_matrix : np.ndarray of shape (K, K), K = number of classes
-        A conditional probability matrix of the form P(label=k_s|true_label=k_y) containing
+    noise_matrix : np.ndarray
+        A conditional probability matrix (of shape ``(K, K)``) of the form ``P(label=k_s|true_label=k_y)`` containing
         the fraction of examples in every class, labeled as every other class.
-        Assumes columns of noise_matrix sum to 1.
+        Assumes columns of `noise_matrix` sum to 1.
 
-    inverse_noise_matrix : np.ndarray of shape (K, K), K = number of classes
-        A conditional probability matrix of the form P(true_label=k_y|label=k_s) representing
-        the estimated fraction observed examples in each class k_s, that are
-        mislabeled examples from every other class k_y. If None, the
-        inverse_noise_matrix will be computed from pred_probs and labels.
-        Assumes columns of inverse_noise_matrix sum to 1.
+    inverse_noise_matrix : np.ndarray
+        A conditional probability matrix (of shape ``(K, K)``)  of the form ``P(true_label=k_y|label=k_s)`` representing
+        the estimated fraction observed examples in each class `k_s`, that are
+        mislabeled examples from every other class `k_y`. If None, the
+        inverse_noise_matrix will be computed from `pred_probs` and `labels`.
+        Assumes columns of `inverse_noise_matrix` sum to 1.
 
     Returns
     -------
-    pyx : np.ndarray (shape (N, K))
-        P(true_label=k|x) is a matrix with K model-predicted probabilities.
+    pyx : np.ndarray
+        ``P(true_label=k|x)`` is a  ``(N, K)`` matrix of model-predicted probabilities.
         Each row of this matrix corresponds to an example `x` and contains the model-predicted
         probabilities that `x` belongs to each possible class.
         The columns must be ordered such that these probabilities correspond to class 0,1,2,...

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -18,11 +18,15 @@
 Ancillary helper methods used internally throughout this package; mostly related to Confident Learning algorithms.
 """
 
+import warnings
 import numpy as np
 import pandas as pd
+from typing import Any, Union, Tuple
+
+from cleanlab.typing import DatasetLike, LabelLike
 
 
-def remove_noise_from_class(noise_matrix, class_without_noise):
+def remove_noise_from_class(noise_matrix, class_without_noise) -> np.ndarray:
     """A helper function in the setting of PU learning.
     Sets all P(label=class_without_noise|true_label=any_other_class) = 0
     in noise_matrix for pulearning setting, where we have
@@ -57,7 +61,7 @@ def remove_noise_from_class(noise_matrix, class_without_noise):
     return x
 
 
-def clip_noise_rates(noise_matrix):
+def clip_noise_rates(noise_matrix) -> np.ndarray:
     """Clip all noise rates to proper range [0,1), but
     do not modify the diagonal terms because they are not
     noise rates.
@@ -72,7 +76,7 @@ def clip_noise_rates(noise_matrix):
         Diagonal terms are not noise rates, but are consistency P(label=k|true_label=k)
         Assumes columns of noise_matrix sum to 1"""
 
-    def clip_noise_rate_range(noise_rate):
+    def clip_noise_rate_range(noise_rate) -> float:
         """Clip noise rate P(label=k'|true_label=k) or P(true_label=k|label=k')
         into proper range [0,1)"""
         return min(max(noise_rate, 0.0), 0.9999)
@@ -95,7 +99,7 @@ def clip_noise_rates(noise_matrix):
     return noise_matrix
 
 
-def clip_values(x, low=0.0, high=1.0, new_sum=None):
+def clip_values(x, low=0.0, high=1.0, new_sum=None) -> np.ndarray:
     """Clip all values in p to range [low,high].
     Preserves sum of x.
 
@@ -131,7 +135,7 @@ def clip_values(x, low=0.0, high=1.0, new_sum=None):
     return x
 
 
-def value_counts(x):
+def value_counts(x) -> Any:
     """Returns an np.ndarray of shape (K, 1), with the
     value counts for every unique item in the labels list/array,
     where K is the number of unique entries in labels.
@@ -167,7 +171,7 @@ def value_counts(x):
             return np.unique(x, return_counts=True)[1]
 
 
-def round_preserving_sum(iterable):
+def round_preserving_sum(iterable) -> np.ndarray:
     """Rounds an iterable of floats while retaining the original summed value.
     The name of each parameter is required. The type and description of each
     parameter is optional, but should be included if not obvious.
@@ -202,7 +206,7 @@ def round_preserving_sum(iterable):
     return ints.astype(int)
 
 
-def round_preserving_row_totals(confident_joint):
+def round_preserving_row_totals(confident_joint) -> np.ndarray:
     """Rounds confident_joint cj to type int
     while preserving the totals of reach row.
     Assumes that cj is a 2D np.ndarray of type float.
@@ -224,7 +228,7 @@ def round_preserving_row_totals(confident_joint):
     ).astype(int)
 
 
-def int2onehot(labels):
+def int2onehot(labels) -> np.ndarray:
     """Convert list of lists to a onehot matrix for multi-labels
 
     Parameters
@@ -239,7 +243,7 @@ def int2onehot(labels):
     return mlb.fit_transform(labels)
 
 
-def onehot2int(onehot_matrix):
+def onehot2int(onehot_matrix) -> list:
     """Convert a onehot matrix for multi-labels to a list of lists of ints
 
     Parameters
@@ -256,7 +260,7 @@ def onehot2int(onehot_matrix):
     return [list(np.where(row == 1)[0]) for row in onehot_matrix]
 
 
-def estimate_pu_f1(s, prob_s_eq_1):
+def estimate_pu_f1(s, prob_s_eq_1) -> float:
     """Computes Claesen's estimate of f1 in the pulearning setting.
 
     Parameters
@@ -279,7 +283,7 @@ def estimate_pu_f1(s, prob_s_eq_1):
     return recall**2 / (2.0 * frac_positive) if frac_positive != 0 else np.nan
 
 
-def confusion_matrix(true, pred):
+def confusion_matrix(true, pred) -> np.ndarray:
     """Implements a confusion matrix for true labels
     and predicted labels. true and pred MUST BE the same length
     and have the same distinct set of class labels represented.
@@ -392,7 +396,7 @@ def print_joint_matrix(joint_matrix, round_places=2):
     )
 
 
-def compress_int_array(int_array, num_possible_values):
+def compress_int_array(int_array, num_possible_values) -> np.ndarray:
     """Compresses dtype of np.ndarray<int> if num_possible_values is small enough."""
     try:
         compressed_type = None
@@ -407,7 +411,9 @@ def compress_int_array(int_array, num_possible_values):
         return int_array
 
 
-def train_val_split(X, labels, train_idx, holdout_idx):
+def train_val_split(
+    X, labels, train_idx, holdout_idx
+) -> Tuple[DatasetLike, DatasetLike, LabelLike, LabelLike]:
     """Splits data into training/validation sets based on given indices"""
     labels_train, labels_holdout = (
         labels[train_idx],
@@ -450,14 +456,14 @@ def train_val_split(X, labels, train_idx, holdout_idx):
     return X_train, X_holdout, labels_train, labels_holdout
 
 
-def subset_X_y(X, labels, mask):
+def subset_X_y(X, labels, mask) -> Tuple[DatasetLike, LabelLike]:
     """Extracts subset of features/labels where mask is True"""
     labels = subset_labels(labels, mask)
     X = subset_data(X, mask)
     return X, labels
 
 
-def subset_labels(labels, mask):
+def subset_labels(labels, mask) -> Union[list, np.ndarray, pd.Series]:
     """Extracts subset of labels where mask is True"""
     try:  # filtering labels as if it is array or DataFrame
         return labels[mask]
@@ -468,7 +474,7 @@ def subset_labels(labels, mask):
             raise TypeError("labels must be 1D np.ndarray, list, or pd.Series.")
 
 
-def subset_data(X, mask):
+def subset_data(X, mask) -> DatasetLike:
     """Extracts subset of data examples where mask (np.ndarray) is True"""
     try:
         import torch
@@ -479,11 +485,13 @@ def subset_data(X, mask):
     except Exception:
         pass
     try:
-        import tensorflow
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            import tensorflow
 
-        if isinstance(X, tensorflow.data.Dataset):  # special splitting for tensorflow Dataset
-            mask_idx = np.nonzero(mask)[0]
-            return extract_indices_tf(X, mask_idx, allow_shuffle=True)
+            if isinstance(X, tensorflow.data.Dataset):  # special splitting for tensorflow Dataset
+                mask_idx = np.nonzero(mask)[0]
+                return extract_indices_tf(X, mask_idx, allow_shuffle=True)
     except Exception:
         pass
     try:
@@ -492,7 +500,7 @@ def subset_data(X, mask):
         raise TypeError("Data features X must be subsettable with boolean mask array: X[mask]")
 
 
-def extract_indices_tf(X, idx, allow_shuffle):
+def extract_indices_tf(X, idx, allow_shuffle) -> DatasetLike:
     """Extracts subset of tensorflow dataset corresponding to examples at particular indices.
 
     Args:
@@ -549,7 +557,7 @@ def extract_indices_tf(X, idx, allow_shuffle):
     return X_subset
 
 
-def unshuffle_tensorflow_dataset(X):
+def unshuffle_tensorflow_dataset(X) -> tuple:
     """Applies iterative inverse transformations to dataset to get version before ShuffleDataset was created.
     If no ShuffleDataset is in the transformation-history of this dataset, returns None.
 
@@ -586,7 +594,7 @@ def unshuffle_tensorflow_dataset(X):
     return (None, None)
 
 
-def is_torch_dataset(X):
+def is_torch_dataset(X) -> bool:
     try:
         import torch
 
@@ -597,7 +605,7 @@ def is_torch_dataset(X):
     return False  # assumes this cannot be torch dataset if torch cannot be imported
 
 
-def is_tensorflow_dataset(X):
+def is_tensorflow_dataset(X) -> bool:
     try:
         import tensorflow
 
@@ -608,7 +616,7 @@ def is_tensorflow_dataset(X):
     return False  # assumes this cannot be tensorflow dataset if tensorflow cannot be imported
 
 
-def csr_vstack(a, b):
+def csr_vstack(a, b) -> DatasetLike:
     """Takes in 2 csr_matrices and appends the second one to the bottom of the first one.
     Alternative to scipy.sparse.vstack. Returns a sparse matrix.
     """
@@ -619,7 +627,7 @@ def csr_vstack(a, b):
     return a
 
 
-def append_extra_datapoint(to_data, from_data, index):
+def append_extra_datapoint(to_data, from_data, index) -> DatasetLike:
     """Appends an extra datapoint to the data object ``to_data``.
     This datapoint is taken from the data object ``from_data`` at the corresponding index.
     One place this could be useful is ensuring no missing classes after train/validation split.
@@ -644,7 +652,7 @@ def append_extra_datapoint(to_data, from_data, index):
             raise TypeError("Data features X must support: X.append(X[i])")
 
 
-def get_num_classes(labels=None, pred_probs=None, label_matrix=None, multi_label=None):
+def get_num_classes(labels=None, pred_probs=None, label_matrix=None, multi_label=None) -> int:
     """Determines the number of classes based on information considered in a
     canonical ordering. label_matrix can be: noise_matrix, inverse_noise_matrix, confident_joint,
     or any other K x K matrix where K = number of classes.
@@ -664,7 +672,7 @@ def get_num_classes(labels=None, pred_probs=None, label_matrix=None, multi_label
     return num_unique_classes(labels, multi_label=multi_label)
 
 
-def num_unique_classes(labels, multi_label=None):
+def num_unique_classes(labels, multi_label=None) -> int:
     """Finds the number of unique classes for both single-labeled
     and multi-labeled labels. If multi_label is set to None (default)
     this method will infer if multi_label is True or False based on

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -480,8 +480,8 @@ def subset_data(X, mask) -> DatasetLike:
         import torch
 
         if isinstance(X, torch.utils.data.Dataset):
-            mask_idx = np.nonzero(mask)[0]
-            return torch.utils.data.Subset(X, mask_idx)
+            mask_idx_list = list(np.nonzero(mask)[0])
+            return torch.utils.data.Subset(X, mask_idx_list)
     except Exception:
         pass
     try:

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -638,7 +638,7 @@ def append_extra_datapoint(to_data, from_data, index) -> DatasetLike:
     if isinstance(to_data, np.ndarray):
         return np.vstack([to_data, from_data[index]])
     elif isinstance(from_data, (pd.DataFrame, pd.Series)):
-        X_extra = from_data.iloc[[index]]
+        X_extra = from_data.iloc[[index]]  # type: ignore
         to_data = pd.concat([to_data, X_extra])
         return to_data.reset_index(drop=True)
     else:

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -194,10 +194,11 @@ def labels_to_array(y: Union[LabelLike, np.generic]) -> np.ndarray:
         y_series: np.ndarray = y.to_numpy()
         return y_series
     elif isinstance(y, pd.DataFrame):
-        y = y.values
-        if y.shape[1] != 1:
+        y_arr = y.values
+        assert isinstance(y_arr, np.ndarray)
+        if y_arr.shape[1] != 1:
             raise ValueError("labels must be one dimensional.")
-        return y.flatten()
+        return y_arr.flatten()
     else:  # y is list, np.ndarray, or some other tuple-like object
         try:
             return np.asarray(y)

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -187,7 +187,7 @@ def labels_to_array(y: Union[LabelLike, np.generic]) -> np.ndarray:
 
     Returns
     -------
-    np.ndarray
+    labels_array : np.ndarray
         1D numpy array of labels.
     """
     if isinstance(y, pd.Series):

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -98,7 +98,7 @@ def get_label_quality_multiannotator(
 
     Returns
     -------
-    dict
+    labels_info : dict
         Dictionary containing up to 3 pandas DataFrame with keys as below:
 
         ``label_quality`` : pandas.DataFrame
@@ -461,7 +461,7 @@ def _get_consensus_stats(
 
     Returns
     ------
-    tuple
+    stats : tuple
         A tuple of (consensus_label, annotator_agreement, consensus_quality_score, post_pred_probs).
     """
 
@@ -544,7 +544,7 @@ def _get_annotator_stats(
     Returns
     -------
     annotator_stats : pd.DataFrame
-        Returns overall statistics about each annotator.
+        Overall statistics about each annotator.
         For details, see the documentation of :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
     """
 

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -83,9 +83,8 @@ def order_label_issues(
     Returns
     -------
     label_issues_idx : np.ndarray
-      Return an array of the indices of the label issues, ordered by the label-quality scoring method
-      passed to `rank_by`.
-
+      Return an array of the indices of the examples with label issues,
+      ordered by the label-quality scoring method passed to `rank_by`.
     """
 
     assert_valid_inputs(X=None, y=labels, pred_probs=pred_probs, multi_label=False)
@@ -172,14 +171,14 @@ def get_label_quality_scores(
     Returns
     -------
     label_quality_scores : np.ndarray
-      Scores are between 0 and 1 where lower scores indicate labels less likely to be correct.
+      Contains one score (between 0 and 1) per example.
+      Lower scores indicate more likely mislabeled examples.
 
     See Also
     --------
     get_self_confidence_for_each_label
     get_normalized_margin_for_each_label
     get_confidence_weighted_entropy_for_each_label
-
     """
 
     # TODO: remove allow_missing_classes once supported
@@ -288,11 +287,12 @@ def get_label_quality_ensemble_scores(
     Returns
     -------
     label_quality_scores : np.ndarray
+      Contains one score (between 0 and 1) per example.
+      Lower scores indicate more likely mislabeled examples.
 
     See Also
     --------
     get_label_quality_scores
-
     """
 
     MIN_ALLOWED = 1e-6  # lower-bound clipping threshold to prevents 0 in logs and division
@@ -448,7 +448,7 @@ def get_self_confidence_for_each_label(
     This is a function to compute label-quality scores for classification datasets,
     where lower scores indicate labels less likely to be correct.
 
-    The self-confidence is the holdout probability that an example belongs to
+    The self-confidence is the classifier's predicted probability that an example belongs to
     its given class label.
 
     Self-confidence can work better than normalized-margin for detecting label errors due to out-of-distribution (OOD) or weird examples
@@ -465,9 +465,8 @@ def get_self_confidence_for_each_label(
     Returns
     -------
     label_quality_scores : np.ndarray
-      An array of holdout probabilities that each example in `pred_probs` belongs to its
-      label.
-
+      Contains one score (between 0 and 1) per example.
+      Lower scores indicate more likely mislabeled examples.
     """
 
     # np.mean is used so that this works for multi-labels (list of lists)
@@ -487,9 +486,9 @@ def get_normalized_margin_for_each_label(
     Letting k denote the given label for a datapoint, the normalized margin is
     ``(p(label = k) - max(p(label != k)))``, i.e. the probability
     of the given label minus the probability of the argmax label that is not
-    the given label. This gives you an idea of how likely an example is BOTH
-    its given label AND not another label, and therefore, scores its likelihood
-    of being a good label or a label error.
+    the given label (``normalized_margin = prob_label - max_prob_not_label``).
+    This gives you an idea of how likely an example is BOTH its given label AND not another label,
+    and therefore, scores its likelihood of being a good label or a label error.
 
     Normalized margin works better for finding class conditional label errors where
     there is another label in the set of classes that is clearly better than the given label.
@@ -505,8 +504,8 @@ def get_normalized_margin_for_each_label(
     Returns
     -------
     label_quality_scores : np.ndarray
-      An array of scores (between 0 and 1) for each example of its likelihood of
-      being correctly labeled. ``normalized_margin = prob_label - max_prob_not_label``
+      Contains one score (between 0 and 1) per example.
+      Lower scores indicate more likely mislabeled examples.
     """
 
     self_confidence = get_self_confidence_for_each_label(labels, pred_probs)
@@ -538,8 +537,8 @@ def get_confidence_weighted_entropy_for_each_label(
     Returns
     -------
     label_quality_scores : np.ndarray
-      An array of scores (between 0 and 1) for each example of its likelihood of
-      being correctly labeled.
+      Contains one score (between 0 and 1) per example.
+      Lower scores indicate more likely mislabeled examples.
     """
 
     MIN_ALLOWED = 1e-6  # lower-bound clipping threshold to prevents 0 in logs and division


### PR DESCRIPTION
* Should format docstrings properly for the return information
* Also adds type annotations for many files (likely not fully mypy-strict compatible yet)
* Miscellaneous docstring language improvements
* Other formatting improvements
* Allow redefinition for mypy