### PR TITLE
Add helper function to reduce code duplication

### DIFF
--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -23,7 +23,6 @@ Methods for analysis of classification data labeled by multiple annotators, incl
 * An overall quality score for each annotator which measures our confidence in the overall correctness of labels obtained from this annotator.
 """
 
-from re import L
 import warnings
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
- Added helper function to check for missing classes in consensus labels to eliminate code duplication
- Moved `convert_long_to_wide_dataset` higher in the file to group public functions at the top