### PR TITLE
Add EMA multi-label score aggregator

### DIFF
--- a/cleanlab/internal/multilabel_utils.py
+++ b/cleanlab/internal/multilabel_utils.py
@@ -20,7 +20,7 @@ Helper classes and functions used internally to compute label quality scores in 
 
 from enum import Enum
 import itertools
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 import numpy as np
 from sklearn.model_selection import cross_val_predict
@@ -239,17 +239,10 @@ class MultilabelScorer:
     def __init__(
         self,
         base_scorer: ClassLabelScorer = ClassLabelScorer.SELF_CONFIDENCE,
-        aggregator: Aggregator = Aggregator(exponential_moving_average, alpha=0.8),
+        aggregator: Union[Aggregator, Callable] = Aggregator(exponential_moving_average, alpha=0.8),
         *,
         strict: bool = True,
     ):
-        """
-        Initialize object with a base scoring function that is applied to each label and function that pools scores accross labels.
-
-        Examples
-        --------
-
-        """
         self.base_scorer = base_scorer
         if not isinstance(aggregator, Aggregator):
             self.aggregator = Aggregator(aggregator)

--- a/cleanlab/internal/multilabel_utils.py
+++ b/cleanlab/internal/multilabel_utils.py
@@ -179,7 +179,7 @@ class MultilabelScorer:
     def __init__(
         self,
         base_scorer: ClassLabelScorer = ClassLabelScorer.SELF_CONFIDENCE,
-        aggregator: Optional[Aggregator] = None,
+        aggregator: Aggregator = Aggregator(exponential_moving_average, alpha=0.8),
         *,
         strict: bool = True,
     ):
@@ -213,9 +213,7 @@ class MultilabelScorer:
         array([0.9, 0.4])
         """
         self.base_scorer = base_scorer
-        if aggregator is None:
-            self.aggregator = Aggregator(exponential_moving_average, alpha=0.8)
-        elif not isinstance(aggregator, Aggregator):
+        if not isinstance(aggregator, Aggregator):
             self.aggregator = Aggregator(aggregator)
         else:
             self.aggregator = aggregator

--- a/cleanlab/internal/multilabel_utils.py
+++ b/cleanlab/internal/multilabel_utils.py
@@ -201,7 +201,22 @@ def exponential_moving_average(
 
     For a score vector s = (s_1, ..., s_K) with K scores, the values
     are sorted in *descending* order and the exponential moving average
-    of the last score is calculated.
+    of the last score is calculated, denoted as EMA_K according to the
+    note below.
+
+    Note
+    ----
+
+    The recursive formula for the EMA at step :math:`t = 2, ..., K` is:
+
+    .. math::
+
+        \\text{EMA}_t = \\alpha \cdot s_t + (1 - \\alpha) \cdot \\text{EMA}_{t-1},
+
+    We set :math:`\\text{EMA}_1 = s_1` as the largest score in the sorted vector s.
+
+    :math:`\\alpha` is the "forgetting factor" that gives more weight to the
+    most recent scores, and successively less weight to the previous scores.
 
     Parameters
     ----------
@@ -220,6 +235,7 @@ def exponential_moving_average(
 
     Returns
     -------
+    s_ema :
         Exponential moving average score.
 
     Examples

--- a/cleanlab/internal/multilabel_utils.py
+++ b/cleanlab/internal/multilabel_utils.py
@@ -109,6 +109,37 @@ class ClassLabelScorer(Enum):
         """
         return self.value(labels, pred_probs, **kwargs)
 
+    @classmethod
+    def from_str(cls, method: str) -> "ClassLabelScorer":
+        """Constructs an instance of the ClassLabelScorer enum based on the given method name.
+
+        Parameters
+        ----------
+        method:
+            The name of the scoring method to use.
+
+        Returns
+        -------
+        scorer:
+            An instance of the ClassLabelScorer enum.
+
+        Raises
+        ------
+        ValueError:
+            If the given method name is not a valid method name.
+            It must be one of the following: "self_confidence", "normalized_margin", or "confidence_weighted_entropy".
+
+        Example
+        -------
+        >>> from cleanlab.internal.multilabel_utils import ClassLabelScorer
+        >>> ClassLabelScorer.from_str("self_confidence")
+        <ClassLabelScorer.SELF_CONFIDENCE: get_self_confidence_for_each_label>
+        """
+        try:
+            return cls[method.upper()]
+        except KeyError:
+            raise ValueError(f"Invalid method name: {method}")
+
 
 class Aggregator:
     """Helper class for aggregating the label quality scores for each class into a single score for each datapoint.

--- a/cleanlab/internal/multilabel_utils.py
+++ b/cleanlab/internal/multilabel_utils.py
@@ -118,7 +118,7 @@ class Aggregator:
         return self.method(scores, **{**kwargs, **self.kwargs})
 
     def __repr__(self):
-        return f"Aggregator(method={self.method.__name__})"
+        return f"Aggregator(method={self.method.__name__}, kwargs={self.kwargs})"
 
 
 def exponential_moving_average(

--- a/cleanlab/internal/multilabel_utils.py
+++ b/cleanlab/internal/multilabel_utils.py
@@ -148,6 +148,7 @@ class Aggregator:
 
         Returns
         -------
+        aggregated_scores:
             A single label quality score for each datapoint.
         """
         self._validate_scores(scores)

--- a/cleanlab/internal/multilabel_utils.py
+++ b/cleanlab/internal/multilabel_utils.py
@@ -121,6 +121,58 @@ class Aggregator:
         return f"Aggregator(method={self.method.__name__})"
 
 
+def exponential_moving_average(
+    s: np.ndarray,
+    *,
+    alpha: Optional[float] = None,
+    axis: int = 1,
+    **_,
+) -> np.ndarray:
+    """Exponential moving average (EMA) score function.
+
+    For a score vector s = (s_1, ..., s_K) with K scores, the values
+    are sorted in *descending* order and the exponential moving average
+    of the last score is calculated.
+
+    Parameters
+    ----------
+    s :
+        Scores to be transformed.
+
+    alpha :
+        Discount factor that determines the weight of the previous EMA score.
+        Higher alpha means that the previous EMA score has a lower weight while
+        the current score has a higher weight.
+
+        If alpha is None, it is set to 2 / (K + 1) where K is the number of scores.
+
+    axis :
+        Axis along which the scores are sorted.
+
+    Returns
+    -------
+        Exponential moving average score.
+
+    Examples
+    --------
+    >>> from cleanlab.internal.multilabel_utils import exponential_moving_average
+    >>> import numpy as np
+    >>> s = np.array([0.1, 0.2, 0.3])
+    >>> exponential_moving_average(s, alpha=0.5)
+    np.array([0.175])
+    """
+    K = s.shape[1]
+    s_sorted = np.fliplr(np.sort(s, axis=axis))
+    if alpha is None:
+        # One conventional choice for alpha is 2/(K + 1), where K is the number of periods in the moving average.
+        alpha = float(2 / (K + 1))
+    s_T = s_sorted.T
+    s_ema, s_next = s_T[0], s_T[1:]
+    for s_i in s_next:
+        s_ema = alpha * s_i + (1 - alpha) * s_ema
+    return s_ema
+
+
 class MultilabelScorer:
     """Aggregates label quality scores across different classes to produce one score per example in multi-label classification tasks."""
 
@@ -315,56 +367,3 @@ def get_cross_validated_multilabel_pred_probs(X, labels, *, clf, cv):
     split_generator = _get_split_generator(labels, cv)
     pred_probs = cross_val_predict(clf, X, labels, cv=split_generator, method="predict_proba")
     return pred_probs
-
-
-# Aggregators
-
-
-def exponential_moving_average(
-    s: np.ndarray,
-    *,
-    alpha: Optional[float] = None,
-    axis: int = 1,
-    **_,
-) -> np.ndarray:
-    """Exponential moving average (EMA) score function.
-
-    For a score vector s = (s_1, ..., s_K) with K scores, the values
-    are sorted in *descending* order and the exponential moving average
-    of the last score is calculated.
-
-    Parameters
-    ----------
-    s :
-        Scores to be transformed.
-
-    alpha :
-        Discount factor that determines the weight of the previous EMA score.
-        Higher alpha means that the previous EMA score has a lower weight while
-        the current score has a higher weight.
-
-        If alpha is None, it is set to 2 / (K + 1) where K is the number of scores.
-
-    axis :
-        Axis along which the scores are sorted.
-
-    Returns
-    -------
-        Exponential moving average score.
-
-    Examples
-    --------
-    >>> s = np.array([0.1, 0.2, 0.3])
-    >>> exponential_moving_average(s, alpha=0.5)
-    np.array([0.175])
-    """
-    K = s.shape[1]
-    s_sorted = np.fliplr(np.sort(s, axis=axis))
-    if alpha is None:
-        # One conventional choice for alpha is 2/(K + 1), where K is the number of periods in the moving average.
-        alpha = float(2 / (K + 1))
-    s_T = s_sorted.T
-    s_ema, s_next = s_T[0], s_T[1:]
-    for s_i in s_next:
-        s_ema = alpha * s_i + (1 - alpha) * s_ema
-    return s_ema

--- a/docs/source/cleanlab/internal/index.rst
+++ b/docs/source/cleanlab/internal/index.rst
@@ -15,5 +15,6 @@ internal
     util
     latent_algebra
     label_quality_utils
+    multilabel_utils
     token_classification_utils
     validation

--- a/docs/source/cleanlab/internal/multilabel_utils.rst
+++ b/docs/source/cleanlab/internal/multilabel_utils.rst
@@ -1,0 +1,8 @@
+multilabel_utils
+================
+
+.. automodule:: cleanlab.internal.multilabel_utils
+    :autosummary:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tests/test_multilabel_classification.py
+++ b/tests/test_multilabel_classification.py
@@ -98,7 +98,9 @@ def dummy_features(labels):
 
 
 @pytest.mark.parametrize("base_scorer", [scorer for scorer in mlutils.ClassLabelScorer])
-@pytest.mark.parametrize("aggregator", [np.min, np.max, np.mean, None])
+@pytest.mark.parametrize(
+    "aggregator", [mlutils.exponential_moving_average, np.min, np.max, np.mean, None]
+)
 @pytest.mark.parametrize("strict", [True, False])
 def test_multilabel_scorer(base_scorer, aggregator, strict, labels, pred_probs):
     scorer = mlutils.MultilabelScorer(base_scorer, aggregator, strict=strict)

--- a/tests/test_multilabel_classification.py
+++ b/tests/test_multilabel_classification.py
@@ -99,7 +99,7 @@ def dummy_features(labels):
 
 @pytest.mark.parametrize("base_scorer", [scorer for scorer in mlutils.ClassLabelScorer])
 @pytest.mark.parametrize(
-    "aggregator", [mlutils.exponential_moving_average, np.min, np.max, np.mean, None]
+    "aggregator", [mlutils.exponential_moving_average, np.min, np.max, np.mean]
 )
 @pytest.mark.parametrize("strict", [True, False])
 def test_multilabel_scorer(base_scorer, aggregator, strict, labels, pred_probs):

--- a/tests/test_multilabel_classification.py
+++ b/tests/test_multilabel_classification.py
@@ -111,6 +111,17 @@ def test_multilabel_scorer(base_scorer, aggregator, strict, labels, pred_probs):
     assert test_scores.shape == (labels.shape[0],)
 
 
+@pytest.mark.parametrize(
+    "method", ["self_confidence", "normalized_margin", "confidence_weighted_entropy"]
+)
+def test_class_label_scorer_from_str(method):
+    for m in (method, method.upper()):
+        scorer = mlutils.ClassLabelScorer.from_str(m)
+        assert callable(scorer)
+        with pytest.raises(ValueError):
+            mlutils.ClassLabelScorer.from_str(m.replace("_", "-"))
+
+
 @pytest.fixture
 def scorer():
     return mlutils.MultilabelScorer(

--- a/tests/test_multilabel_classification.py
+++ b/tests/test_multilabel_classification.py
@@ -271,3 +271,19 @@ def test_get_cross_validated_multilabel_pred_probs(dummy_features, labels, cv, p
     # Gold master test - Ensure output is consistent
     assert dummy_features.shape == (10, 2)
     assert np.allclose(pred_probs, pred_probs_gold, atol=5e-4)
+
+
+def test_exponential_moving_average():
+    # Test that the exponential moving average is correct
+    # for a simple example.
+    alpha = 0.5
+    for x, expected_ema in zip(
+        [
+            np.ones(5).reshape(1, -1),
+            np.array([[0.1, 0.2, 0.3]]),
+            np.array([x / 10 for x in range(1, 7)]).reshape(2, 3),
+        ],
+        [1, 0.175, np.array([0.175, 0.475])],
+    ):
+        ema = mlutils.exponential_moving_average(x, alpha=alpha)
+        assert np.allclose(ema, expected_ema, atol=1e-4)


### PR DESCRIPTION
This PR adds more helper functions and classes to the internal `multilabel_utils.py` module

## New functionality

- `exponential_moving_average`: A function that aggregates scores, placing more significance on low label quality scores. After sorting a score vector, $s$, (in descending order), an exponential moving average (EMA) filter is applied to the vector and the last (worst) score is returned. ([relevant Wikipedia article](https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average))
  - The plan is to make this the default aggregator in the multi-label classification.
- `Aggregator`: A helper class that handles the calls to the aggregation functions and validates their inputs.
- `from_str` constructor for `ClassLabelScorer`: This should make it easy to integrate with existing label quality score functionality that picks methods based on their names.

## Docs updates
Docs for the internal `multilabel_utils.py` module have also been added.
- Missing docstrings have been added.
- Usage examples added to most of the classes/functions.