### PR TITLE
Fix details disclosure elements in docs

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,0 +1,21 @@
+details {
+    margin-bottom: 0.75rem;
+    margin-top: 0.5rem;
+}
+
+details summary {
+    cursor: pointer;
+}
+
+details summary > * {
+    display: inline;
+}
+
+details[open] summary {
+    padding-bottom: 0.75rem;
+    border-bottom: 2px dashed #ccc;
+}
+
+details[open] {
+    border-bottom: 2px dashed #ccc;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -230,6 +230,8 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+html_css_files = ["css/custom.css"]
+
 html_sidebars = {
     "**": [
         "brand.html",

--- a/docs/source/tutorials/audio.ipynb
+++ b/docs/source/tutorials/audio.ipynb
@@ -246,10 +246,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<details><summary>Below is the code used to make audio files playable.</summary>\n",
+    "<details><summary>See the implementation of `display_example` **(click to expand)**</summary>\n",
     "\n",
-    "```\n",
-    "\n",
+    "```python\n",
     "# Note: This pulldown content is for docs.cleanlab.ai, if running on local Jupyter or Colab, please ignore it.\n",
     "\n",
     "import tensorflow_io as tfio\n",
@@ -274,8 +273,8 @@
     "    label = Path(wav_file_name).parts[-1].split(\"_\")[0]\n",
     "    print(f\"Given label for this example: {label}\")\n",
     "    display.display(display.Audio(wav_file_example, rate=audio_rate))\n",
-    "\n",
     "```\n",
+    "\n",
     "</details>"
    ]
   },

--- a/docs/source/tutorials/dataset_health.ipynb
+++ b/docs/source/tutorials/dataset_health.ipynb
@@ -121,10 +121,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<details><summary>Below is the code used for fetching data.</summary>\n",
+    "<details><summary>See the code for fetching data **(click to expand)**</summary>\n",
     "\n",
-    "```\n",
-    "\n",
+    "```python\n",
     "# Note: This pulldown content is for docs.cleanlab.ai, if running on local Jupyter or Colab, please ignore it.\n",
     "\n",
     "mnist_test_set = [\"0\", \"1\" ,\"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", \"9\"]\n",
@@ -177,7 +176,6 @@
     "          f\"probabilities of shape {pred_probs.shape}\\n\")\n",
     "\n",
     "    return pred_probs, labels, ALL_CLASSES[dataset_name]\n",
-    "\n",
     "```\n",
     "\n",
     "</details>"

--- a/docs/source/tutorials/image.ipynb
+++ b/docs/source/tutorials/image.ipynb
@@ -347,10 +347,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<details><summary>Below is the code used for plotting.</summary>\n",
+    "<details><summary>See the implementation of `plot_examples` **(click to expand)**</summary>\n",
     "\n",
-    "```\n",
-    "\n",
+    "```python\n",
     "# Note: This pulldown content is for docs.cleanlab.ai, if running on local Jupyter or Colab, please ignore it.\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
@@ -363,7 +362,6 @@
     "        plt.axis(\"off\")\n",
     "\n",
     "    plt.tight_layout(h_pad=2.0)\n",
-    "\n",
     "```\n",
     "</details>"
    ]

--- a/docs/source/tutorials/indepth_overview.ipynb
+++ b/docs/source/tutorials/indepth_overview.ipynb
@@ -116,10 +116,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<details><summary>Below is the code used for data-generation.</summary>\n",
+    "<details><summary>See the code for data generation **(click to expand)**</summary>\n",
     "\n",
-    "```\n",
     "\n",
+    "```python\n",
     "# Note: This pulldown content is for docs.cleanlab.ai, if running on local Jupyter or Colab, please ignore it.\n",
     "\n",
     "SEED = 0\n",
@@ -212,7 +212,6 @@
     "            alpha=alpha\n",
     "        )\n",
     "    _ = plt.title(title, fontsize=25)\n",
-    "\n",
     "```\n",
     "\n",
     "</details>"

--- a/docs/source/tutorials/multiannotator.ipynb
+++ b/docs/source/tutorials/multiannotator.ipynb
@@ -161,8 +161,7 @@
    "id": "69b5ddaa",
    "metadata": {},
    "source": [
-    "<details>\n",
-    "    <summary> Below is the code used for data-generation. </summary>\n",
+    "<details><summary>See the code for data generation **(click to expand)**</summary>\n",
     "    \n",
     "```ipython3\n",
     "# Note: This pulldown content is for docs.cleanlab.ai, if running on local Jupyter or Colab, please ignore it.\n",

--- a/docs/source/tutorials/token_classification.ipynb
+++ b/docs/source/tutorials/token_classification.ipynb
@@ -147,9 +147,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<details><summary>Below is the code used to read the .npz file.</summary>\n",
-    "\n",
-    "```\n",
+    "<details><summary>See the code for reading the `.npz` file **(click to expand)**</summary> \n",
     "\n",
     "# Note: This pulldown content is for docs.cleanlab.ai, if running on local Jupyter or Colab, please ignore it.\n",
     "\n",
@@ -209,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<details><summary>Below is the code used for reading the CoNLL data files.</summary>\n",
+    "<details><summary>See the code for reading the CoNLL data files **(click to expand)**</summary>\n",
     "\n",
     "```\n",
     "\n",


### PR DESCRIPTION
This patch makes the following fixes:

- Make summary text appear on the same line as the ">" arrow marker; prior to this patch, it was being pushed down to the next line because there were nested block elements inside the `<summary>` element
- Style details element to visually delineate collapsible content with dashed lines above and below the content
- Add syntax highlighting for code blocks in details disclosure elements (some were missing syntax highlighting)
- Hide a cell that was meant to be hidden in the audio tutorial

See https://github.com/cleanlab/cleanlab/issues/440 for some screenshots of the details disclosure elements prior to this patch.

Here's an example of what these elements look like now.

Collapsed:

<img width="829" alt="Screen Shot 2022-09-16 at 2 58 13 PM" src="https://user-images.githubusercontent.com/3526486/190711711-147cd1d7-b3da-4100-985f-c1215e5b053c.png">

Expanded:

<img width="857" alt="Screen Shot 2022-09-16 at 2 58 19 PM" src="https://user-images.githubusercontent.com/3526486/190711725-8057a829-5061-4561-aeda-02b63db4fed9.png">

The summary element looked ugly due to a block element being present inside the `<summary>`. This was present in the rendered docs even though it was not explicitly in the source. Even though our source (in a Markdown cell in a Jupyter notebook) looked like:

```html
<summary>Example text</summary>
```

The rendered docs had:

```html
<summary><p>Example text</p></summary>
```

The easy fix was to leave this as-is and fix the styling with CSS, making all elements inside the summary to be displayed as inline elements.

Where was the extra `<p>` tag coming from? Different Markdown parsers handle mixed Markdown/HTML differently. We are using nbsphinx, which does something especially weird [[1]]: converting from Markdown -> reStructuredText -> HTML.

For example, consider the following Markdown:

```markdown
<details><summary>Summary</summary>

Body.

</details>
```

nbsphinx was first converting it to this reST:

```rst
.. raw:: html

   <details>

.. raw:: html

   <summary>

Summary

.. raw:: html

   </summary>

Body.

.. raw:: html

   </details>
```

And then this reST was being converted to HTML. This is where the extra `<p>` was coming from.

One workaround for this behavior is to switch to raw HTML cells in the notebook, rather than Markdown cells, and write pure HTML there. This has the disadvantage that it's inconvenient when the content inside the `<details>` has extra markup: Markdown is very convenient for that (e.g., for styling text), and having the contents being parsed as Markdown also allows us to easily use syntax highlighting inside the body.

Another workaround is to use raw reST cells [[2]] and write the proper reST directly (avoiding the bad Markdown -> reST conversion). This preserves the ability to use convenient formatting (though with reST instead of Markdown) as well as syntax-highlighted code blocks. For example:

```rst
.. raw:: html

    <details><summary>Summary</summary>

.. code-block:: python

    def meaning_of_life():
        return 42

.. raw:: html

    </details>
```

The above snippet produces the expected HTML, with syntax-highlighted code in the body, and without the extra `<p>` inside the `<summary>`.

Rather than either of these workarounds, the most convenient one for developers is to fix the issue using CSS, so that the Markdown cells in the tutorials can be left as-is and no special care is required when writing details disclosure elements, which is what this patch does.

Fixes https://github.com/cleanlab/cleanlab/issues/440.

[1]: https://github.com/spatialaudio/nbsphinx/blob/fc79fd1ac5ab6df225b256ef4ca203c58c5ad92b/src/nbsphinx.py#L1309
[2]: https://nbsphinx.readthedocs.io/en/0.8.9/raw-cells.html#reST