### PR TITLE
Fix docs build in CI

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -21,7 +21,11 @@ jobs:
           fetch-depth: 0
 
       - name: Install Pandoc
-        run: sudo apt-get install pandoc
+        # pin Pandoc version
+        run: |
+          cd /tmp
+          wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-linux-amd64.tar.gz
+          sudo tar xzvf pandoc-2.19.2-linux-amd64.tar.gz --strip-components 1 -C /usr/local
 
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
This patch pins the Pandoc version to a more recent release (2.19.2).

As explained in d8cc2e50566e90dcfb9aff118a41610d4be070ee, nbconvert translates Markdown -> reST -> HTML, and it uses Pandoc for this Markdown -> reST conversion. Older versions of Pandoc don't do a high-fidelity conversion; in particular, they don't have great support for mixed Markdown/HTML content.

Consider the following Markdown, the core of how we use the details disclosure element in several tutorial notebooks:

```markdown
<details><summary>Summary</summary>

Body.

</details>
```

Using Pandoc 2.19.2, this converts to the following reST:

```rst
.. raw:: html

   <details>

.. raw:: html

   <summary>

Summary

.. raw:: html

   </summary>

Body.

.. raw:: html

   </details>
```

This is a correct conversion. However, using Pandoc 2.5, which is the version of Pandoc that was being used by CI prior to this patch (the version of Pandoc available in the package repository for Ubuntu 20.04), it converts as follows:

```rst
.. raw:: html

   <details>

Summary

Body.

.. raw:: html

   </details>
```

The `<summary>` tag is lost in this conversion.

This patch switches to a more recent version of Pandoc to fix this issue.

I tested this by [debugging the GitHub action with SSH](https://github.com/marketplace/actions/debugging-with-ssh) and manually checking the generated HTML to ensure that it contains the `<summary>` tag that wasn't being emitted prior to this patch.