### PR TITLE
make num_label_issues = cj calibrated offdiag sum

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -109,7 +109,7 @@ def num_label_issues(
     # Normalize confident joint so that it estimates the joint, p(labels,y)
     joint = confident_joint / float(np.sum(confident_joint))
     frac_issues = 1.0 - joint.trace()
-    num_issues = np.round(frac_issues * len(labels))
+    num_issues = np.rint(frac_issues * len(labels))
 
     return num_issues
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -109,7 +109,7 @@ def num_label_issues(
     # Normalize confident joint so that it estimates the joint, p(labels,y)
     joint = confident_joint / float(np.sum(confident_joint))
     frac_issues = 1.0 - joint.trace()
-    num_issues = int(frac_issues * len(labels))
+    num_issues = np.round(frac_issues * len(labels))
 
     return num_issues
 


### PR DESCRIPTION
The discrepancy occurs because cj calibrated maintains a guarantee that it will perfectly count every example in the dataset (assumes no out of distribution examples).

You can see this when this occurs by following this stack-call of methods:

* see `calibrate_confident_joint`, specifically this line here: https://github.com/cleanlab/cleanlab/blob/9240a8c56d020abec8566a0a56d22dcb99d32528/cleanlab/count.py#L172
* round here https://github.com/cleanlab/cleanlab/blob/9240a8c56d020abec8566a0a56d22dcb99d32528/cleanlab/internal/util.py#L209
* the actual rounding occurs here https://github.com/cleanlab/cleanlab/blob/9240a8c56d020abec8566a0a56d22dcb99d32528/cleanlab/internal/util.py#L174

the fix to make `num_label_issues` the same is just to round instead of flooring.

see the two GREEN columns in the attached image:

![image](https://user-images.githubusercontent.com/27030270/190479731-7eb2fe77-6d77-41bc-b962-65d3051c06b9.png)
