### PR TITLE
Add workflow for skipping notebooks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,31 @@ pip install -r docs/requirements.txt
 
    **Fast build**: Executing the Jupyter Notebooks (i.e., the `.ipynb` files) that make up some portion of the docs, such as the tutorials, takes a long time. If you want to skip rendering these, set the environment variable `SKIP_NOTEBOOKS=1`. You can either set this using `export SKIP_NOTEBOOKS=1` or do this inline with `SKIP_NOTEBOOKS=1 sphinx-multiversion ...`.
 
+   **Skipping specific notebooks**: If you want to skip rendering a few specific notebooks buring your local build, the best way to do this is to temporarily move the files outside the `cleanlab` folder (so `nbsphinx` would not find it), then build the docs, before finally moving the files back (to ensure they will not be deleted when pushed to GitHub)
+
+   Example workflow for skipping notebooks, given our current working directory is the `cleanlab` root folder and we want to ignore the `audio.ipynb` notebook:
+
+   1. create an empty folder outside of cleanlab folder
+   ```
+   mkdir ../ignore_notebooks
+   ```
+
+   2. move the notebook to ignore from local build to the newly created folder
+   ```
+   mv docs/source/tutorials/audio.ipynb ../ignore_notebooks 
+   ```
+
+   3. build the docs locally, using `sphinx-build` as it does not require you to commit your changes
+   ```
+   sphinx-build docs/source cleanlab-docs
+   ```
+
+   4. move the notebook back to its original location
+   ```
+   mv ../ignore_notebooks/audio.ipynb docs/source/tutorials
+   ```
+
+
    While building the docs with `sphinx-multiversion`, your terminal might output:
    * `unknown config value 'smv_branch_whitelist' in override, ignoring`, and
    * `unknown config value 'smv_tag_whitelist' in override, ignoring`.


### PR DESCRIPTION
I could not find a direct way to skip specific notebooks during local build, so just added an example guide of how to move files out of folder to skip them when building docs locally. 

Ref: https://github.com/cleanlab/cleanlab/issues/357