### PR TITLE
Make type checking pass with mypy 0.981

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -265,7 +265,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         self.clf_final_kwargs = None
 
     def fit(
-        self,
+        self: TCleanLearning,
         X,
         labels=None,
         *,

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -260,11 +260,11 @@ def find_overlapping_classes(
     num_overlapping = (df["Joint Probability"] * num_examples).round().astype(int)
     df.insert(loc=2, column="Num Overlapping Examples", value=num_overlapping)
     if class_names is not None:
-        df.insert(  # type: ignore
-            loc=0, column="Class Name A", value=df["Class Index A"].apply(lambda x: class_names[x])
+        df.insert(
+            loc=0, column="Class Name A", value=df["Class Index A"].apply(lambda x: class_names[x])  # type: ignore
         )
-        df.insert(  # type: ignore
-            loc=1, column="Class Name B", value=df["Class Index B"].apply(lambda x: class_names[x])
+        df.insert(
+            loc=1, column="Class Name B", value=df["Class Index B"].apply(lambda x: class_names[x])  # type: ignore
         )
     return df.sort_values(by="Joint Probability", ascending=False).reset_index(drop=True)
 


### PR DESCRIPTION
Mypy 0.981 adds a check [[1]] to ensure that functions that return a type variable receive at least one argument containing that type variable.

For situations where an instance method returns an instance of the class, this patch annotates the `self` argument with the generic type as well (otherwise, it's inferred to be the class type, which triggers the check added in mypy 0.981). This is the pattern recommended by the mypy documentation [[2]].

This patch also fixes an unrelated type error (missing `type: ignore` annotation).

[1]: https://github.com/python/mypy/commit/6a4c2c843e5f3c743a855022ca9cdce1089c8559
[2]: https://mypy.readthedocs.io/en/stable/generics.html#generic-methods-and-generic-self

CC @elisno @ulya-tkch 