### PR TITLE
Pass docs versions as context variables to jinja

### DIFF
--- a/docs/source/_templates/versioning.html
+++ b/docs/source/_templates/versioning.html
@@ -23,6 +23,16 @@
                 >developer</a
             >
         </li>
+        {% for version in RELEASE_VERSIONS %}
+        <li class="toctree-l1">
+            <a
+                id="{{ version }}"
+                class="reference internal"
+                href="{{DOCS_SITE_URL}}{{version}}/"
+                >{{version}}</a
+            >
+        </li>
+        {% endfor %}
     </ul>
 </div>
 
@@ -47,21 +57,6 @@
             "master <code class='docutils literal notranslate'><span class='pre'> (" +
             commit_hash.slice(0, 7) +
             "&hellip;)</span></code>";
-    });
-    window.addEventListener("load", () => {
-        let unorderedList = document.getElementById("commit_hash").parentElement.parentElement;
-        
-        for (let i = 0; i < ReleaseVersions.length; i++) {
-            let listItem = document.createElement("li");
-            listItem.className = "toctree-l1";
-            let anchor = document.createElement("a");
-            anchor.className = "reference internal";
-            anchor.id = ReleaseVersions[i];
-            anchor.href = DOCS_SITE_URL + ReleaseVersions[i] + "/";
-            anchor.innerHTML = ReleaseVersions[i];
-            listItem.appendChild(anchor);
-            unorderedList.appendChild(listItem);
-        }
     });
 </script>
 

--- a/docs/source/_templates/versioning.js
+++ b/docs/source/_templates/versioning.js
@@ -2,10 +2,3 @@ var Version = {
   version_number: "placeholder_version_number",
   commit_hash: "placeholder_commit_hash",
 };
-
-// Add new version tags here before a release 
-var ReleaseVersions = [
-  "2.1.0",
-  "2.0.0",
-  "1.0.1",
-]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -141,6 +141,14 @@ GITHUB_REF_NAME = os.getenv("GITHUB_REF_NAME") or "master"
 # Pass additional variables to Jinja templates
 html_context = {
     "DOCS_SITE_URL": DOCS_SITE_URL,
+    # Add new tags to RELEASE_VERSIONS before release
+    # fmt: off
+    "RELEASE_VERSIONS": [
+        "v2.1.0",
+        "v2.0.0", 
+        "v1.0.1"
+    ],
+    # fmt: on
 }
 
 # -- nbsphinx Configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -146,7 +146,7 @@ html_context = {
     "RELEASE_VERSIONS": [
         "v2.1.0",
         "v2.0.0", 
-        "v1.0.1"
+        "v1.0.1",
     ],
     # fmt: on
 }


### PR DESCRIPTION
This replaces the fix in #480.