### PR TITLE
Strip input prompts when copying code snippets

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,6 +105,16 @@ autodoc_default_options = {
 # Subclasses should show parent classes docstrings if they don't override them.
 autodoc_inherit_docstrings = True
 
+# -- Options for copybutton extension -----------------------------------------
+
+# Strip input prompts when copying code blocks. Supports:
+# - Python Repl + continuation prompt
+# - Bash prompt
+# - ipython + continuation prompt
+# - jupyter-console + continuation prompt
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+
 # -- Options for katex extension -------------------------------------------
 
 if os.getenv("CI") or shutil.which("katex") is not None:


### PR DESCRIPTION
sphinx-copybutton is already set up in the docs: https://github.com/cleanlab/cleanlab/blob/7ab4cbbf2350cf99b1e26d066484e4372fe7e214/docs/source/conf.py#L40

This PR configures the extension to exclude prompts (like `>>>`) from copied code snippets.

Configuration provided in https://sphinx-copybutton.readthedocs.io/en/latest/use.html#using-regexp-prompt-identifiers

## Example

```python
>>> 1+1
2
```
Before the PR, pressing the copy button in the docs would copy `>>> 1+1`
After the PR, only `1+1` would be copied in our docs after this PR


### Note
The copy button on github copies the entire code block!
