### PR TITLE
Change output of display_issues

### DIFF
--- a/cleanlab/token_classification/summary.py
+++ b/cleanlab/token_classification/summary.py
@@ -111,24 +111,25 @@ def display_issues(
                 given = class_names[given]
 
             shown += 1
-            print("Sentence %d, token %d: \n%s" % (i, j, color_sentence(sentence, word)))
+            print("Sentence %d, token %d:" % (i, j))
             if labels and not pred_probs:
-                print("Given label: %s\n" % str(given))
+                print("Given label: %s" % str(given))
             elif not labels and pred_probs:
-                print("Predicted label according to provided pred_probs: %s\n" % str(prediction))
+                print("Predicted label according to provided pred_probs: %s" % str(prediction))
             elif labels and pred_probs:
                 print(
-                    "Given label: %s, predicted label according to provided pred_probs: %s\n"
+                    "Given label: %s, predicted label according to provided pred_probs: %s"
                     % (str(given), str(prediction))
                 )
-            else:
-                print()
+            print("----")
+            print(color_sentence(sentence, word))
         else:
             shown += 1
             sentence = get_sentence(given_words[issue])
-            print("Sentence %d: %s\n" % (issue, sentence))
+            print("Sentence %d: %s" % (issue, sentence))
         if shown == top:
             break
+        print("\n")
 
 
 def common_label_issues(

--- a/cleanlab/token_classification/summary.py
+++ b/cleanlab/token_classification/summary.py
@@ -80,7 +80,13 @@ def display_issues(
     ... ]
     >>> display_issues(issues, given_words)
     Sentence 2, token 0:
+    ----
+    An sentence with a typo
     ...
+    ...
+    Sentence 0, token 1:
+    ----
+    A ?weird sentence
     """
     if not class_names:
         print(

--- a/cleanlab/token_classification/summary.py
+++ b/cleanlab/token_classification/summary.py
@@ -88,6 +88,7 @@ def display_issues(
         )
         print("Specify this argument to see the string names of each class. \n")
 
+    top = min(top, len(issues))
     shown = 0
     is_tuple = isinstance(issues[0], tuple)
 


### PR DESCRIPTION
Ensure display_issues won't print trailing whitespace/newlines after iterating the list of issues.

The example in the docstring:

```python
from cleanlab.token_classification.summary import display_issues
issues = [(2, 0), (0, 1)]
given_words = [
    ["A", "?weird", "sentence"],
    ["A", "valid", "sentence"],
    ["An", "sentence", "with", "a", "typo"],
]
display_issues(issues, given_words)
```

would now give:

```
Sentence 2, token 0:
----
An sentence with a typo


Sentence 0, token 1:
----
A ?weird sentence
```