### PR TITLE
Mention internal format label function in multiannotator docs

### DIFF
--- a/cleanlab/internal/multiannotator_utils.py
+++ b/cleanlab/internal/multiannotator_utils.py
@@ -43,7 +43,7 @@ def assert_valid_inputs_multiannotator(
             )
 
     # Raise error if labels are not formatted properly
-    all_labels_flatten = labels_multiannotator.replace({pd.NA: np.NaN}).values.ravel()
+    all_labels_flatten = labels_multiannotator.replace({pd.NA: np.NaN}).astype(float).values.ravel()
     all_labels_flatten = all_labels_flatten[~np.isnan(all_labels_flatten)]
     assert_valid_class_labels(all_labels_flatten)
 

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -68,8 +68,9 @@ def get_label_quality_multiannotator(
         where N is the number of examples and M is the number of annotators.
         ``labels_multiannotator[n][m]`` = label for n-th example given by m-th annotator.
 
-        For a dataset with K classes, each given label must be an integer in 0, 1, ..., K-1 or
-        ``NaN`` if this annotator did not label a particular example. If pd.DataFrame, column names should correspond to each annotator's ID.
+        For a dataset with K classes, each given label must be an integer in 0, 1, ..., K-1 or ``NaN`` if this annotator did not label a particular example.
+        If you have string or other differently formatted labels, you can convert them to the proper format using :py:func:`format_multiannotator_labels <cleanlab.internal.multiannotator_utils.format_multiannotator_labels>`.
+        If pd.DataFrame, column names should correspond to each annotator's ID.
     pred_probs : np.ndarray
         An array of shape ``(N, K)`` of predicted class probabilities from a trained classifier model.
         Predicted probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.

--- a/docs/source/tutorials/multiannotator.ipynb
+++ b/docs/source/tutorials/multiannotator.ipynb
@@ -391,7 +391,8 @@
     "\n",
     "You can easily replace the above with your own multiannotator labels and features, then continue with the rest of the tutorial.\n",
     " \n",
-    "`multiannotator_labels` should be a numpy array or pandas DataFrame with each column representing an annotator and each row representing an example. Your labels should be represented as integer indices 0, 1, ..., num_classes - 1, where examples that are not annotated by a particular annotator are represented using `np.nan` or `pd.NA`.\n",
+    "`multiannotator_labels` should be a numpy array or pandas DataFrame with each column representing an annotator and each row representing an example. Your labels should be represented as integer indices 0, 1, ..., num_classes - 1, where examples that are not annotated by a particular annotator are represented using `np.nan` or `pd.NA`. If you have string labels or other labels that do not fit the required format, you can convert them to the proper format using `cleanlab.internal.multiannotator_utils.format_multiannotator_labels`. \n",
+    "    \n",
     "Your features can be represented however you like (since these are not inputs to `cleanlab.multiannotator` methods) as long as you are able to fit a classifer to them and obtain its predicted class probabilities! \n",
     "\n",
     "</div>\n"


### PR DESCRIPTION
- mention the newly added function to format labels (#504)  in multiannotator docstring + tutorial
- fix tiny bug in converting pd.NA to np.NaN