### PR TITLE
Deploy docs for token classification module

### DIFF
--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -241,7 +241,7 @@ def color_sentence(sentence: str, word: str) -> str:
     >>> color_sentence(sentence, word)
     'This is a \x1b[31msentence\x1b[0m.'
 
-    Also works for multiple occurences of the word
+    Also works for multiple occurrences of the word
 
     >>> document = "This is a sentence. This is another sentence."
     >>> word = "sentence"

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -104,16 +104,16 @@ def process_token(token: str, replace: List[Tuple[str, str]] = [("#", "")]) -> s
 
     Parameters
     ----------
-        token: str
-            token which potentially contains special characters
+    token:
+        token which potentially contains special characters
 
-        replace: List[Tuple[str, str]]
-            list of tuples `(s1, s2)`, where all occurances of s1 are replaced by s2
+    replace:
+        list of tuples `(s1, s2)`, where all occurances of s1 are replaced by s2
 
     Returns
     ---------
-        processed_token: str
-            processed token whose special character has been replaced
+    processed_token:
+        processed token whose special character has been replaced
 
     Note
     ----
@@ -133,16 +133,16 @@ def mapping(entities: List[int], maps: List[int]) -> List[int]:
 
     Parameters
     ----------
-        entities: List[int]
-            a list of given entities
+    entities:
+        a list of given entities
 
-        maps: List[int]
-            a list of mapped entities, such that the i'th indexed token should be mapped to `maps[i]`
+    maps:
+        a list of mapped entities, such that the i'th indexed token should be mapped to `maps[i]`
 
     Returns
     ---------
-        mapped_entities: List[int]
-            a list of mapped entities
+    mapped_entities:
+        a list of mapped entities
 
     Examples
     --------
@@ -163,19 +163,19 @@ def merge_probs(probs: np.ndarray, maps: List[int]) -> np.ndarray:
 
     Parameters
     ----------
-        probs:
-            np.array of shape `(N, K)`, where N is the number of tokens, and K is the number of classes for the model
+    probs:
+        np.array of shape `(N, K)`, where N is the number of tokens, and K is the number of classes for the model
 
-        maps: List[int]
-            a list of mapped index, such that the probability of the token being in the i'th class is mapped to the
-            `maps[i]` index. If `maps[i] == -1`, the i'th column of `probs` is ignored. If `np.any(maps == -1)`, the
-            returned probability is re-normalized.
+    maps:
+        a list of mapped index, such that the probability of the token being in the i'th class is mapped to the
+        `maps[i]` index. If `maps[i] == -1`, the i'th column of `probs` is ignored. If `np.any(maps == -1)`, the
+        returned probability is re-normalized.
 
     Returns
     ---------
-        probs_merged:
-            np.array of shape `(N, K')`, where K' is the number of new classes. Probablities are merged and
-            re-normalized if necessary.
+    probs_merged:
+        np.array of shape `(N, K')`, where K' is the number of new classes. Probablities are merged and
+        re-normalized if necessary.
 
     """
     old_classes = probs.shape[1]
@@ -197,15 +197,15 @@ def color_sentence(sentence: str, word: str) -> str:
 
     Parameters
     ----------
-        sentence:
-            a sentence where the word is searched
+    sentence:
+        a sentence where the word is searched
 
-        word:
-            keyword to find in `sentence`. Assumes the word exists in the sentence.
+    word:
+        keyword to find in `sentence`. Assumes the word exists in the sentence.
     Returns
     ---------
-        colored_sentence:
-            `sentence` where the every occurance of the word is colored red, using `termcolor.colored`
+    colored_sentence:
+        `sentence` where the every occurance of the word is colored red, using `termcolor.colored`
 
     """
     colored_word = colored(word, "red")

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -36,7 +36,8 @@ def get_sentence(words: List[str]) -> str:
 
     Returns
     ----------
-    sentence formed by list of word-level tokens
+    sentence:
+        sentence formed by list of word-level tokens
 
     Examples
     --------

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -118,6 +118,19 @@ def process_token(token: str, replace: List[Tuple[str, str]] = [("#", "")]) -> s
     Note
     ----
         Only applies to characters in the original input token.
+
+    Examples
+    --------
+    >>> from cleanlab.internal.token_classification_utils import process_token
+    >>> token = "#Comment"
+    >>> process_token("#Comment")
+    'Comment'
+
+    Specify custom replacement rules
+
+    >>> replace = [("C", "a"), ("a", "C")]
+    >>> process_token("Cleanlab", replace)
+    'aleCnlCb'
     """
     replace_dict = {re.escape(k): v for (k, v) in replace}
     pattern = "|".join(replace_dict.keys())
@@ -177,6 +190,18 @@ def merge_probs(probs: np.ndarray, maps: List[int]) -> np.ndarray:
         np.array of shape `(N, K')`, where K' is the number of new classes. Probablities are merged and
         re-normalized if necessary.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from cleanlab.internal.token_classification_utils import merge_probs
+    >>> probs = np.array([
+    ...     [0.55, 0.0125, 0.0375, 0.1, 0.3],
+    ...     [0.1, 0.8, 0, 0.075, 0.025],
+    ... ])
+    >>> maps = [0, 1, 1, 2, 2]
+    >>> merge_probs(probs, maps)
+    array([[0.55, 0.05, 0.4 ],
+           [0.1 , 0.8 , 0.1 ]])
     """
     old_classes = probs.shape[1]
     map_size = np.max(maps) + 1
@@ -207,6 +232,20 @@ def color_sentence(sentence: str, word: str) -> str:
     colored_sentence:
         `sentence` where the every occurance of the word is colored red, using `termcolor.colored`
 
+    Examples
+    --------
+    >>> from cleanlab.internal.token_classification_utils import color_sentence
+    >>> sentence = "This is a sentence."
+    >>> word = "sentence"
+    >>> color_sentence(sentence, word)
+    'This is a \x1b[31msentence\x1b[0m.'
+
+    Works for multiple occurences of the word
+
+    >>> document = "This is a sentence. This is another sentence."
+    >>> word = "sentence"
+    >>> color_sentence(document, word)
+    'This is a \x1b[31msentence\x1b[0m. This is another \x1b[31msentence\x1b[0m.'
     """
     colored_word = colored(word, "red")
     colored_sentence, number_of_substitions = re.subn(

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -188,7 +188,7 @@ def merge_probs(probs: np.ndarray, maps: List[int]) -> np.ndarray:
     Returns
     ---------
     probs_merged:
-        np.array of shape `(N, K')`, where K' is the number of new classes. Probablities are merged and
+        np.array of shape ``(N, K')``, where `K` is the number of new classes. Probabilities are merged and
         re-normalized if necessary.
 
     Examples

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -31,14 +31,20 @@ def get_sentence(words: List[str]) -> str:
 
     Parameters
     ----------
-    words: List[str]
+    words:
         list of word-level tokens
 
     Returns
     ----------
-    sentence: string
+    sentence:
         sentence formed by list of word-level tokens
 
+    Examples
+    --------
+    >>> from cleanlab.internal.token_classification_utils import get_sentence
+    >>> words = ["This", "is", "a", "sentence", "."]
+    >>> get_sentence(words)
+    'This is a sentence.'
     """
     sentence = ""
     for word in words:

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -64,21 +64,33 @@ def filter_sentence(
 
     Parameters
     ----------
-        sentences: List[str]
-            list of sentences
+    sentences:
+        list of sentences
 
-        condition: Optional[Callable[[str], bool]]
-            sentence filtering condition
+    condition:
+        sentence filtering condition
 
     Returns
     ---------
-        sentences: List[str]
-            list of sentences filtered
+    sentences:
+        list of sentences filtered
 
-        mask: List[bool]
-            boolean mask such that `mask[i] == True` if the i'th sentence is included in the
-            filtered sentence, otherwise `mask[i] == False`
+    mask:
+        boolean mask such that `mask[i] == True` if the i'th sentence is included in the
+        filtered sentence, otherwise `mask[i] == False`
 
+    Examples
+    --------
+    >>> from cleanlab.internal.token_classification_utils import filter_sentence
+    >>> sentences = ["Short sentence.", "This is a longer sentence."]
+    >>> condition = lambda x: len(x.split()) > 2
+    >>> long_sentences, _ = filter_sentence(sentences, condition)
+    >>> long_sentences
+    ['This is a longer sentence.']
+    >>> document = ["# Headline", "Sentence 1.", "&", "Sentence 2."]
+    >>> sentences, mask = filter_sentence(document)
+    >>> sentences, mask
+    (['Sentence 1.', 'Sentence 2.'], [False, True, False, True])
     """
     if not condition:
         condition = lambda sentence: len(sentence) > 1 and "#" not in sentence

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -240,7 +240,7 @@ def color_sentence(sentence: str, word: str) -> str:
     >>> color_sentence(sentence, word)
     'This is a \x1b[31msentence\x1b[0m.'
 
-    Works for multiple occurences of the word
+    Also works for multiple occurences of the word
 
     >>> document = "This is a sentence. This is another sentence."
     >>> word = "sentence"

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -231,7 +231,7 @@ def color_sentence(sentence: str, word: str) -> str:
     Returns
     ---------
     colored_sentence:
-        `sentence` where the every occurance of the word is colored red, using `termcolor.colored`
+        `sentence` where the every occurrence of the word is colored red, using ``termcolor.colored``
 
     Examples
     --------

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -36,8 +36,7 @@ def get_sentence(words: List[str]) -> str:
 
     Returns
     ----------
-    sentence:
-        sentence formed by list of word-level tokens
+    sentence formed by list of word-level tokens
 
     Examples
     --------

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -146,12 +146,12 @@ def mapping(entities: List[int], maps: List[int]) -> List[int]:
 
     Examples
     --------
-        >>> unique_identities = [0, 1, 2, 3, 4]  # ["O", "B-PER", "I-PER", "B-LOC", "I-LOC"]
-        >>> maps = [0, 1, 1, 2, 2]  # ["O", "PER", "PER", "LOC", "LOC"]
-        >>> mapping(unique_identities, maps)
-        [0, 1, 1, 2, 2]  # ["O", "PER", "PER", "LOC", "LOC"]
-        >>> mapping([0, 0, 4, 4, 3, 4, 0, 2], maps)
-        [0, 0, 2, 2, 2, 2, 0, 1]  # ["O", "O", "LOC", "LOC", "LOC", "LOC", "O", "PER"]
+    >>> unique_identities = [0, 1, 2, 3, 4]  # ["O", "B-PER", "I-PER", "B-LOC", "I-LOC"]
+    >>> maps = [0, 1, 1, 2, 2]  # ["O", "PER", "PER", "LOC", "LOC"]
+    >>> mapping(unique_identities, maps)
+    [0, 1, 1, 2, 2]  # ["O", "PER", "PER", "LOC", "LOC"]
+    >>> mapping([0, 0, 4, 4, 3, 4, 0, 2], maps)
+    [0, 0, 2, 2, 2, 2, 0, 1]  # ["O", "O", "LOC", "LOC", "LOC", "LOC", "O", "PER"]
     """
     f = lambda x: maps[x]
     return list(map(f, entities))

--- a/cleanlab/token_classification/filter.py
+++ b/cleanlab/token_classification/filter.py
@@ -54,6 +54,18 @@ def find_label_issues(
     issues:
         a list containing all potential issues identified by cleanlab, such that each element is a tuple (i, j), which
         corresponds to the j'th token of the i'th sentence.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from cleanlab.token_classification.filter import find_label_issues
+    >>> labels = [[0, 0, 1], [0, 1]]
+    >>> pred_probs = [
+    ...     np.array([[0.9, 0.1], [0.7, 0.3], [0.05, 0.95]]),
+    ...     np.array([[0.8, 0.2], [0.8, 0.2]]),
+    ... ]
+    >>> find_label_issues(labels, pred_probs)
+    [(1, 1)]
     """
     labels_flatten = [l for label in labels for l in label]
     pred_probs_flatten = np.array([pred for pred_prob in pred_probs for pred in pred_prob])

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -31,16 +31,16 @@ def softmin_sentence_score(token_scores: List[np.ndarray], temperature: float = 
 
     Parameters
     ----------
-    token_scores: list
+    token_scores:
         token scores in nested list format, where `token_scores[i]` is a list of token scores of the i'th
         sentence
 
-    temperature: float, default=0.05
+    temperature:
         temperature of the softmax function
 
     Returns
     ---------
-    sentence_scores: np.array
+    sentence_scores:
         np.array of shape `(N, )`, where `N` is the number of sentences. Contains score for each sentence.
 
     Examples
@@ -86,16 +86,16 @@ def get_label_quality_scores(
 
     Parameters
     ----------
-    labels: list
+    labels:
         noisy token labels in nested list format, such that `labels[i]` is a list of token labels of the i'th
         sentence. For datasets with `K` classes, each label must be in 0, 1, ..., K-1. All classes must be present.
-    pred_probs: list
+    pred_probs:
         list of np.arrays, such that `pred_probs[i]` is the model-predicted probabilities for the tokens in
         the i'th sentence, and has shape `(N, K)`. Each row of the matrix corresponds to a token `t` and contains
         the model-predicted probabilities that `t` belongs to each possible class, for each of the K classes. The
         columns must be ordered such that the probabilities correspond to class 0, 1, ..., K-1.
 
-    tokens: list, optional, default=None
+    tokens:
         tokens in nested list format, such that `tokens[i]` is a list of tokens for the i'th sentence. See return value
         `token_info` for more info.
     sentence_score_method: {"min", "softmin"}, default="min"
@@ -107,15 +107,15 @@ def get_label_quality_scores(
         other scores.
     token_score_method: {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="self_confidence"
         label quality scoring method. See `cleanlab.rank.get_label_quality_scores` for more info.
-    sentence_score_kwargs: dict, optional, default={}
+    sentence_score_kwargs:
         keyword arguments for `sentence_score_method`. Supports keyword arguments when `sentence_score_method` is "softmin".
         See `cleanlab.token_classification.rank.softmin_sentence_score` for more info.
     Returns
     ----------
-    sentence_scores: np.array
+    sentence_scores:
         A vector of sentence scores between 0 and 1, where lower scores indicate sentence is more likely to contain at
         least one label issue.
-    token_info: list
+    token_info:
         A list of pandas.Series, such that token_info[i] contains the
         token scores for the i'th sentence. If tokens are provided, the series is indexed by the tokens.
 
@@ -181,19 +181,19 @@ def issues_from_scores(
 
     Parameters
     ----------
-    sentence_scores: np.array
+    sentence_scores:
         np.array of shape `(N, )`, where `N` is the number of sentences.
 
-    token_scores: list, optional, default=None
+    token_scores:
         token scores in nested list, such that `token_scores[i]` contains the tokens scores for the i'th sentence
 
-    threshold: int, default=0.1
+    threshold:
         tokens (or sentences, if `token_scores` is not provided) with quality scores above the threshold are not
         included in the result.
 
     Returns
     ---------
-    issues: list
+    issues:
         list of tuples `(i, j)`, which indicates the j'th token of the i'th sentence, sorted by token label quality
         score. If `token_scores` is not provided, returns list of indices of sentences with label quality score below
         threshold.

--- a/cleanlab/token_classification/summary.py
+++ b/cleanlab/token_classification/summary.py
@@ -295,14 +295,14 @@ def filter_by_token(
 
     Parameters
     ----------
-        token:
-            the specific token the user is looking for
+    token:
+        the specific token the user is looking for
 
-        issues:
-            list of tuples `(i, j)`, which represents the j'th token of the i'th sentence.
+    issues:
+        list of tuples `(i, j)`, which represents the j'th token of the i'th sentence.
 
-        given_words:
-            tokens in a nested-list format, such that `given_words[i]` contains the words of the i'th sentence from
+    given_words:
+        tokens in a nested-list format, such that `given_words[i]` contains the words of the i'th sentence from
         the original file.
 
     Returns

--- a/cleanlab/token_classification/summary.py
+++ b/cleanlab/token_classification/summary.py
@@ -69,6 +69,18 @@ def display_issues(
     top: int, default=20
         maximum number of outputs to be printed.
 
+    Examples
+    --------
+    >>> from cleanlab.token_classification.summary import display_issues
+    >>> issues = [(2, 0), (0, 1)]
+    >>> given_words = [
+    ...     ["A", "?weird", "sentence"],
+    ...     ["A", "valid", "sentence"],
+    ...     ["An", "sentence", "with", "a", "typo"],
+    ... ]
+    >>> display_issues(issues, given_words)
+    Sentence 2, token 0:
+    ...
     """
     if not class_names:
         print(
@@ -175,6 +187,20 @@ def common_label_issues(
         a data frame with columns ['token', 'num_label_issues'], and each row contains the information for a specific
         token, ordered by the number of label issues in descending order.
 
+    Examples
+    --------
+    >>> from cleanlab.token_classification.summary import common_label_issues
+    >>> issues = [(2, 0), (0, 1)]
+    >>> given_words = [
+    ...     ["A", "?weird", "sentence"],
+    ...     ["A", "valid", "sentence"],
+    ...     ["An", "sentence", "with", "a", "typo"],
+    ... ]
+    >>> df = common_label_issues(issues, given_words)
+    >>> df
+        token  num_label_issues
+    0      An                 1
+    1  ?weird                 1
     """
     count: Dict[str, Any] = {}
     if not labels or not pred_probs:
@@ -284,6 +310,18 @@ def filter_by_token(
     returned_issues:
         list of tuples `(i, j)`, which represents the j'th token of the i'th sentence.
 
+    Examples
+    --------
+    >>> from cleanlab.token_classification.summary import filter_by_token
+    >>> token = "?weird"
+    >>> issues = [(2, 0), (0, 1)]
+    >>> given_words = [
+    ...     ["A", "?weird", "sentence"],
+    ...     ["A", "valid", "sentence"],
+    ...     ["An", "sentence", "with", "a", "typo"],
+    ... ]
+    >>> filter_by_token(token, issues, given_words)
+    [(0, 1)]
     """
     returned_issues = []
     for issue in issues:

--- a/cleanlab/token_classification/summary.py
+++ b/cleanlab/token_classification/summary.py
@@ -156,14 +156,14 @@ def common_label_issues(
 
     labels:
         list of given labels, such that `labels[i]` is a list containing the given labels of the tokens in the i'th
-    sentence, and has length equal to the number of given tokens of the i'th sentence. If provided, also
-    displays the given label of the token.
+        sentence, and has length equal to the number of given tokens of the i'th sentence. If provided, also
+        displays the given label of the token.
 
     pred_probs:
         list of model-predicted probability, such that `pred_probs[i]` contains the model-predicted probability of
-    the tokens in the i'th sentence, and has shape `(N, K)`, where `N` is the number of given tokens of the i'th
-    sentence, and `K` is the number of classes predicted by the model. If both `labels` and `pred_probs` are
-    provided, also evaluate each type of given/predicted label swap.
+        the tokens in the i'th sentence, and has shape `(N, K)`, where `N` is the number of given tokens of the i'th
+        sentence, and `K` is the number of classes predicted by the model. If both `labels` and `pred_probs` are
+        provided, also evaluate each type of given/predicted label swap.
 
     class_names:
         name of classes. If not provided, display the integer index for predicted and given labels.

--- a/docs/source/cleanlab/internal/index.rst
+++ b/docs/source/cleanlab/internal/index.rst
@@ -15,4 +15,5 @@ internal
     util
     latent_algebra
     label_quality_utils
+    token_classification_utils
     validation

--- a/docs/source/cleanlab/internal/token_classification_utils.rst
+++ b/docs/source/cleanlab/internal/token_classification_utils.rst
@@ -1,0 +1,8 @@
+token_classification_utils
+==========================
+
+.. automodule:: cleanlab.internal.token_classification_utils
+    :autosummary:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/cleanlab/token_classification/filter.rst
+++ b/docs/source/cleanlab/token_classification/filter.rst
@@ -1,0 +1,8 @@
+filter
+======
+
+.. automodule:: cleanlab.token_classification.filter
+    :autosummary:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/cleanlab/token_classification/index.rst
+++ b/docs/source/cleanlab/token_classification/index.rst
@@ -1,0 +1,14 @@
+token_classification
+====================
+
+.. automodule:: cleanlab.token_classification
+    :autosummary:
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. toctree::
+
+    filter
+    rank
+    summary

--- a/docs/source/cleanlab/token_classification/rank.rst
+++ b/docs/source/cleanlab/token_classification/rank.rst
@@ -1,0 +1,8 @@
+rank
+====
+
+.. automodule:: cleanlab.token_classification.rank
+    :autosummary:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/cleanlab/token_classification/summary.rst
+++ b/docs/source/cleanlab/token_classification/summary.rst
@@ -1,0 +1,8 @@
+summary
+=======
+
+.. automodule:: cleanlab.token_classification.summary
+    :autosummary:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -119,6 +119,7 @@ The example below shows how to view all dataset-level issues in one line of code
    cleanlab/dataset
    cleanlab/outlier
    cleanlab/multiannotator
+   cleanlab/token_classification/index
    cleanlab/benchmarking/index
    cleanlab/experimental/index
    cleanlab/internal/index


### PR DESCRIPTION
## Additions in this PR

- Minimal usage examples for each function defined in the cleanlab.token_classification package.
  - Each example starts with an import statement for the documented function as well as external dependencies (numpy).
  - Define toy input-variables that match the signatures.
  - Show outputs of documented functions.
- Add modules in the cleanlab.token_classification package to the reference section of the docs.

## Changes in this PR

- Remove hard-coded parameter/return types in docstrings.
  - This should now be inferred by autodoc-typehint when building the docs.

## References
This PR is a supplement to #437.
Related issue: #384.
