### PR TITLE
Add a link for How to Contribute in docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -97,6 +97,14 @@ The example below shows how to view all dataset-level issues in one line of code
    health_summary(labels, pred_probs, class_names=class_names)
 
 
+Contributing 
+------------
+
+As cleanlab is an open-source project, we welcome contributions from the community.
+
+Please see our `contributing guidelines <https://github.com/cleanlab/cleanlab/blob/master/CONTRIBUTING.md>`_ for more information.
+
+
 .. toctree::
    :hidden:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -109,7 +109,6 @@ Please see our `contributing guidelines <https://github.com/cleanlab/cleanlab/bl
    :hidden:
 
    Quickstart <self>
-   How to contribute <https://github.com/cleanlab/cleanlab/blob/master/CONTRIBUTING.md>
 
 .. toctree::
    :hidden:
@@ -147,7 +146,8 @@ Please see our `contributing guidelines <https://github.com/cleanlab/cleanlab/bl
 .. toctree::
    :caption: Guides
    :hidden:
-
+   
+   How to contribute <https://github.com/cleanlab/cleanlab/blob/master/CONTRIBUTING.md>
    Migrating to v2.x <migrating/migrate_v2>
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -109,6 +109,7 @@ Please see our `contributing guidelines <https://github.com/cleanlab/cleanlab/bl
    :hidden:
 
    Quickstart <self>
+   How to contribute <https://github.com/cleanlab/cleanlab/blob/master/CONTRIBUTING.md>
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
This PR adds a small section at the bottom of the landing/quickstart page linking to CONTRIBUTING.md.

It also adds the same link in the toctree, visible in the sidebar.