### PR TITLE
supporting multilabel via one-vs-rest reductions

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -176,7 +176,7 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> 
       The multi-label setting supports classification tasks where an example has 1 or more labels.
       Example of a multi-labeled `labels` input: ``[[0,1], [1], [0,2], [0,1,2], [0], [1], ...]``.
       The major difference in how this is calibrated versus single-label is that
-      confident/calibrated joint arrays have shape ``(K, 2, 2)`` formatted in a one-vs-rest fashion such that they contain a 2x2 matrix for each class that counts examples which are correctly/incorrectly labeled as belonging to that class. 
+      confident/calibrated joint arrays have shape ``(K, 2, 2)`` formatted in a one-vs-rest fashion such that they contain a 2x2 matrix for each class that counts examples which are correctly/incorrectly labeled as belonging to that class.
       After calibration, the entries in each class-specific 2x2 matrix will sum to the number of examples.
 
     Returns

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -338,7 +338,7 @@ def _estimate_joint_multilabel(labels, pred_probs, *, confident_joint=None) -> n
       class 0, 1, ..., K-1. They need not sum to 1.0
 
     confident_joint : np.ndarray, optional
-       An array of shape ``(num_classes,2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
+       An array of shape ``(K, 2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
        estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.
        Entry ``(c, j, k)`` in the matrix is the number of examples in a one-vs-rest class confidently counted into the pair of ``(class c, noisy label=j, true label=k)`` classes.
        The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -439,16 +439,18 @@ def compute_confident_joint(
     confident_joint_counts : np.ndarray
       An array of shape ``(K, K)`` representing counts of examples
       for which we are confident about their given and true label (if `multi_label` is False).
-      If multi_label is True,
-      An array of shape ``(K, 2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
-      estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.
-      Entry ``(c, j, k)`` in the matrix is the number of examples in a one-vs-rest class confidently counted into the pair of ``(class c, noisy label=j, true label=k)`` classes.
+      If `multi_label` is True,
+      this array instead has shape ``(K, 2, 2)`` representing a one-vs-rest format for the  confident joint, where for each class `c`:
+      Entry ``(c, 0, 0)`` in this one-vs-rest array is the number of examples whose noisy label contains `c` confidently identified as truly belonging to class `c` as well.
+      Entry ``(c, 1, 0)`` in this one-vs-rest array is the number of examples whose noisy label contains `c` confidently identified as not actually belonging to class `c`.
+      Entry ``(c, 0, 1)`` in this one-vs-rest array is the number of examples whose noisy label does not contain `c` confidently identified as truly belonging to class `c`.
+      Entry ``(c, 1, 1)`` in this one-vs-rest array is the number of examples whose noisy label does not contain `c` confidently identified as actually not belonging to class `c` as well.
 
 
       Note
       ----
-      if `return_indices_of_off_diagonals` is set as True, this function instead returns a tuple `(confident_joint, indices_off_diagonal)`
-      where `indices_off_diagonal` is an array and each array contains the indices of examples counted in off-diagonals of confident joint.
+      If `return_indices_of_off_diagonals` is set as True, this function instead returns a tuple `(confident_joint, indices_off_diagonal)`
+      where `indices_off_diagonal` is a list of arrays and each array contains the indices of examples counted in off-diagonals of confident joint.
 
     Note
     ----

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -438,7 +438,7 @@ def compute_confident_joint(
     -------
     confident_joint_counts : np.ndarray
       An array of shape ``(K, K)`` representing counts of examples
-      for which we are confident about their given and true label.
+      for which we are confident about their given and true label (if `multi_label` is False).
       If multi_label is True,
       An array of shape ``(K, 2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
       estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -1333,10 +1333,11 @@ def _get_confident_thresholds_multilabel(
     pred_probs: np.ndarray,
 ):
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
-    confident_thresholds = np.array((num_classes, pred_probs.shape[1]))
+    confident_thresholds = np.ndarray((num_classes, 2))
     y_one = int2onehot(labels)
     for class_num in range(num_classes):
         pred_probabilitites = _binarize_pred_probs_slice(pred_probs, class_num)
         confident_thresholds[class_num] = get_confident_thresholds(
             pred_probs=pred_probabilitites, labels=y_one[:, class_num]
         )
+    return confident_thresholds

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -332,7 +332,7 @@ def _estimate_joint_multilabel(labels, pred_probs, *, confident_joint=None) -> n
      -------
      confident_joint_distribution : np.ndarray
        An array of shape ``(K, 2, 2)`` representing an
-       estimate of the true joint distribution of noisy and true labels in a multi-label setting.
+       estimate of the true joint distribution of noisy and true labels for each class, in a one-vs-rest format employed for multi-label settings.
     """
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
     try:

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -576,8 +576,8 @@ def _compute_confident_joint_multi_label(
     Parameters
     ----------
     labels : list of list/iterable (length N)
-        These are multiclass labels. Each list in the list contains
-        all the labels for that example. This method will fail if labels
+        List of noisy labels for multi-label classification. Each list in the list contains
+        all the class assignments for that example. This method will fail if labels
         is not a list of lists (or a list of np.ndarrays or iterable).
 
     pred_probs : np.ndarray (shape (N, K))

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -321,28 +321,14 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
 def _estimate_joint_multilabel(labels, pred_probs, *, confident_joint=None) -> np.ndarray:
     """Parameters
      ----------
-     labels : np.ndarray
-       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
-       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
-       All the classes (0, 1, ..., and K-1) MUST be present in ``labels``, such that:
-       ``len(set(labels)) == pred_probs.shape[1]`` for standard multi-class classification with single-labeled data (e.g. ``labels =  [1,0,2,1,1,0...]``).
-       For multi-label classification where each example can belong to multiple classes(e.g. ``labels = [[1,2],[1],[0],..]``),
-       your labels should instead satisfy: ``len(set(k for l in labels for k in l)) == pred_probs.shape[1])``.
+     labels : list
+      Refer to documentation for this argument in filter.find_label_issues() for details.
 
      pred_probs : np.ndarray
-       An array of shape ``(N, K)`` of model-predicted probabilities,
-      ``P(label=k|x)``. Each row of this matrix corresponds
-      to an example `x` and contains the model-predicted probabilities that
-      `x` belongs to each possible class, for each of the K classes. The
-      columns must be ordered such that these probabilities correspond to
-      class 0, 1, ..., K-1. They need not sum to 1.0
+       Refer to documentation for this argument in count.estimate_joint() for details.
 
     confident_joint : np.ndarray, optional
-       An array of shape ``(K, 2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
-       estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.
-       Entry ``(c, j, k)`` in the matrix is the number of examples in a one-vs-rest class confidently counted into the pair of ``(class c, noisy label=j, true label=k)`` classes.
-       The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
-       If not provided, it is computed from the given (noisy) `labels` and `pred_probs`.
+       Refer to documentation for this argument in filter.find_label_issues() with multi_label=True for details.
 
      Returns
      -------
@@ -690,7 +676,12 @@ def estimate_latent(
     Returns
     ------
     tuple
-      A tuple containing (py, noise_matrix, inv_noise_matrix)."""
+      A tuple containing (py, noise_matrix, inv_noise_matrix).
+
+    Note
+    ----
+    Multi-label classification is not supported in this method.
+    """
 
     # 'ps' is p(labels=k)
     ps = value_counts(labels) / float(len(labels))
@@ -795,7 +786,12 @@ def estimate_py_and_noise_matrices_from_probabilities(
     Returns
     ------
     estimates : tuple
-        A tuple of arrays: (`py`, `noise_matrix`, `inverse_noise_matrix`, `confident_joint`)."""
+        A tuple of arrays: (`py`, `noise_matrix`, `inverse_noise_matrix`, `confident_joint`).
+
+    Note
+    ----
+    Multi-label classification is not supported in this method.
+    """
 
     confident_joint = compute_confident_joint(
         labels=labels,
@@ -1390,13 +1386,9 @@ def _get_confident_thresholds_multilabel(
     Parameters
     ----------
     labels: list
-       List of noisy labels for multi-label classification where each example can belong to multiple classes (e.g. ``labels = [[1,2],[1],[0],..]`` indicates the first example in dataset belongs to both class 1 and class 2.
-       For multi-label settings, your `labels` should instead satisfy: ``len(set(k for l in labels for k in l)) == pred_probs.shape[1])``.
-
+       Refer to documentation for this argument in count.calibrate_confident_joint() with multi_label=True for details.
     pred_probs : np.ndarray
        Predicted-probabilities in the same format expected by the :py:func:`get_confident_thresholds <cleanlab.count.get_confident_thresholds>` function.
-
-
 
     Returns
     -------

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -175,9 +175,8 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> 
       The multi-label setting supports classification tasks where an example has 1 or more labels.
       Example of a multi-labeled `labels` input: ``[[0,1], [1], [0,2], [0,1,2], [0], [1], ...]``.
       The major difference in how this is calibrated versus single-label is that
-      the total number of errors considered is based on the number of labels,
-      not the number of examples. So, the calibrated `confident_joint` will sum
-      to the number of total labels.
+      the calibrated joint is calculated in a one-vs-rest setting, and will return an array of shape ``(K, 2, 2)``
+      each entry k in ``(k,i,j)`` will sum to the number of total labels.
 
     Returns
     -------

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -476,7 +476,7 @@ def _compute_confident_joint_multi_label(
     thresholds=None,
     calibrate=True,
     return_indices_of_off_diagonals=False,
-) -> Union[np.ndarray, Tuple[np.ndarray, list]]:  # type: ignore
+) -> Union[np.ndarray, Tuple[np.ndarray, list]]:
     """Computes the confident joint for multi_labeled data. Thus,
     input `labels` is a list of lists (or list of iterable).
     This is intended as a helper function. You should probably

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -1384,7 +1384,7 @@ def _get_confident_thresholds_multilabel(
     Parameters
     ----------
     labels: list
-       Refer to documentation for this argument in count.calibrate_confident_joint() with multi_label=True for details.
+       Refer to documentation for this argument in ``count.calibrate_confident_joint()`` with `multi_label=True` for details.
     pred_probs : np.ndarray
        Predicted-probabilities in the same format expected by the :py:func:`get_confident_thresholds <cleanlab.count.get_confident_thresholds>` function.
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -377,8 +377,6 @@ def compute_confident_joint(
     confident_joint_counts : np.ndarray
       An array of shape ``(K, K)`` representing counts of examples
       for which we are confident about their given and true label.
-      If `return_indices_of_off_diagonals` is ``True``, `confident_joint_counts` is the first element of returned tuple
-      and second element is another array of indices counted in off-diagonals of confident joint.
 
     Note: if `return_indices_of_off_diagonals` is set as True, this function instead returns a tuple `(confident_joint, indices_off_diagonal)`
     where `indices_off_diagonal` is an array and each array contains the indices of examples counted in off-diagonals of confident joint.

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -115,7 +115,7 @@ def num_label_issues(
 
     if confident_joint is None:
         # Original non-calibrated counts of confidently correctly and incorrectly labeled examples.
-        confident_joint = compute_confident_joint(
+        computed_confident_joint = compute_confident_joint(
             labels=labels, pred_probs=pred_probs, calibrate=False
         )  # type: ignore
     else:

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -456,7 +456,7 @@ def compute_confident_joint(
       An array of shape ``(K, K)`` representing counts of examples
       for which we are confident about their given and true label.
       If multi_label is True,
-      An array of shape ``(num_classes,2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
+      An array of shape ``(K, 2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
       estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.
       Entry ``(c, j, k)`` in the matrix is the number of examples in a one-vs-rest class confidently counted into the pair of ``(class c, noisy label=j, true label=k)`` classes.
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -160,7 +160,7 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> 
       Entry ``(j, k)`` in the matrix is the number of examples confidently counted into the pair of ``(noisy label=j, true label=k)`` classes.
       The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
       If not provided, it is computed from the given (noisy) `labels` and `pred_probs`.
-      If multi_label is True, then the confident should be an array of shape ``(K, 2, 2)``.
+      If `multi_label` is True, then the `confident_joint` should be a one-vs-rest array of shape ``(K, 2, 2)``, and an array of the same shape will be returned.
 
     labels : np.ndarray
       A discrete vector of noisy labels, i.e. some labels may be erroneous.

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -205,7 +205,7 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> 
 
 
 def _calibrate_confident_joint_multilabel(confident_joint: np.ndarray, labels: list) -> np.ndarray:
-    """Calibrates the confident joint for muli-label classification data. Here
+    """Calibrates the confident joint for multi-label classification data. Here
         input `labels` is a list of lists (or list of iterable).
         This is intended as a helper function. You should probably
         be using `calibrate_confident_joint(multi_label=True)` instead.

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -380,6 +380,7 @@ def compute_confident_joint(
 
     Note: if `return_indices_of_off_diagonals` is set as True, this function instead returns a tuple `(confident_joint, indices_off_diagonal)`
     where `indices_off_diagonal` is an array and each array contains the indices of examples counted in off-diagonals of confident joint.
+    
     Note
     ----
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -1391,7 +1391,7 @@ def _get_confident_thresholds_multilabel(
     Returns
     -------
     confident_thresholds : np.ndarray
-      An array of shape ``(K, 2)`` where K is the number of classes.
+      An array of shape ``(K, 2, 2)`` where `K` is the number of classes, in a one-vs-rest format.
     """
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
     try:

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -331,12 +331,11 @@ def _estimate_joint_multilabel(labels, pred_probs, *, confident_joint=None) -> n
 
      pred_probs : np.ndarray
        An array of shape ``(N, K)`` of model-predicted probabilities,
-       ``P(label=k|x)``. Each row of this matrix corresponds
-       to an example `x` and contains the model-predicted probabilities that
-       `x` belongs to each possible class, for each of the K classes. The
-       columns must be ordered such that these probabilities correspond to
-       class 0, 1, ..., K-1. `pred_probs` should have been computed using 3 (or
-       higher) fold cross-validation.
+      ``P(label=k|x)``. Each row of this matrix corresponds
+      to an example `x` and contains the model-predicted probabilities that
+      `x` belongs to each possible class, for each of the K classes. The
+      columns must be ordered such that these probabilities correspond to
+      class 0, 1, ..., K-1. They need not sum to 1.0
 
     confident_joint : np.ndarray, optional
        An array of shape ``(num_classes,2, 2)`` representing the confident joint, the matrix used for identifying label issues, which

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -562,9 +562,9 @@ def _compute_confident_joint_multi_label(
     Parameters
     ----------
     labels : list of list/iterable (length N)
-        List of noisy labels for multi-label classification. Each list in the list contains
-        all the class assignments for that example. This method will fail if labels
-        is not a list of lists (or a list of np.ndarrays or iterable).
+        Given noisy labels for multi-label classification.
+        Must be a list of lists (or a list of np.ndarrays or iterable).
+        The i-th element is a list containing the classes that the i-th example belongs to.
 
     pred_probs : np.ndarray (shape (N, K))
         P(label=k|x) is a matrix with K model-predicted probabilities.

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -1333,7 +1333,7 @@ def _get_confident_thresholds_multilabel(
     pred_probs: np.ndarray,
 ):
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
-    confident_thresholds = np.ndarray((num_classes, 2))
+    confident_thresholds: np.ndarray = np.ndarray((num_classes, 2))
     y_one = int2onehot(labels)
     for class_num in range(num_classes):
         pred_probabilitites = _binarize_pred_probs_slice(pred_probs, class_num)

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -176,8 +176,8 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> 
       The multi-label setting supports classification tasks where an example has 1 or more labels.
       Example of a multi-labeled `labels` input: ``[[0,1], [1], [0,2], [0,1,2], [0], [1], ...]``.
       The major difference in how this is calibrated versus single-label is that
-      the calibrated joint is calculated in a one-vs-rest setting, and will return an array of shape ``(K, 2, 2)``
-      each entry k in ``(k,i,j)`` will sum to the number of total labels.
+      confident/calibrated joint arrays have shape ``(K, 2, 2)`` formatted in a one-vs-rest fashion such that they contain a 2x2 matrix for each class that counts examples which are correctly/incorrectly labeled as belonging to that class. 
+      After calibration, the entries in each class-specific 2x2 matrix will sum to the number of examples.
 
     Returns
     -------

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -536,7 +536,7 @@ def _compute_confident_joint_multi_label(
         raise ValueError(
             "wrong format for labels, should be a list of list[indices], please check the documentation in find_label_issues for further information"
         )
-    confident_joint_list = np.ndarray(shape=(num_classes, 2, 2), dtype=np.int64)  # type: ignore
+    confident_joint_list: np.ndarray = np.ndarray(shape=(num_classes, 2, 2), dtype=np.int64)
     indices_off_diagonal = []
     for class_num in range(0, num_classes):
         pred_probabilitites = _binarize_pred_probs_slice(pred_probs, class_num)

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -120,7 +120,7 @@ def num_label_issues(
         )  # type: ignore
 
     if estimation_method is "off_diagonal":
-        num_issues = np.sum(confident_joint) - np.trace(confident_joint)  # type: ignore
+        num_issues: int = np.sum(confident_joint) - np.trace(confident_joint)  # type: ignore
     elif estimation_method is "off_diagonal_calibrated":
         # Estimate_joint calibrates the row sums to match the prior distribution of given labels and normalizes to sum to 1
         joint = estimate_joint(labels, pred_probs, confident_joint=confident_joint)

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -591,9 +591,7 @@ def _compute_confident_joint_multi_label(
     Returns
     -------
     confident_joint_counts : np.ndarray
-      An array of shape ``(K, 2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
-      estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.
-      Entry ``(c, j, k)`` in the matrix is the number of examples in a one-vs-rest class confidently counted into the pair of ``(class c, noisy label=j, true label=k)`` classes.
+      An array of shape ``(K, 2, 2)`` representing the confident joint of noisy and true labels for each class, in a one-vs-rest format employed for multi-label settings.
 
     Note: if `return_indices_of_off_diagonals` is set as True, this function instead returns a tuple `(confident_joint_counts, indices_off_diagonal)`
     where `indices_off_diagonal` is a list of arrays (one per class) and each array contains the indices of examples counted in off-diagonals of confident joint for that class.

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -291,12 +291,10 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
     -------
     confident_joint_distribution : np.ndarray
       An array of shape ``(K, K)`` representing an
-      estimate of the true joint distribution of noisy and true labels.
-      If multi_label is True,
-      An array of shape ``(num_classes,2, 2)`` representing an
-      estimate of the true joint distribution of noisy and true labels,
-      Entry ``(c, j, k)`` in the matrix is the number of examples in a one-vs-rest class confidently counted into the pair of ``(class c, noisy label=j, true label=k)`` classes.
-
+      estimate of the true joint distribution of noisy and true labels (if `multi_label` is False).
+      If `multi_label` is True, an array of shape ``(K, 2, 2)`` representing an
+      estimate of the true joint distribution of noisy and true labels for each class in a one-vs-rest fashion.
+      Entry ``(c, i, j)`` in this array is the number of examples confidently counted into a``(class c, noisy label=i, true label=j)`` bin, where `i,j` are either 0 or 1 to denote whether this example belongs to class `c` or not (recall examples can belong to multiple classes in multi-label classification).
     """
 
     if confident_joint is None:

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -294,7 +294,9 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
       estimate of the true joint distribution of noisy and true labels (if `multi_label` is False).
       If `multi_label` is True, an array of shape ``(K, 2, 2)`` representing an
       estimate of the true joint distribution of noisy and true labels for each class in a one-vs-rest fashion.
-      Entry ``(c, i, j)`` in this array is the number of examples confidently counted into a``(class c, noisy label=i, true label=j)`` bin, where `i,j` are either 0 or 1 to denote whether this example belongs to class `c` or not (recall examples can belong to multiple classes in multi-label classification).
+      Entry ``(c, i, j)`` in this array is the number of examples confidently counted into a ``(class c, noisy label=i, true label=j)`` bin,
+      where `i, j` are either 0 or 1 to denote whether this example belongs to class `c` or not
+      (recall examples can belong to multiple classes in multi-label classification).
     """
 
     if confident_joint is None:

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -526,8 +526,8 @@ def _compute_confident_joint_multi_label(
       estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.
       Entry ``(c, j, k)`` in the matrix is the number of examples in a one-vs-rest class confidently counted into the pair of ``(class c, noisy label=j, true label=k)`` classes.
 
-    Note: if return_indices_of_off_diagonals is True, this function returns confident_joint_counts, indices_off_diagonal
-    where indices_off_diagonal is a list of array of indices counted in off-diagonals of confident joint for each class.
+    Note: if `return_indices_of_off_diagonals` is set as True, this function instead returns a tuple `(confident_joint_counts, indices_off_diagonal)`
+    where `indices_off_diagonal` is a list of arrays (one per class) and each array contains the indices of examples counted in off-diagonals of confident joint for that class.
     """
 
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -29,7 +29,7 @@ from sklearn.metrics import confusion_matrix
 import sklearn.base
 import numpy as np
 import warnings
-from typing import Tuple, Union, Optional, List
+from typing import Tuple, Union, Optional
 
 from cleanlab.typing import LabelLike
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -375,6 +375,7 @@ def compute_confident_joint(
       of confident joint as a baseline proxy for the label issues. This
       sometimes works as well as ``filter.find_label_issues(confident_joint)``.
 
+
     Returns
     -------
     confident_joint_counts : np.ndarray
@@ -383,6 +384,8 @@ def compute_confident_joint(
       If `return_indices_of_off_diagonals` is ``True``, `confident_joint_counts` is the first element of returned tuple
       and second element is another array of indices counted in off-diagonals of confident joint.
 
+    Note: if `return_indices_of_off_diagonals` is set as True, this function instead returns a tuple `(confident_joint, indices_off_diagonal)`
+    where `indices_off_diagonal` is an array and each array contains the indices of examples counted in off-diagonals of confident joint.
     Note
     ----
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -605,7 +605,7 @@ def _compute_confident_joint_multi_label(
     Returns
     -------
     confident_joint_counts : np.ndarray
-      An array of shape ``(num_classes,2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
+      An array of shape ``(K, 2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
       estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.
       Entry ``(c, j, k)`` in the matrix is the number of examples in a one-vs-rest class confidently counted into the pair of ``(class c, noisy label=j, true label=k)`` classes.
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -564,7 +564,7 @@ def _compute_confident_joint_multi_label(
     if return_indices_of_off_diagonals:
         return confident_joint_list, indices_off_diagonal
 
-    return np.array(confident_joint_list)
+    return confident_joint_list
 
 
 def estimate_latent(

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -117,7 +117,7 @@ def num_label_issues(
         # Original non-calibrated counts of confidently correctly and incorrectly labeled examples.
         computed_confident_joint = compute_confident_joint(
             labels=labels, pred_probs=pred_probs, calibrate=False
-        )  # type: ignore
+        )
     else:
         computed_confident_joint = confident_joint
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -581,7 +581,7 @@ def _compute_confident_joint_multi_label(
 
     calibrate : bool, default = True
         Calibrates confident joint estimate P(label=i, true_label=j) such that
-        np.sum(cj) == len(labels) and np.sum(cj, axis = 1) == np.bincount(labels).
+        ``np.sum(cj) == len(labels) and np.sum(cj, axis = 1) == np.bincount(labels)``.
 
     return_indices_of_off_diagonals: bool, default = False
         If true returns indices of examples that were counted in off-diagonals

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -228,7 +228,7 @@ def _calibrate_confident_joint_multilabel(confident_joint: np.ndarray, labels: l
     -------
     calibrated_cj : np.ndarray
       An array of shape ``(K, 2, 2)`` of type float representing a valid
-      estimate of the joint *counts* of noisy and true labels in a one-vs-rest setting."""
+      estimate of the joint *counts* of noisy and true labels in a one-vs-rest fashion."""
     try:
         y_one = int2onehot(labels)
     except TypeError:

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -310,13 +310,22 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
 def _estimate_joint_multilabel(labels, pred_probs, *, confident_joint) -> np.ndarray:
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
     y_one = int2onehot(labels)
+    if confident_joint is None:
+        calibrated_cj = compute_confident_joint(
+            labels,
+            pred_probs,
+            calibrate=True,
+            multi_label=True,
+        )
+    else:
+        calibrated_cj = confident_joint
     calibrated_cf: np.ndarray = np.ndarray((num_classes, 2, 2))
     for class_num in range(num_classes):
         pred_probabilitites = _binarize_pred_probs_slice(pred_probs, class_num)
         calibrated_cf[class_num] = estimate_joint(
             labels=y_one[:, class_num],
             pred_probs=pred_probabilitites,
-            confident_joint=confident_joint[class_num],
+            confident_joint=calibrated_cj[class_num],
         )
 
     return calibrated_cf

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -205,7 +205,7 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> 
 
 
 def _calibrate_confident_joint_multilabel(confident_joint: np.ndarray, labels: list) -> np.ndarray:
-    """Calibrates the confident joint for multi_labeled data. Thus,
+    """Calibrates the confident joint for muli-label classification data. Here
         input `labels` is a list of lists (or list of iterable).
         This is intended as a helper function. You should probably
         be using `calibrate_confident_joint(multi_label=True)` instead.

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -279,7 +279,7 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
       Entry ``(j, k)`` in the matrix is the number of examples confidently counted into the pair of ``(noisy label=j, true label=k)`` classes.
       The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
       If not provided, it is computed from the given (noisy) `labels` and `pred_probs`.
-      If multi_label is True, then the confident should be an array of shape ``(K, 2, 2)``.
+      If `multi_label` is True, then the `confident_joint` should instead be a one-vs-rest array of shape ``(K, 2, 2)``.
 
     multi_label : bool, optional
       If ``True``, labels should be an iterable (e.g. list) of iterables, containing a

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -183,9 +183,9 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> 
     -------
     calibrated_cj : np.ndarray
       An array of shape ``(K, K)`` representing a valid estimate of the joint *counts* of noisy and true labels (if `multi_label` is False).
-      If `multi_label` is True, the returned `calibrated_cj` is instead an one-vs-rest array of shape ``(K, 2, 2)``, 
-      where for class `c`: entry ``(c, 0, 0)`` in this one-vs-rest  array is the number of examples whose noisy label contains `c` confidently identified as truly belonging to class `c` as well. 
-      Entry ``(c, 1, 0)`` in this one-vs-rest  array is the number of examples whose noisy label contains `c` confidently identified as not actually belonging to class `c`. 
+      If `multi_label` is True, the returned `calibrated_cj` is instead an one-vs-rest array of shape ``(K, 2, 2)``,
+      where for class `c`: entry ``(c, 0, 0)`` in this one-vs-rest  array is the number of examples whose noisy label contains `c` confidently identified as truly belonging to class `c` as well.
+      Entry ``(c, 1, 0)`` in this one-vs-rest  array is the number of examples whose noisy label contains `c` confidently identified as not actually belonging to class `c`.
       Entry ``(c, 0, 1)`` in this one-vs-rest array is the number of examples whose noisy label does not contain `c` confidently identified as truly belonging to class `c`.
       Entry ``(c, 1, 1)`` in this one-vs-rest array is the number of examples whose noisy label does not contain `c` confidently identified as actually not belonging to class `c` as well.
 
@@ -310,7 +310,7 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
 def _estimate_joint_multilabel(labels, pred_probs, *, confident_joint) -> np.ndarray:
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
     y_one = int2onehot(labels)
-    calibrated_cf = np.ndarray((num_classes, 2, 2))
+    calibrated_cf: np.ndarray = np.ndarray((num_classes, 2, 2))
     for class_num in range(num_classes):
         pred_probabilitites = _binarize_pred_probs_slice(pred_probs, class_num)
         calibrated_cf[class_num] = estimate_joint(

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -29,7 +29,7 @@ from sklearn.metrics import confusion_matrix
 import sklearn.base
 import numpy as np
 import warnings
-from typing import Tuple, Union, Optional
+from typing import Tuple, Union, Optional, List
 
 from cleanlab.typing import LabelLike
 
@@ -117,10 +117,10 @@ def num_label_issues(
         # Original non-calibrated counts of confidently correctly and incorrectly labeled examples.
         confident_joint = compute_confident_joint(
             labels=labels, pred_probs=pred_probs, calibrate=False
-        )
+        )  # type: ignore
 
     if estimation_method is "off_diagonal":
-        num_issues = np.sum(confident_joint) - np.trace(confident_joint)
+        num_issues = np.sum(confident_joint) - np.trace(confident_joint)  # type: ignore
     elif estimation_method is "off_diagonal_calibrated":
         # Estimate_joint calibrates the row sums to match the prior distribution of given labels and normalizes to sum to 1
         joint = estimate_joint(labels, pred_probs, confident_joint=confident_joint)
@@ -137,7 +137,9 @@ def num_label_issues(
     return num_issues
 
 
-def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> np.ndarray:
+def calibrate_confident_joint(
+    confident_joint, labels, *, multi_label=False
+) -> Union[np.ndarray, List[np.ndarray]]:
     """Calibrates any confident joint estimate ``P(label=i, true_label=j)`` such that
     ``np.sum(cj) == len(labels)`` and ``np.sum(cj, axis = 1) == np.bincount(labels)``.
 
@@ -195,7 +197,9 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> 
     return round_preserving_row_totals(calibrated_cj)
 
 
-def _calibrate_confident_joint_multilabel(confident_joint, labels):
+def _calibrate_confident_joint_multilabel(
+    confident_joint: np.ndarray, labels: list
+) -> List[np.ndarray]:
     y_one = int2onehot(labels)
     num_classes = len(confident_joint)
     calibrate_confident_joint_list = []
@@ -206,7 +210,7 @@ def _calibrate_confident_joint_multilabel(confident_joint, labels):
                 labels=y_one[:, class_num],
             )
         )
-    return np.array(calibrate_confident_joint_list)
+    return np.array(calibrate_confident_joint_list)  # type: ignore
 
 
 def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=False) -> np.ndarray:
@@ -263,7 +267,7 @@ def estimate_joint(labels, pred_probs, *, confident_joint=None, multi_label=Fals
             multi_label=multi_label,
         )
     else:
-        calibrated_cj = calibrate_confident_joint(confident_joint, labels, multi_label=multi_label)
+        calibrated_cj = calibrate_confident_joint(confident_joint, labels, multi_label=multi_label)  # type: ignore
 
     assert isinstance(calibrated_cj, np.ndarray)
     return calibrated_cj / float(np.sum(calibrated_cj))
@@ -442,7 +446,7 @@ def _compute_confident_joint_multi_label(
     thresholds=None,
     calibrate=True,
     return_indices_of_off_diagonals=False,
-) -> Union[np.ndarray, Tuple[np.ndarray, list]]:
+) -> Union[np.ndarray, Tuple[np.ndarray, list]]:  # type: ignore
     """Computes the confident joint for multi_labeled data. Thus,
     input `labels` is a list of lists (or list of iterable).
     This is intended as a helper function. You should probably
@@ -486,7 +490,7 @@ def _compute_confident_joint_multi_label(
 
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
     y_one = int2onehot(labels)
-    confident_joint_list = np.ndarray(shape=(num_classes, 2, 2), dtype=np.int64)
+    confident_joint_list = np.ndarray(shape=(num_classes, 2, 2), dtype=np.int64)  # type: ignore
     indices_of_issues_list = []
     for class_num in range(0, num_classes):
         pred_probabilitites = _binarize_pred_probs_slice(pred_probs, class_num)

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -712,7 +712,7 @@ def find_predicted_neq_given(labels, pred_probs, *, multi_label=False) -> np.nda
 def _find_predicted_neq_given(labels, pred_probs) -> np.ndarray:
     y_one = int2onehot(labels)
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
-    pred_neq = np.ndarray((num_classes, pred_probs.shape[1]))
+    pred_neq: np.ndarray = np.ndarray((num_classes, pred_probs.shape[1]))
     for class_num in range(num_classes):
         pred_probabilitites = _binarize_pred_probs_slice(pred_probs, class_num)
         pred_neq[class_num] = find_predicted_neq_given(

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -182,6 +182,7 @@ def find_label_issues(
       Entry ``(j, k)`` in the matrix is the number of examples confidently counted into the pair of ``(noisy label=j, true label=k)`` classes.
       The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
       If not provided, it is computed from the given (noisy) `labels` and `pred_probs`.
+      If `multi_label` is True, confident_joint should instead be a one-vs-rest array with shape ``(K, 2, 2)``.
 
     n_jobs : optional
       Number of processing threads used by multiprocessing. Default ``None``
@@ -386,7 +387,7 @@ def find_label_issues(
     # Remove label issues if given label == model prediction
     pred = pred_probs.argmax(axis=1)
     for i, pred_label in enumerate(pred):
-        if not multi_label and pred_label == labels[i]:
+        if pred_label == labels[i]:
             label_issues_mask[i] = False
 
     if verbose:

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -506,9 +506,10 @@ def _find_multilabel_issues_per_class(
       Refer to documentation for this argument in filter.find_label_issues() for details.
 
     confident_joint : np.ndarray, optional
-      An array of shape ``(num_classes,2, 2)`` representing the confident joint, the matrix used for identifying label issues, which
-      estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.
-      Entry ``(c, j, k)`` in the matrix is the number of examples in a one-vs-rest class confidently counted into the pair of ``(class c, noisy label=j, true label=k)`` classes.
+      An array of shape ``(K, 2, 2)`` representing a one-vs-rest formatted confident joint.
+      Entry ``(c, i, j)`` in this array is the number of examples confidently counted into a ``(class c, noisy label=i, true label=j)`` bin,
+      where `i, j` are either 0 or 1 to denote whether this example belongs to class `c` or not
+      (recall examples can belong to multiple classes in multi-label classification).
       The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
       If not provided, it is computed from the given (noisy) `labels` and `pred_probs`.
 

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -555,7 +555,7 @@ def _find_multilabel_issues_per_class(
             )
             confident_joint = None
         elif confident_joint_shape != (num_classes, 2, 2):
-            raise ValueError("confident_joint should be of shape (num_classes,2, 2)")
+            raise ValueError("confident_joint should be of shape (num_classes, 2, 2)")
     for class_num in range(0, num_classes):
         pred_probabilitites = _binarize_pred_probs_slice(pred_probs, class_num)
         if confident_joint is None:

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -526,7 +526,12 @@ def _find_multilabel_issues_per_class(
 
     """
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
-    y_one = int2onehot(labels)
+    try:
+        y_one = int2onehot(labels)
+    except TypeError:
+        raise ValueError(
+            "wrong format for labels, should be a list of list[indices], please check the documentation in find_label_issues for further information"
+        )
     if return_indices_ranked_by is None:
         bissues = np.zeros(y_one.shape).astype(bool)
     else:

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -702,23 +702,20 @@ def find_predicted_neq_given(labels, pred_probs, *, multi_label=False) -> np.nda
 
     assert_valid_inputs(X=None, y=labels, pred_probs=pred_probs, multi_label=multi_label)
     if multi_label:
-        # TODO: This needs to be tested.
-        return np.array(
-            [all(np.argsort(pred_probs[i])[: len(j)] == sorted(j)) for i, j in enumerate(labels)]
-        )
+        return _find_predicted_neq_given_multilabel(labels=labels, pred_probs=pred_probs)
     return np.argmax(pred_probs, axis=1) != np.asarray(labels)
 
 
-def _find_predicted_neq_given(labels, pred_probs) -> np.ndarray:
+def _find_predicted_neq_given_multilabel(labels, pred_probs) -> np.ndarray:
     y_one = int2onehot(labels)
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
-    pred_neq: np.ndarray = np.ndarray((num_classes, pred_probs.shape[1]))
+    pred_neq: np.ndarray = np.zeros(y_one.shape).astype(bool)
     for class_num in range(num_classes):
         pred_probabilitites = _binarize_pred_probs_slice(pred_probs, class_num)
-        pred_neq[class_num] = find_predicted_neq_given(
+        pred_neq[:, class_num] = find_predicted_neq_given(
             labels=y_one[:, class_num], pred_probs=pred_probabilitites
         )
-    return pred_neq
+    return pred_neq.sum(axis=1) >= 1
 
 
 def find_label_issues_using_argmax_confusion_matrix(

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -709,6 +709,18 @@ def find_predicted_neq_given(labels, pred_probs, *, multi_label=False) -> np.nda
     return np.argmax(pred_probs, axis=1) != np.asarray(labels)
 
 
+def _find_predicted_neq_given(labels, pred_probs) -> np.ndarray:
+    y_one = int2onehot(labels)
+    num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
+    pred_neq = np.ndarray((num_classes, pred_probs.shape[1]))
+    for class_num in range(num_classes):
+        pred_probabilitites = _binarize_pred_probs_slice(pred_probs, class_num)
+        pred_neq[class_num] = find_predicted_neq_given(
+            labels=y_one[:, class_num], pred_probs=pred_probabilitites
+        )
+    return pred_neq
+
+
 def find_label_issues_using_argmax_confusion_matrix(
     labels,
     pred_probs,

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -417,6 +417,12 @@ def _find_label_issues_multilabel(
     n_jobs: int = None,
     verbose: bool = False,
 ) -> np.ndarray:
+    """
+
+    A pooling function for _find_multilabel_issues_per_class
+
+
+    """
     per_class_issues = _find_multilabel_issues_per_class(
         labels,
         pred_probs,
@@ -726,7 +732,12 @@ def _find_predicted_neq_given_multilabel(labels, pred_probs) -> np.ndarray:
        labeled with high confidence.
 
     """
-    y_one = int2onehot(labels)
+    try:
+        y_one = int2onehot(labels)
+    except TypeError:
+        raise ValueError(
+            "wrong format for labels, should be a list of list[indices], please check the documentation in find_label_issues for further information"
+        )
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
     pred_neq: np.ndarray = np.zeros(y_one.shape).astype(bool)
     for class_num in range(num_classes):

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -154,9 +154,7 @@ def find_label_issues(
       When ``frac_noise=1.0``, return all "confident" estimated noise indices (recommended).
 
       frac_noise * number_of_mislabeled_examples_in_class_k.
-      Note
-      ----
-      This is not yet supported in multilabel setting.
+      Note: specifying `frac_noise` is not yet supported if `multi_label` is True.
 
     num_to_remove_per_class : array_like
       An iterable of length K, the number of classes.

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -707,6 +707,25 @@ def find_predicted_neq_given(labels, pred_probs, *, multi_label=False) -> np.nda
 
 
 def _find_predicted_neq_given_multilabel(labels, pred_probs) -> np.ndarray:
+    """
+
+    Parameters
+     ----------
+     labels : list
+       List of noisy labels for multi-label classification where each example can belong to multiple classes (e.g. ``labels = [[1,2],[1],[0],..]`` indicates the first example in dataset belongs to both class 1 and class 2.
+       For multi-label settings, your `labels` should instead satisfy: ``len(set(k for l in labels for k in l)) == pred_probs.shape[1])``.
+
+     pred_probs : np.ndarray
+       Predicted-probabilities in the same format expected by the :py:func:`find_label_issues <cleanlab.filter.find_label_issues>` function.
+
+     Returns
+     -------
+     label_issues_mask : np.ndarray
+       A boolean mask for the entire dataset where ``True`` represents a
+       label issue and ``False`` represents an example that is accurately
+       labeled with high confidence.
+
+    """
     y_one = int2onehot(labels)
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
     pred_neq: np.ndarray = np.zeros(y_one.shape).astype(bool)

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -420,7 +420,7 @@ def _find_label_issues_multilabel(
 ) -> np.ndarray:
     """
 
-    A pooling function for _find_multilabel_issues_per_class
+    Finds label issues in multi-label classification data where each example can belong to more than one class. This is done via a one-vs-rest reduction for each class and the  results are subsequently aggregated across all classes.
 
 
     """

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -24,7 +24,7 @@ import multiprocessing
 from multiprocessing.sharedctypes import RawArray
 import sys
 import warnings
-from typing import Any, Optional
+from typing import Any, Optional, Union, Tuple, List
 from functools import reduce
 from cleanlab.count import calibrate_confident_joint
 from cleanlab.rank import (
@@ -461,7 +461,7 @@ def _find_multilabel_issues_per_class(
     confident_joint: Optional[np.ndarray] = None,
     n_jobs: int = None,
     verbose: bool = False,
-) -> np.ndarray:
+) -> Union[np.ndarray, Tuple[List[np.ndarray], List[Any], List[np.ndarray]]]:
     """
     Parameters
     ----------

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -431,7 +431,7 @@ def _find_label_issues_multilabel(
         verbose,
     )
     if return_indices_ranked_by is None:
-        return per_class_issues.sum(axis=1) >= 1
+        return per_class_issues.sum(axis=1) >= 1  # type: ignore
     else:
         label_issues_list, labels_list, pred_probs_list = per_class_issues
         label_issues_idx = reduce(np.union1d, label_issues_list)

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -154,6 +154,9 @@ def find_label_issues(
       When ``frac_noise=1.0``, return all "confident" estimated noise indices (recommended).
 
       frac_noise * number_of_mislabeled_examples_in_class_k.
+      Note
+      ----
+      This is not yet supported in multilabel setting.
 
     num_to_remove_per_class : array_like
       An iterable of length K, the number of classes.
@@ -794,6 +797,10 @@ def find_label_issues_using_argmax_confusion_matrix(
       A boolean mask for the entire dataset where ``True`` represents a
       label issue and ``False`` represents an example that is accurately
       labeled with high confidence.
+
+    Note
+    ----
+    Multi-label classification is not supported in this method.
     """
 
     assert_valid_inputs(X=None, y=labels, pred_probs=pred_probs, multi_label=False)

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -431,7 +431,8 @@ def _find_label_issues_multilabel(
         verbose,
     )
     if return_indices_ranked_by is None:
-        return per_class_issues.sum(axis=1) >= 1  # type: ignore
+        assert isinstance(per_class_issues, np.ndarray)
+        return per_class_issues.sum(axis=1) >= 1
     else:
         label_issues_list, labels_list, pred_probs_list = per_class_issues
         label_issues_idx = reduce(np.union1d, label_issues_list)

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -689,6 +689,7 @@ def num_unique_classes(labels, multi_label=None) -> int:
 
 
 def _binarize_pred_probs_slice(pred_probs: np.ndarray, class_num: int) -> np.ndarray:
+    """Binarize predicted probabilities of a particular class, in the form of a one-vs-rest setting"""
     pred_probs_class = pred_probs[:, class_num]
     pred_probabilities = np.stack([1 - pred_probs_class, pred_probs_class]).T
     return pred_probabilities

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -478,7 +478,6 @@ def test_pruning_order_method():
 def test_find_label_issues_multi_label(multi_label, filter_by, return_indices_ranked_by):
     """Note: argmax_not_equal method is not compatible with multi_label == True"""
     dataset = multilabel_data if multi_label else data
-    labels = dataset["labels"]
 
     noise_idx = filter.find_label_issues(
         labels=dataset["labels"],
@@ -488,7 +487,7 @@ def test_find_label_issues_multi_label(multi_label, filter_by, return_indices_ra
         return_indices_ranked_by=return_indices_ranked_by,
     )
     if return_indices_ranked_by is not None:
-        noise_bool = np.zeros(len(labels)).astype(bool)
+        noise_bool = np.zeros(len(dataset["labels"])).astype(bool)
         noise_bool[noise_idx] = True
         noise_idx = noise_bool
     acc = np.mean(
@@ -550,10 +549,9 @@ def test_find_label_issues_multi_label_small(confident_joint, return_indices_ran
 @pytest.mark.parametrize("multi_label", [True, False])
 def test_confident_learning_filter(return_indices_of_off_diagonals, multi_label):
     dataset = multilabel_data if multi_label else data
-    labels = dataset["labels"]
     if return_indices_of_off_diagonals:
         cj, indices = count.compute_confident_joint(
-            labels=labels,
+            labels=dataset["labels"],
             pred_probs=dataset["pred_probs"],
             calibrate=False,
             return_indices_of_off_diagonals=True,
@@ -569,7 +567,7 @@ def test_confident_learning_filter(return_indices_of_off_diagonals, multi_label)
             assert len(indices) == (np.sum(cj) - np.trace(cj))
     else:
         cj = count.compute_confident_joint(
-            labels=labels,
+            labels=dataset["labels"],
             pred_probs=dataset["pred_probs"],
             calibrate=False,
             return_indices_of_off_diagonals=return_indices_of_off_diagonals,

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -24,7 +24,6 @@ import scipy
 import pytest
 from sklearn.multioutput import MultiOutputClassifier
 from sklearn.linear_model import LogisticRegression
-from sklearn.model_selection import cross_val_predict
 
 
 def make_data(

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -340,33 +340,24 @@ def test_estimate_joint(use_confident_joint):
     assert abs(np.sum(joint) - 1.0) < 1e-6
 
 
-@pytest.mark.parametrize("use_confident_joint", [True, False])
-def test_estimate_joint_multilabel(use_confident_joint):
+def test_estimate_joint_multilabel():
     dataset = multilabel_data
-    if use_confident_joint:
-        cj = count.compute_confident_joint(
-            labels=dataset["labels"], pred_probs=dataset["pred_probs"], multi_label=True
-        )
-        assert cj.shape == (3, 2, 2)
-        joint = count.estimate_joint(
-            labels=dataset["labels"],
-            pred_probs=dataset["pred_probs"],
-            confident_joint=cj,
-            multi_label=True,
-        )
-        joint_2 = count.estimate_joint(
-            labels=dataset["labels"],
-            pred_probs=dataset["pred_probs"],
-            multi_label=True,
-        )
-        assert np.array_equal(joint, joint_2)
-    else:
-
-        joint = count.estimate_joint(
-            labels=dataset["labels"],
-            pred_probs=dataset["pred_probs"],
-            multi_label=True,
-        )
+    cj = count.compute_confident_joint(
+        labels=dataset["labels"], pred_probs=dataset["pred_probs"], multi_label=True
+    )
+    assert cj.shape == (3, 2, 2)
+    joint = count.estimate_joint(
+        labels=dataset["labels"],
+        pred_probs=dataset["pred_probs"],
+        confident_joint=cj,
+        multi_label=True,
+    )
+    joint_2 = count.estimate_joint(
+        labels=dataset["labels"],
+        pred_probs=dataset["pred_probs"],
+        multi_label=True,
+    )
+    assert np.array_equal(joint, joint_2)
     assert joint.shape == (3, 2, 2)
     # Check that each joint sums to 1.
     for j in joint:
@@ -593,7 +584,7 @@ def test_find_label_issues_multi_label_small(confident_joint, return_indices_ran
     expected_output = [False, False, False, False, True]
     assert noise_idx.tolist() == noise_idx2.tolist() == expected_output
     if confident_joint is not None:
-        assert noise_idx3.tolist() != [False, False, False, False, True]
+        assert noise_idx3.tolist() != expected_output
 
 
 @pytest.mark.parametrize("return_indices_of_off_diagonals", [True, False])

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -15,6 +15,7 @@
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
 
 from cleanlab import count, filter
+from cleanlab.count import get_confident_thresholds
 from cleanlab.internal.latent_algebra import compute_inv_noise_matrix
 from cleanlab.benchmarking.noise_generation import generate_noise_matrix_from_trace
 from cleanlab.benchmarking.noise_generation import generate_noisy_labels
@@ -363,6 +364,20 @@ def test_estimate_joint_multilabel(use_confident_joint):
     # Check that each joint sums to 1.
     for j in joint:
         assert abs(np.sum(j) - 1.0) < 1e-6
+
+
+def test_confidence_thresholds():
+    dataset = data
+    cft = get_confident_thresholds(pred_probs=dataset["pred_probs"], labels=dataset["labels"])
+    assert cft.shape == (dataset["pred_probs"].shape[1],)
+
+
+def test_confidence_thresholds_multilabel():
+    dataset = multilabel_data
+    cft = get_confident_thresholds(
+        pred_probs=dataset["pred_probs"], labels=dataset["labels"], multi_label=True
+    )
+    assert cft.shape == (dataset["pred_probs"].shape[1], 2)
 
 
 def test_compute_confident_joint():

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -24,6 +24,7 @@ import scipy
 import pytest
 from sklearn.multioutput import MultiOutputClassifier
 from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import cross_val_predict
 
 
 def make_data(
@@ -493,10 +494,7 @@ def test_find_label_issues_multi_label(multi_label, filter_by, return_indices_ra
     )
     # Make sure cleanlab does reasonably well finding the errors.
     # acc is the accuracy of detecting a label error.
-    if multi_label:
-        assert acc > 0.85
-    else:
-        assert acc > 0.85
+    assert acc > 0.85
 
 
 @pytest.mark.parametrize(

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -205,7 +205,6 @@ def test_calibrate_joint(multi_label):
 
     # Check calibration
     if multi_label:
-
         y_one = int2onehot(labels)
         for class_num in range(0, len(calibrated_cj)):
             label_counts = np.bincount(y_one[:, class_num])

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -85,18 +85,12 @@ def make_data(
         labels=labels,
         cv_n_folds=3,
     )
-    multi_labels = [list(set([z, true_labels_train[i]])) for i, z in enumerate(labels)]
-    if len(labels) > 20:
-        multi_labels[20] = [0, 1, 2]
-    else:
-        multi_labels[-1] = [0, 1, 2]
     return {
         "X_train": X_train,
         "true_labels_train": true_labels_train,
         "X_test": X_test,
         "true_labels_test": true_labels_test,
         "labels": labels,
-        "multi_labels": multi_labels,
         "ps": ps,
         "py": py,
         "noise_matrix": noise_matrix,

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -229,12 +229,24 @@ def test_calibrate_joint(multi_label):
 
 
 @pytest.mark.parametrize("use_confident_joint", [True, False])
-def test_estimate_joint(use_confident_joint):
-    joint = count.estimate_joint(
-        labels=data["labels"],
-        pred_probs=data["pred_probs"],
-        confident_joint=data["cj"] if use_confident_joint else None,
-    )
+@pytest.mark.parametrize("multi_label", [True, False])
+def test_estimate_joint(use_confident_joint, multi_label):
+    labels = data["multi_labels"] if multi_label else data["labels"]
+    if use_confident_joint and multi_label:
+        joint = count.estimate_joint(
+            labels=labels,
+            pred_probs=data["pred_probs"],
+            confident_joint=None,
+            multi_label=multi_label,
+        )
+    else:
+
+        joint = count.estimate_joint(
+            labels=labels,
+            pred_probs=data["pred_probs"],
+            confident_joint=data["cj"] if use_confident_joint else None,
+            multi_label=multi_label,
+        )
 
     # Check that joint sums to 1.
     assert abs(np.sum(joint) - 1.0) < 1e-6

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -571,13 +571,14 @@ def test_find_label_issues_multi_label_small(confident_joint, return_indices_ran
         confident_joint=cj,
         return_indices_ranked_by=return_indices_ranked_by,
     )
-    noise_idx3 = filter.find_label_issues(
-        labels=labels,
-        pred_probs=pred_probs,
-        multi_label=True,
-        confident_joint=cj[::-1],
-        return_indices_ranked_by=return_indices_ranked_by,
-    )
+    if confident_joint is not None:
+        noise_idx3 = filter.find_label_issues(
+            labels=labels,
+            pred_probs=pred_probs,
+            multi_label=True,
+            confident_joint=cj[::-1],
+            return_indices_ranked_by=return_indices_ranked_by,
+        )
 
     def _idx_to_bool(idx):
         noise_bool = np.zeros(len(labels)).astype(bool)
@@ -587,10 +588,12 @@ def test_find_label_issues_multi_label_small(confident_joint, return_indices_ran
     if return_indices_ranked_by is not None:
         noise_idx = _idx_to_bool(noise_idx)
         noise_idx2 = _idx_to_bool(noise_idx2)
-        noise_idx3 = _idx_to_bool(noise_idx3)
+        if confident_joint is not None:
+            noise_idx3 = _idx_to_bool(noise_idx3)
     expected_output = [False, False, False, False, True]
     assert noise_idx.tolist() == noise_idx2.tolist() == expected_output
-    assert noise_idx3.tolist() != [False, False, False, False, True]
+    if confident_joint is not None:
+        assert noise_idx3.tolist() != [False, False, False, False, True]
 
 
 @pytest.mark.parametrize("return_indices_of_off_diagonals", [True, False])

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -351,6 +351,7 @@ def test_estimate_joint_multilabel(use_confident_joint):
             confident_joint=cj,
             multi_label=True,
         )
+
     else:
 
         joint = count.estimate_joint(
@@ -359,8 +360,9 @@ def test_estimate_joint_multilabel(use_confident_joint):
             confident_joint=dataset["cj"] if use_confident_joint else None,
             multi_label=True,
         )
-    # Check that joint sums to 1.
-    assert abs(np.sum(joint) - 1.0) < 1e-6
+    # Check that each joint sums to 1.
+    for j in joint:
+        assert abs(np.sum(j) - 1.0) < 1e-6
 
 
 def test_compute_confident_joint():

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -233,10 +233,13 @@ def test_calibrate_joint(multi_label):
 def test_estimate_joint(use_confident_joint, multi_label):
     labels = data["multi_labels"] if multi_label else data["labels"]
     if use_confident_joint and multi_label:
+        cj = count.compute_confident_joint(
+            labels=labels, pred_probs=data["pred_probs"], multi_label=multi_label
+        )
         joint = count.estimate_joint(
             labels=labels,
             pred_probs=data["pred_probs"],
-            confident_joint=None,
+            confident_joint=cj,
             multi_label=multi_label,
         )
     else:

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -640,6 +640,21 @@ def test_predicted_neq_given_filter():
     )
 
 
+def test_predicted_neq_given_filter_multilabel():
+    pred_probs = np.array(
+        [
+            [0.9, 0.1, 0.0, 0.4],
+            [0.7, 0.8, 0.2, 0.3],
+            [0.9, 0.8, 0.4, 0.2],
+            [0.1, 0.1, 0.8, 0.3],
+            [0.4, 0.5, 0.1, 0.1],
+        ]
+    )
+    labels = [[0], [0, 1], [0, 1], [2], [0, 2, 3]]
+    label_issues = filter.find_predicted_neq_given(labels, pred_probs, multi_label=True)
+    assert all(label_issues == [False, False, False, False, True])
+
+
 @pytest.mark.parametrize("calibrate", [True, False])
 @pytest.mark.parametrize("filter_by", ["prune_by_noise_rate", "prune_by_class", "both"])
 def test_find_label_issues_using_argmax_confusion_matrix(calibrate, filter_by):


### PR DESCRIPTION
Adding Multi-Label fix for find label issues, 
This method now solves it using one-vs-rest reductions


```
pred_probs = np.array(
         [
             [0.9, 0.1, 0.0, 0.4],
             [0.7, 0.8, 0.2, 0.3],
             [0.9, 0.8, 0.4, 0.2],
             [0.1, 0.1, 0.8, 0.3],
             [0.4, 0.5, 0.1, 0.1],
         ]
     )
labels = [[0], [0, 1], [0, 1], [2], [0, 2, 3]]
noise_idx = filter.find_label_issues(
         labels=labels,
         pred_probs=pred_probs,
         multi_label=True,
     )
```