### PR TITLE
Add missing backticks and language annotation

### DIFF
--- a/docs/source/tutorials/token_classification.ipynb
+++ b/docs/source/tutorials/token_classification.ipynb
@@ -149,6 +149,7 @@
    "source": [
     "<details><summary>See the code for reading the `.npz` file **(click to expand)**</summary> \n",
     "\n",
+    "```python\n",
     "# Note: This pulldown content is for docs.cleanlab.ai, if running on local Jupyter or Colab, please ignore it.\n",
     "\n",
     "def read_npz(filepath): \n",
@@ -209,7 +210,7 @@
    "source": [
     "<details><summary>See the code for reading the CoNLL data files **(click to expand)**</summary>\n",
     "\n",
-    "```\n",
+    "```python\n",
     "\n",
     "# Note: This pulldown content is for docs.cleanlab.ai, if running on local Jupyter or Colab, please ignore it.\n",
     "\n",


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/3526486/190835751-73f22faf-012f-4b24-88d1-653ea09a4be7.png)

Thanks @huiwengoh for pointing this out.