### PR TITLE
Add support for missing classes

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -741,7 +741,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         else:
             label_matrix = inverse_noise_matrix
         self.num_classes = get_num_classes(labels, pred_probs, label_matrix)
-        if len(labels) / self.num_classes < self.cv_n_folds:
+        if (pred_probs is None) and (len(labels) / self.num_classes < self.cv_n_folds):
             raise ValueError(
                 "Need more data from each class for cross-validation. "
                 "Try decreasing cv_n_folds (eg. to 2 or 3) in CleanLearning()"

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -1359,7 +1359,7 @@ def get_confident_thresholds(
     confident_thresholds : np.ndarray
       An array of shape ``(K, )`` where K is the number of classes."""
 
-    labels = cleanlab.internal.validation.labels_to_array(labels)
+    labels = labels_to_array(labels)
     all_classes = range(pred_probs.shape[1])
     unique_classes = get_unique_classes(labels)
     BIG_VALUE = 2

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -1063,7 +1063,7 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
     ------
     estimates: tuple
       A tuple of five arrays (py, noise matrix, inverse noise matrix, confident joint, predicted probability matrix).
-    
+
     Note
     ----
     Multi-label classification is not supported in this method.

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -44,6 +44,7 @@ from cleanlab.internal.util import (
     get_unique_classes,
     is_torch_dataset,
     is_tensorflow_dataset,
+    TINY_VALUE,
 )
 from cleanlab.internal.multilabel_utils import stack_complement, get_onehot_num_classes
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -41,6 +41,7 @@ from cleanlab.internal.util import (
     append_extra_datapoint,
     train_val_split,
     get_num_classes,
+    get_unique_classes,
     is_torch_dataset,
     is_tensorflow_dataset,
 )
@@ -1435,9 +1436,7 @@ def get_confident_thresholds(
       An array of shape ``(K, )`` where K is the number of classes."""
 
     all_classes = range(pred_probs.shape[1])
-    unique_classes = (
-        np.unique([l for lst in labels for l in lst]) if multi_label else np.unique(labels)
-    )
+    unique_classes = get_unique_classes(labels, multi_label=multi_label)
     # labels must be a valid np.ndarray.
     labels = cleanlab.internal.validation.labels_to_array(labels)
     # When all_classes != unique_classes the class threshold for the missing classes is set to

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -22,7 +22,7 @@ Methods for estimating latent structures used for confident learning, including:
 * Latent inverse noise matrix characterizing the flipping process: `inv`: ``P(true label | given label)``
 * Latent `confident_joint`, an un-normalized matrix that counts the confident subset of label errors under the joint distribution for true/given label
 """
-
+import cleanlab.internal.util
 from sklearn.linear_model import LogisticRegression as LogReg
 from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import confusion_matrix
@@ -34,7 +34,7 @@ from typing import Tuple, Union, Optional
 from cleanlab.typing import LabelLike
 
 from cleanlab.internal.util import (
-    value_counts,
+    value_counts_fill_missing_classes,
     clip_values,
     clip_noise_rates,
     round_preserving_row_totals,
@@ -121,10 +121,15 @@ def num_label_issues(
     else:
         computed_confident_joint = confident_joint
 
+<<<<<<< HEAD
     assert isinstance(computed_confident_joint, np.ndarray)
 
     if estimation_method == "off_diagonal":
         num_issues: int = np.sum(computed_confident_joint) - np.trace(computed_confident_joint)
+=======
+    if estimation_method == "off_diagonal":
+        num_issues = np.sum(confident_joint) - np.trace(confident_joint)
+>>>>>>> 81c736f (Add support for missing classes.)
     elif estimation_method == "off_diagonal_calibrated":
         # Estimate_joint calibrates the row sums to match the prior distribution of given labels and normalizes to sum to 1
         joint = estimate_joint(labels, pred_probs, confident_joint=computed_confident_joint)
@@ -191,10 +196,15 @@ def calibrate_confident_joint(confident_joint, labels, *, multi_label=False) -> 
 
     """
 
+<<<<<<< HEAD
     if multi_label:
         return _calibrate_confident_joint_multilabel(confident_joint, labels)
     else:
         label_counts = value_counts(labels)
+=======
+    num_classes = len(confident_joint)
+    label_counts = value_counts_fill_missing_classes(labels, num_classes, multi_label=multi_label)
+>>>>>>> 81c736f (Add support for missing classes.)
     # Calibrate confident joint to have correct p(labels) prior on noisy labels.
     calibrated_cj = (confident_joint.T / confident_joint.sum(axis=1) * label_counts).T
     # Calibrate confident joint to sum to:
@@ -513,7 +523,11 @@ def compute_confident_joint(
     # true_labels_confident omits meaningless all-False rows
     true_labels_confident = true_label_guess[at_least_one_confident]
     labels_confident = labels[at_least_one_confident]
-    confident_joint = confusion_matrix(true_labels_confident, labels_confident).T
+    confident_joint = confusion_matrix(
+        y_true=true_labels_confident,
+        y_pred=labels_confident,
+        labels=range(pred_probs.shape[1]),
+    ).T
     # Guarantee at least one correctly labeled example is represented in every class
     np.fill_diagonal(confident_joint, confident_joint.diagonal().clip(min=1))
     if calibrate:
@@ -623,6 +637,7 @@ def estimate_latent(
     labels,
     *,
     py_method="cnt",
+    multi_label=False,
     converge_latent_estimates=False,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Computes the latent prior ``p(y)``, the noise matrix ``P(labels|y)`` and the
@@ -649,6 +664,16 @@ def estimate_latent(
       which works well even when the noise matrices are estimated poorly by using
       the matrix diagonals instead of all the probabilities.
 
+    multi_label : bool, optional
+      If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
+      list of labels for each example, instead of just a single label.
+      The multi-label setting supports classification tasks where an example has 1 or more labels.
+      Example of a multi-labeled `labels` input: ``[[0,1], [1], [0,2], [0,1,2], [0], [1], ...]``.
+      The major difference in how this is calibrated versus single-label is that
+      the total number of errors considered is based on the number of labels,
+      not the number of examples. So, the calibrated `confident_joint` will sum
+      to the number of total labels.
+
     converge_latent_estimates : bool, optional
       If ``True``, forces numerical consistency of estimates. Each is estimated
       independently, but they are related mathematically with closed form
@@ -664,8 +689,10 @@ def estimate_latent(
     Multi-label classification is not supported in this method.
     """
 
+    num_classes = len(confident_joint)
     # 'ps' is p(labels=k)
-    ps = value_counts(labels) / float(len(labels))
+    label_counts = value_counts_fill_missing_classes(labels, num_classes, multi_label=multi_label)
+    ps = label_counts / np.sum(label_counts)
     # Number of training examples confidently counted from each noisy class
     labels_class_counts = confident_joint.sum(axis=1).astype(float)
     # Number of training examples confidently counted into each true class
@@ -706,6 +733,7 @@ def estimate_py_and_noise_matrices_from_probabilities(
     converge_latent_estimates=True,
     py_method="cnt",
     calibrate=True,
+    multi_label=False,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Computes the confident counts
     estimate of latent variables `py` and the noise rates
@@ -764,6 +792,16 @@ def estimate_py_and_noise_matrices_from_probabilities(
       Calibrates confident joint estimate ``P(label=i, true_label=j)`` such that
       ``np.sum(cj) == len(labels)`` and ``np.sum(cj, axis = 1) == np.bincount(labels)``.
 
+    multi_label : bool, optional
+      If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
+      list of labels for each example, instead of just a single label.
+      The multi-label setting supports classification tasks where an example has 1 or more labels.
+      Example of a multi-labeled `labels` input: ``[[0,1], [1], [0,2], [0,1,2], [0], [1], ...]``.
+      The major difference in how this is calibrated versus single-label is that
+      the total number of errors considered is based on the number of labels,
+      not the number of examples. So, the calibrated `confident_joint` will sum
+      to the number of total labels.
+
     Returns
     ------
     estimates : tuple
@@ -779,11 +817,13 @@ def estimate_py_and_noise_matrices_from_probabilities(
         pred_probs=pred_probs,
         thresholds=thresholds,
         calibrate=calibrate,
+        multi_label=multi_label,
     )
     py, noise_matrix, inv_noise_matrix = estimate_latent(
         confident_joint=confident_joint,
         labels=labels,
         py_method=py_method,
+        multi_label=multi_label,
         converge_latent_estimates=converge_latent_estimates,
     )
     assert isinstance(confident_joint, np.ndarray)
@@ -798,6 +838,7 @@ def estimate_confident_joint_and_cv_pred_proba(
     *,
     cv_n_folds=5,
     thresholds=None,
+    multi_label=False,
     seed=None,
     calibrate=True,
     clf_kwargs={},
@@ -856,6 +897,16 @@ def estimate_confident_joint_and_cv_pred_proba(
       k. This is not used for pruning/filtering, only for estimating the
       noise rates using confident counts.
 
+    multi_label : bool, optional
+      If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
+      list of labels for each example, instead of just a single label.
+      The multi-label setting supports classification tasks where an example has 1 or more labels.
+      Example of a multi-labeled `labels` input: ``[[0,1], [1], [0,2], [0,1,2], [0], [1], ...]``.
+      The major difference in how this is calibrated versus single-label is that
+      the total number of errors considered is based on the number of labels,
+      not the number of examples. So, the calibrated `confident_joint` will sum
+      to the number of total labels.
+
     seed : int, optional
         Set the default state of the random number generator used to split
         the cross-validated folds. If None, uses np.random current random state.
@@ -880,7 +931,8 @@ def estimate_confident_joint_and_cv_pred_proba(
     assert_valid_inputs(X, labels)
     labels = labels_to_array(labels)
     num_classes = get_num_classes(
-        labels=labels
+        labels=labels,
+        multi_label=multi_label,  # TODO: add multi_label thoughout and fix comment below)
     )  # This method definitely only works if all classes are present.
 
     # Create cross-validation object for out-of-sample predicted probabilities.
@@ -923,6 +975,7 @@ def estimate_confident_joint_and_cv_pred_proba(
                     "Duplicated some data across multiple folds to ensure training does not fail "
                     f"because these classes do not have enough data for proper cross-validation: {missing_classes}."
                 )
+                # TODO: might need to redo this part now given this PR
                 for missing_class in missing_classes:
                     # Duplicate one instance of missing_class from holdout data to the training data:
                     holdout_inds = np.where(s_holdout_cv == missing_class)[0]
@@ -961,6 +1014,7 @@ def estimate_confident_joint_and_cv_pred_proba(
         pred_probs=pred_probs,  # P(labels = k|x)
         thresholds=thresholds,
         calibrate=calibrate,
+        multi_label=multi_label,
     )
     assert isinstance(confident_joint, np.ndarray)
     assert isinstance(pred_probs, np.ndarray)
@@ -977,6 +1031,7 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
     thresholds=None,
     converge_latent_estimates=False,
     py_method="cnt",
+    multi_label=False,
     seed=None,
     clf_kwargs={},
     validation_func=None,
@@ -1036,6 +1091,16 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
       works well even when the noise matrices are estimated poorly by using
       the matrix diagonals instead of all the probabilities.
 
+    multi_label : bool, optional
+      If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
+      list of labels for each example, instead of just a single label.
+      The multi-label setting supports classification tasks where an example has 1 or more labels.
+      Example of a multi-labeled `labels` input: ``[[0,1], [1], [0,2], [0,1,2], [0], [1], ...]``.
+      The major difference in how this is calibrated versus single-label is that
+      the total number of errors considered is based on the number of labels,
+      not the number of examples. So, the calibrated `confident_joint` will sum
+      to the number of total labels.
+
     seed : int, optional
       Set the default state of the random number generator used to split
       the cross-validated folds. If ``None``, uses ``np.random`` current random state.
@@ -1059,6 +1124,7 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
         clf=clf,
         cv_n_folds=cv_n_folds,
         thresholds=thresholds,
+        multi_label=multi_label,
         seed=seed,
         clf_kwargs=clf_kwargs,
         validation_func=validation_func,
@@ -1068,6 +1134,7 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
         confident_joint=confident_joint,
         labels=labels,
         py_method=py_method,
+        multi_label=multi_label,
         converge_latent_estimates=converge_latent_estimates,
     )
 
@@ -1080,6 +1147,7 @@ def estimate_cv_predicted_probabilities(
     clf=LogReg(multi_class="auto", solver="lbfgs"),
     *,
     cv_n_folds=5,
+    multi_label=False,
     seed=None,
     clf_kwargs={},
     validation_func=None,
@@ -1108,6 +1176,16 @@ def estimate_cv_predicted_probabilities(
       The number of cross-validation folds used to compute
       out-of-sample probabilities for each example in `X`.
 
+    multi_label : bool, optional
+      If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
+      list of labels for each example, instead of just a single label.
+      The multi-label setting supports classification tasks where an example has 1 or more labels.
+      Example of a multi-labeled `labels` input: ``[[0,1], [1], [0,2], [0,1,2], [0], [1], ...]``.
+      The major difference in how this is calibrated versus single-label is that
+      the total number of errors considered is based on the number of labels,
+      not the number of examples. So, the calibrated `confident_joint` will sum
+      to the number of total labels.
+
     seed : int, optional
       Set the default state of the random number generator used to split
       the cross-validated folds. If ``None``, uses ``np.random`` current random state.
@@ -1132,6 +1210,7 @@ def estimate_cv_predicted_probabilities(
         labels=labels,
         clf=clf,
         cv_n_folds=cv_n_folds,
+        multi_label=multi_label,
         seed=seed,
         clf_kwargs=clf_kwargs,
         validation_func=validation_func,
@@ -1146,6 +1225,7 @@ def estimate_noise_matrices(
     cv_n_folds=5,
     thresholds=None,
     converge_latent_estimates=True,
+    multi_label=False,
     seed=None,
     clf_kwargs={},
     validation_func=None,
@@ -1194,6 +1274,16 @@ def estimate_noise_matrices(
       independently, but they are related mathematically with closed form
       equivalences. This will iteratively make them mathematically consistent.
 
+    multi_label : bool, optional
+      If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
+      list of labels for each example, instead of just a single label.
+      The multi-label setting supports classification tasks where an example has 1 or more labels.
+      Example of a multi-labeled `labels` input: ``[[0,1], [1], [0,2], [0,1,2], [0], [1], ...]``.
+      The major difference in how this is calibrated versus single-label is that
+      the total number of errors considered is based on the number of labels,
+      not the number of examples. So, the calibrated `confident_joint` will sum
+      to the number of total labels.
+
     seed : int, optional
         Set the default state of the random number generator used to split
         the cross-validated folds. If None, uses np.random current random state.
@@ -1217,6 +1307,7 @@ def estimate_noise_matrices(
         cv_n_folds=cv_n_folds,
         thresholds=thresholds,
         converge_latent_estimates=converge_latent_estimates,
+        multi_label=multi_label,
         seed=seed,
         clf_kwargs=clf_kwargs,
         validation_func=validation_func,
@@ -1343,11 +1434,21 @@ def get_confident_thresholds(
     confident_thresholds : np.ndarray
       An array of shape ``(K, )`` where K is the number of classes."""
 
-    # Assumes all classes are represented in labels: [0, 1, 2, ... num_classes - 1]
-    unique_classes = range(
-        get_num_classes(labels=labels, pred_probs=pred_probs, multi_label=multi_label)
+    all_classes = range(pred_probs.shape[1])
+    unique_classes = (
+        np.unique([l for lst in labels for l in lst]) if multi_label else np.unique(labels)
     )
+    # labels must be a valid np.ndarray.
+    labels = cleanlab.internal.validation.labels_to_array(labels)
+    # When all_classes != unique_classes the class threshold for the missing classes is set to
+    # BIG_VALUE such that no valid prob >= BIG_VALUE (no example will be counted in missing classes)
+    # REQUIRES: pred_probs.max() >= 1
+    # TODO: if you want this to work for arbitrary softmax outputs where pred_probs.max()
+    #  may exceed 1, change BIG_VALUE = 2 --> BIG_VALUE = 2 * pred_probs.max(). Downside of
+    #  this approach is that there will be no standard value returned for missing classes.
+    BIG_VALUE = 2
     if multi_label:
+<<<<<<< HEAD
         return _get_confident_thresholds_multilabel(labels=labels, pred_probs=pred_probs)
     else:
         confident_thresholds = np.array(
@@ -1384,3 +1485,18 @@ def _get_confident_thresholds_multilabel(
             pred_probs=pred_probabilitites, labels=labels
         )
     return confident_thresholds
+=======
+        # Compute thresholds = p(label=k | k in set of given labels)
+        k_in_l = {k: [k in lst for lst in labels] for k in unique_classes}
+        # The avg probability of class given that the label is represented.
+        confident_thresholds = [
+            np.mean(pred_probs[:, k][k_in_l[k]]) if k in unique_classes else BIG_VALUE
+            for k in all_classes
+        ]
+    else:
+        confident_thresholds = [
+            np.mean(pred_probs[:, k][labels == k]) if k in unique_classes else BIG_VALUE
+            for k in all_classes
+        ]
+    return np.array(confident_thresholds)
+>>>>>>> 81c736f (Add support for missing classes.)

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -299,7 +299,7 @@ def find_label_issues(
         # Prepare multiprocessing shared data
         if n_jobs > 1:
             _labels = RawArray("I", labels)  # type: ignore
-            _label_counts = RawArray("I", label_counts)
+            _label_counts = RawArray("I", label_counts)  # type: ignore
             _prune_count_matrix = RawArray("I", prune_count_matrix.flatten())  # type: ignore
             _pred_probs = RawArray("f", pred_probs.flatten())  # type: ignore
         else:  # Multiprocessing is turned off. Create tuple with all parameters

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -390,6 +390,7 @@ def find_label_issues(
         label_issues_mask = find_predicted_neq_given(labels, pred_probs, multi_label=multi_label)
 
     # Remove label issues if given label == model prediction
+    # TODO: consider use of _multiclass_crossval_predict() here
     pred = pred_probs.argmax(axis=1)
     for i, pred_label in enumerate(pred):
         if pred_label == labels[i]:
@@ -975,6 +976,7 @@ def _prune_by_count(k: int, args=None) -> np.ndarray:
     return label_issues_mask
 
 
+# TODO: move to utils
 def _multiclass_crossval_predict(labels, pred_probs) -> np.ndarray:
     """Returns a numpy 2D array of one-hot encoded
     multiclass predictions. Each row in the array

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -242,7 +242,6 @@ def find_label_issues(
     else:
         assert n_jobs >= 1
 
-    # Number of examples in each class of labels
     if multi_label:
         return _find_label_issues_multilabel(
             labels,
@@ -258,10 +257,7 @@ def find_label_issues(
             verbose,
         )
 
-    else:
-        label_counts = value_counts(labels)
-
-    # Number of classes
+    # Else this is standard multi-class classification
     K = get_num_classes(
         labels=labels, pred_probs=pred_probs, label_matrix=confident_joint, multi_label=multi_label
     )

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -34,7 +34,7 @@ import cleanlab.internal.multilabel_scorer as ml_scorer
 
 from cleanlab.internal.validation import assert_valid_inputs
 from cleanlab.internal.util import (
-    value_counts,
+    value_counts_fill_missing_classes,
     round_preserving_row_totals,
     get_num_classes,
 )
@@ -242,6 +242,7 @@ def find_label_issues(
     else:
         assert n_jobs >= 1
 
+<<<<<<< HEAD
     # Number of examples in each class of labels
     if multi_label:
         return _find_label_issues_multilabel(
@@ -260,10 +261,14 @@ def find_label_issues(
 
     else:
         label_counts = value_counts(labels)
+=======
+>>>>>>> 81c736f (Add support for missing classes.)
     # Number of classes
     K = get_num_classes(
         labels=labels, pred_probs=pred_probs, label_matrix=confident_joint, multi_label=multi_label
     )
+    # Number of examples in each class of labels
+    label_counts = value_counts_fill_missing_classes(labels, K, multi_label=multi_label)
     # Boolean set to true if dataset is large
     big_dataset = K * len(labels) > 1e8
     # Ensure labels are of type np.ndarray()

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -994,8 +994,13 @@ def _multiclass_crossval_predict(labels, pred_probs) -> np.ndarray:
         `pred_probs` should have been computed using 3 (or higher) fold cross-validation."""
 
     from sklearn.metrics import f1_score
+
     boundaries = np.arange(0.05, 0.9, 0.05)
-    K = get_num_classes(labels=labels, pred_probs=pred_probs, multi_label=True,)
+    K = get_num_classes(
+        labels=labels,
+        pred_probs=pred_probs,
+        multi_label=True,
+    )
     labels_one_hot = int2onehot(labels, K)
     f1s = [
         f1_score(

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -37,6 +37,7 @@ from cleanlab.internal.util import (
     value_counts_fill_missing_classes,
     round_preserving_row_totals,
     get_num_classes,
+    int2onehot,
 )
 from cleanlab.internal.multilabel_utils import stack_complement, get_onehot_num_classes
 
@@ -972,8 +973,8 @@ def _prune_by_count(k: int, args=None) -> np.ndarray:
     return label_issues_mask
 
 
-# TODO: move to utils
-def _multiclass_crossval_predict(labels, pred_probs) -> np.ndarray:
+# TODO: decide if we want to keep this based on TODO above. If so move to utils. Add unit test for this.
+def _multiclass_crossval_predict(labels, pred_probs) -> np.ndarray:  # pragma: no cover
     """Returns a numpy 2D array of one-hot encoded
     multiclass predictions. Each row in the array
     provides the predictions for a particular example.

--- a/cleanlab/internal/latent_algebra.py
+++ b/cleanlab/internal/latent_algebra.py
@@ -123,7 +123,7 @@ def compute_inv_noise_matrix(py, noise_matrix, *, ps=None) -> np.ndarray:
 
     joint = noise_matrix * py
     ps = joint.sum(axis=1) if ps is None else ps
-    inverse_noise_matrix = joint.T / ps
+    inverse_noise_matrix = joint.T / np.clip(ps, a_min=TINY_VALUE, a_max=None)
 
     # Clip inverse noise rates P(true_label=k_s|true_label=k_y) into proper range [0,1)
     return clip_noise_rates(inverse_noise_matrix)
@@ -183,7 +183,7 @@ def compute_noise_matrix_from_inverse(ps, inverse_noise_matrix, *, py=None) -> n
 
     joint = (inverse_noise_matrix * ps).T
     py = joint.sum(axis=0) if py is None else py
-    noise_matrix = joint / py
+    noise_matrix = joint / np.clip(py, a_min=TINY_VALUE, a_max=None)
 
     # Clip inverse noise rates P(true_label=k_y|true_label=k_s) into proper range [0,1)
     return clip_noise_rates(noise_matrix)
@@ -248,13 +248,18 @@ def compute_py(
     if py_method == "cnt":
         # Computing py this way avoids dividing by zero noise rates.
         # More robust bc error est_p(true_label|labels) / est_p(labels|y) ~ p(true_label|labels) / p(labels|y)
-        py = inverse_noise_matrix.diagonal() / noise_matrix.diagonal() * ps
-        # Equivalently,
-        # py = (true_labels_class_counts / labels_class_counts) * ps
+        py = (
+            inverse_noise_matrix.diagonal()
+            / np.clip(noise_matrix.diagonal(), a_min=TINY_VALUE, a_max=None)
+            * ps
+        )
+        # Equivalently: py = (true_labels_class_counts / labels_class_counts) * ps
     elif py_method == "eqn":
         py = np.linalg.inv(noise_matrix).dot(ps)
     elif py_method == "marginal":
-        py = true_labels_class_counts / float(sum(true_labels_class_counts))
+        py = true_labels_class_counts / np.clip(
+            float(sum(true_labels_class_counts)), a_min=TINY_VALUE, a_max=None
+        )
     elif py_method == "marginal_ps":
         py = np.dot(inverse_noise_matrix, ps)
     else:
@@ -312,7 +317,11 @@ def compute_pyx(pred_probs, noise_matrix, inverse_noise_matrix):
             + ", but shape should be (N, K)"
         )
 
-    pyx = pred_probs * inverse_noise_matrix.diagonal() / noise_matrix.diagonal()
+    pyx = (
+        pred_probs
+        * inverse_noise_matrix.diagonal()
+        / np.clip(noise_matrix.diagonal(), a_min=TINY_VALUE, a_max=None)
+    )
     # Make sure valid probabilities that sum to 1.0
     return np.apply_along_axis(
         func1d=clip_values, axis=1, arr=pyx, **{"low": 0.0, "high": 1.0, "new_sum": 1.0}

--- a/cleanlab/internal/latent_algebra.py
+++ b/cleanlab/internal/latent_algebra.py
@@ -28,7 +28,7 @@ import warnings
 import numpy as np
 from typing import Tuple
 
-from cleanlab.internal.util import value_counts, clip_values, clip_noise_rates
+from cleanlab.internal.util import value_counts, clip_values, clip_noise_rates, TINY_VALUE
 
 
 def compute_ps_py_inv_noise_matrix(

--- a/cleanlab/internal/multilabel_utils.py
+++ b/cleanlab/internal/multilabel_utils.py
@@ -58,7 +58,7 @@ def get_onehot_num_classes(labels, pred_probs=None):
     """Returns OneHot encoding of MultiLabel Data, and number of classes"""
     num_classes = get_num_classes(labels=labels, pred_probs=pred_probs)
     try:
-        y_one = int2onehot(labels)
+        y_one = int2onehot(labels, K=num_classes)
     except TypeError:
         raise ValueError(
             "wrong format for labels, should be a list of list[indices], please check the documentation in find_label_issues for further information"

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -264,6 +264,7 @@ def round_preserving_row_totals(confident_joint) -> np.ndarray:
     ).astype(int)
 
 
+# TODO: move to multilabel_utils.py
 def int2onehot(labels, K) -> np.ndarray:
     """Convert list of lists to a onehot matrix for multi-labels
 
@@ -282,6 +283,7 @@ def int2onehot(labels, K) -> np.ndarray:
     return mlb.fit_transform(labels)
 
 
+# TODO: move to multilabel_utils.py
 def onehot2int(onehot_matrix) -> list:
     """Convert a onehot matrix for multi-labels to a list of lists of ints
 

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -21,7 +21,7 @@ Ancillary helper methods used internally throughout this package; mostly related
 import warnings
 import numpy as np
 import pandas as pd
-from typing import Any, Union, Tuple
+from typing import Union, Tuple
 
 from cleanlab.typing import DatasetLike, LabelLike
 from cleanlab.internal.validation import labels_to_array

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -177,7 +177,8 @@ def value_counts(x, *, num_classes=None, multi_label=False) -> np.ndarray:
     if num_classes <= max(unique_classes):
         raise ValueError(f"Required: num_classes > max(x), but {num_classes} <= {max(x)}.")
     # Add zero counts for all missing classes in [0, 1,..., num_classes-1]
-    missing_classes = get_missing_classes(x, num_classes=num_classes, multi_label=multi_label)
+    # multi_label=False regardless because x was flattened.
+    missing_classes = get_missing_classes(x, num_classes=num_classes, multi_label=False)
     missing_counts = [(z, 0) for z in missing_classes]
     # Return counts with zeros for all missing classes.
     return np.array(list(zip(*sorted(list(zip(unique_classes, counts)) + missing_counts)))[1])
@@ -196,7 +197,6 @@ def get_missing_classes(labels, *, pred_probs=None, num_classes=None, multi_labe
     """Find which classes are present in ``pred_probs`` but not present in ``labels``.
 
     See ``count.compute_confident_joint`` for parameter docstrings."""
-
     if pred_probs is None and num_classes is None:
         raise ValueError("Both pred_probs and num_classes are None. You must provide exactly one.")
     if pred_probs is not None and num_classes is not None:
@@ -264,18 +264,21 @@ def round_preserving_row_totals(confident_joint) -> np.ndarray:
     ).astype(int)
 
 
-def int2onehot(labels) -> np.ndarray:
+def int2onehot(labels, K) -> np.ndarray:
     """Convert list of lists to a onehot matrix for multi-labels
 
     Parameters
     ----------
     labels: list of lists of integers
       e.g. [[0,1], [3], [1,2,3], [1], [2]]
-      All integers from 0,1,...,K-1 must be represented."""
+      All integers from 0,1,...,K-1 must be represented.
+
+    K: int
+      The number of classes."""
 
     from sklearn.preprocessing import MultiLabelBinarizer
 
-    mlb = MultiLabelBinarizer()
+    mlb = MultiLabelBinarizer(classes=range(K))
     return mlb.fit_transform(labels)
 
 

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -98,7 +98,7 @@ def clip_noise_rates(noise_matrix) -> np.ndarray:
     np.fill_diagonal(noise_matrix, diagonal)
 
     # Re-normalized noise_matrix so that columns sum to one.
-    noise_matrix = noise_matrix / noise_matrix.sum(axis=0)
+    noise_matrix = noise_matrix / np.clip(noise_matrix.sum(axis=0), a_min=TINY_VALUE, a_max=None)
     return noise_matrix
 
 
@@ -134,7 +134,9 @@ def clip_values(x, low=0.0, high=1.0, new_sum=None) -> np.ndarray:
     )  # Vectorize clip_range for efficiency with np.ndarrays
     prev_sum = sum(x) if new_sum is None else new_sum  # Store previous sum
     x = vectorized_clip(x)  # Clip all values (efficiently)
-    x = x * prev_sum / float(sum(x))  # Re-normalized values to sum to previous sum
+    x = (
+        x * prev_sum / np.clip(float(sum(x)), a_min=TINY_VALUE, a_max=None)
+    )  # Re-normalized values to sum to previous sum
     return x
 
 

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -27,6 +27,9 @@ from cleanlab.typing import DatasetLike, LabelLike
 from cleanlab.internal.validation import labels_to_array
 
 
+TINY_VALUE = 1e-100
+
+
 def remove_noise_from_class(noise_matrix, class_without_noise) -> np.ndarray:
     """A helper function in the setting of PU learning.
     Sets all P(label=class_without_noise|true_label=any_other_class) = 0
@@ -96,7 +99,6 @@ def clip_noise_rates(noise_matrix) -> np.ndarray:
 
     # Re-normalized noise_matrix so that columns sum to one.
     noise_matrix = noise_matrix / noise_matrix.sum(axis=0)
-
     return noise_matrix
 
 

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -136,40 +136,75 @@ def clip_values(x, low=0.0, high=1.0, new_sum=None) -> np.ndarray:
     return x
 
 
-def value_counts(x) -> Any:
+def value_counts(x, *, num_classes=None, multi_label=False) -> np.ndarray:
     """Returns an np.ndarray of shape (K, 1), with the
     value counts for every unique item in the labels list/array,
     where K is the number of unique entries in labels.
 
-    Why this matters? Here is an example:
-
-    .. code:: python
-
-        x = [np.random.randint(0,100) for i in range(100000)]
-
-    .. code:: ipython3
-
-        %timeit np.bincount(x)
-        # Result: 100 loops, best of 3: 3.9 ms per loop
-
-    .. code:: ipython3
-
-        %timeit np.unique(x, return_counts=True)[1]
-        # Result: 100 loops, best of 3: 7.47 ms per loop
+    Works for both single-labeled and multi-labeled data.
 
     Parameters
     ----------
     x : list or np.ndarray (one dimensional)
         A list of discrete objects, like lists or strings, for
         example, class labels 'y' when training a classifier.
-        e.g. ["dog","dog","cat"] or [1,2,0,1,1,0,2]"""
-    try:
-        return x.value_counts()
-    except Exception:
-        if type(x[0]) is int and (np.array(x) >= 0).all():
-            return np.bincount(x)
-        else:
-            return np.unique(x, return_counts=True)[1]
+        e.g. ["dog","dog","cat"] or [1,2,0,1,1,0,2]
+
+    num_classes : int (default: None)
+        Setting this fills the value counts for missing classes with zeros.
+        For example, if x = [0, 0, 1, 1, 3] then setting ``num_classes=5`` returns
+        [2, 2, 0, 1, 0] whereas setting ``num_classes=None`` would return [2, 2, 1]. This assumes
+        your labels come from the set [0, 1,... num_classes=1] even if some classes are missing.
+
+    multi_label : bool, optional
+      If ``True``, labels should be an iterable (e.g. list) of iterables, containing a
+      list of labels for each example, instead of just a single label.
+      Assumes all classes in pred_probs.shape[1] are represented in labels.
+      The multi-label setting supports classification tasks where an example has 1 or more labels.
+      Example of a multi-labeled `labels` input: ``[[0,1], [1], [0,2], [0,1,2], [0], [1], ...]``.
+      The major difference in how this is calibrated versus single-label is that
+      the total number of errors considered is based on the number of labels,
+      not the number of examples. So, the calibrated `confident_joint` will sum
+      to the number of total labels."""
+
+    # Efficient method if x is pd.Series, np.ndarray, or list
+    if multi_label:
+        x = [z for lst in x for z in lst]  # Flatten
+    unique_classes, counts = np.unique(x, return_counts=True)
+    if num_classes is None or num_classes == len(unique_classes):
+        return counts
+    # Else, there are missing classes
+    if num_classes <= max(unique_classes):
+        raise ValueError(f"Required: num_classes > max(x), but {num_classes} <= {max(x)}.")
+    # Add zero counts for all missing classes in [0, 1,..., num_classes-1]
+    missing_classes = get_missing_classes(x, num_classes=num_classes, multi_label=multi_label)
+    missing_counts = [(z, 0) for z in missing_classes]
+    # Return counts with zeros for all missing classes.
+    return np.array(list(zip(*sorted(list(zip(unique_classes, counts)) + missing_counts)))[1])
+
+
+def value_counts_fill_missing_classes(x, num_classes, *, multi_label=False) -> np.ndarray:
+    """Same as ``internal.util.value_counts`` but requires that num_classes is provided and
+    always fills missing classes with zero counts.
+
+    See ``internal.util.value_counts`` for parameter docstrings."""
+
+    return value_counts(x, num_classes=num_classes, multi_label=multi_label)
+
+
+def get_missing_classes(labels, *, pred_probs=None, num_classes=None, multi_label=False):
+    """Find which classes are present in ``pred_probs`` but not present in ``labels``.
+
+    See ``count.compute_confident_joint`` for parameter docstrings."""
+
+    if pred_probs is None and num_classes is None:
+        raise ValueError("Both pred_probs and num_classes are None. You must provide exactly one.")
+    if pred_probs is not None and num_classes is not None:
+        raise ValueError("Both pred_probs and num_classes are not None. Only one may be provided.")
+    if num_classes is None:
+        num_classes = pred_probs.shape[1]
+    unique_classes = get_unique_classes(labels, multi_label=multi_label)
+    return sorted(set(range(num_classes)).difference(unique_classes))
 
 
 def round_preserving_sum(iterable) -> np.ndarray:
@@ -538,7 +573,8 @@ def extract_indices_tf(X, idx, allow_shuffle) -> DatasetLike:
     keys_tensor = tensorflow.constant(idx)
     vals_tensor = tensorflow.ones_like(keys_tensor)  # Ones will be casted to True
     table = tensorflow.lookup.StaticHashTable(
-        tensorflow.lookup.KeyValueTensorInitializer(keys_tensor, vals_tensor), default_value=0
+        tensorflow.lookup.KeyValueTensorInitializer(keys_tensor, vals_tensor),
+        default_value=0,
     )  # If index not in table, return 0
 
     def hash_table_filter(index, value):
@@ -681,12 +717,22 @@ def num_unique_classes(labels, multi_label=None) -> int:
     the format of labels.
     This allows for a more general form of multiclass labels that looks
     like this: [1, [1,2], [0], [0, 1], 2, 1]"""
+    return len(get_unique_classes(labels, multi_label))
+
+
+def get_unique_classes(labels, multi_label=None) -> set:
+    """Returns the set of unique classes for both single-labeled
+    and multi-labeled labels. If multi_label is set to None (default)
+    this method will infer if multi_label is True or False based on
+    the format of labels.
+    This allows for a more general form of multiclass labels that looks
+    like this: [1, [1,2], [0], [0, 1], 2, 1]"""
     if multi_label is None:
         multi_label = any(isinstance(l, list) for l in labels)
     if multi_label:
-        return len(set(l for grp in labels for l in list(grp)))
+        return set(l for grp in labels for l in list(grp))
     else:
-        return len(set(labels))
+        return set(labels)
 
 
 def format_labels(labels: LabelLike) -> Tuple[np.ndarray, dict]:

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -79,16 +79,12 @@ def assert_valid_inputs(
         if len(pred_probs) != len(y):
             raise ValueError("pred_probs and labels must have same length.")
         if len(pred_probs.shape) != 2:
-            raise ValueError(
-                "pred_probs array must have shape: num_examples x num_classes."
-            )
+            raise ValueError("pred_probs array must have shape: num_examples x num_classes.")
         # Check for valid probabilities.
         if (np.min(pred_probs) < 0) or (np.max(pred_probs) > 1):
             raise ValueError("Values in pred_probs must be between 0 and 1.")
         if X is not None:
-            warnings.warn(
-                "When X and pred_probs are both provided, the former may be ignored."
-            )
+            warnings.warn("When X and pred_probs are both provided, the former may be ignored.")
 
 
 def assert_valid_class_labels(
@@ -161,7 +157,9 @@ def assert_indexing_works(
         try:
             _ = X[idx]  # type: ignore[call-overload]
         except Exception:
-            msg = "Data features X must support list-based indexing; i.e. one of these must work: \n"
+            msg = (
+                "Data features X must support list-based indexing; i.e. one of these must work: \n"
+            )
             msg += "1)  X[index_list] where say index_list = [0,1,3,10], or \n"
             msg += "2)  X.iloc[index_list] if X is pandas DataFrame."
             raise TypeError(msg)

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -181,10 +181,7 @@ def get_label_quality_scores(
     get_confidence_weighted_entropy_for_each_label
     """
 
-    # TODO: remove allow_missing_classes once supported
-    assert_valid_inputs(
-        X=None, y=labels, pred_probs=pred_probs, multi_label=False, allow_missing_classes=True
-    )
+    assert_valid_inputs(X=None, y=labels, pred_probs=pred_probs, multi_label=False)
 
     # Available scoring functions to choose from
     scoring_funcs = {

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "scikit-learn>=0.18",
         "tqdm>=4.53.0",
         "pandas>=1.0.0",
-        "termcolor>=1.1.0",
+        "termcolor>=1.1.0,<2.1.0",
     ],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "scikit-learn>=0.18",
         "tqdm>=4.53.0",
         "pandas>=1.0.0",
-        "termcolor>=1.1.0,<2.1.0",
+        "termcolor>=1.1.0",
     ],
 )
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -774,3 +774,22 @@ def test_cj_in_find_label_issues_kwargs(filter_by, seed):
     # Chceck that the same exact number of issues are found regardless if the confident joint
     # is computed during find_label_issues or precomputed and provided as a kwargs parameter.
     assert num_issues[0] == num_issues[1]
+
+
+def test_find_issues_missing_classes():
+    labels = np.array([0, 0, 2, 2])
+    pred_probs = np.array(
+        [[0.9, 0.0, 0.1, 0.0], [0.8, 0.0, 0.2, 0.0], [0.1, 0.0, 0.9, 0.0], [0.95, 0.0, 0.05, 0.0]]
+    )
+    issues_df = CleanLearning(
+        find_label_issues_kwargs={"min_examples_per_class": 0}
+    ).find_label_issues(labels=labels, pred_probs=pred_probs)
+    issues = issues_df["is_label_issue"].values
+    assert np.all(issues == np.array([False, False, False, True]))
+    # Check results match without these missing classes present in pred_probs:
+    pred_probs2 = pred_probs[:, list(sorted(np.unique(labels)))]
+    labels2 = np.array([0, 0, 1, 1])
+    issues_df2 = CleanLearning(
+        find_label_issues_kwargs={"min_examples_per_class": 0}
+    ).find_label_issues(labels=labels2, pred_probs=pred_probs2)
+    assert all(issues_df2["is_label_issue"].values == issues)

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -825,10 +825,18 @@ def test_removing_class_consistent_results():
     # Note that only one label is class 1 (we're going to change it to class 2 later...)
     labels = np.array([0, 0, 0, 0, 1, 2, 2, 2])
     # Third example is a label error
-    pred_probs = np.array([
-        [0.9, 0.1, 0.0], [0.8, 0.1, 0.1], [0.1, 0.0, 0.9], [0.9, 0.0, 0.1],
-        [0.1, 0.3, 0.6], [0.1, 0.0, 0.9], [0.1, 0.0, 0.9], [0.1, 0.0, 0.9],
-    ])
+    pred_probs = np.array(
+        [
+            [0.9, 0.1, 0.0],
+            [0.8, 0.1, 0.1],
+            [0.1, 0.0, 0.9],
+            [0.9, 0.0, 0.1],
+            [0.1, 0.3, 0.6],
+            [0.1, 0.0, 0.9],
+            [0.1, 0.0, 0.9],
+            [0.1, 0.0, 0.9],
+        ]
+    )
     cj_with1 = count.compute_confident_joint(labels, pred_probs)
     issues_with1 = filter.find_label_issues(labels, pred_probs)
 
@@ -837,14 +845,20 @@ def test_removing_class_consistent_results():
     issues_no1 = filter.find_label_issues(labels, pred_probs)
 
     assert np.all(issues_with1 == issues_no1)
-    assert np.all(cj_with1 == [
-        [3, 0, 1],
-        [0, 1, 0],
-        [0, 0, 3],
-    ])
+    assert np.all(
+        cj_with1
+        == [
+            [3, 0, 1],
+            [0, 1, 0],
+            [0, 0, 3],
+        ]
+    )
     # Check that the 1, 1 entry goes away and moves to 2, 2 (since we changed label 1 to 2)
-    assert np.all(cj_no1 == [
-        [3, 0, 1],
-        [0, 0, 0],
-        [0, 0, 4],
-    ])
+    assert np.all(
+        cj_no1
+        == [
+            [3, 0, 1],
+            [0, 0, 0],
+            [0, 0, 4],
+        ]
+    )

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -117,7 +117,8 @@ def make_multilabel_data(
     seed=1,
 ):
     np.random.seed(seed=seed)
-    m = len(means) + len(
+    num_classes = len(means)
+    m = num_classes + len(
         box_multilabels
     )  # number of classes by treating each multilabel as 1 unique label
     n = sum(sizes)
@@ -172,7 +173,7 @@ def make_multilabel_data(
     ps = np.bincount(labels_idx) / float(len(labels_idx))
     inv = compute_inv_noise_matrix(py, noise_matrix, ps=ps)
 
-    y_train = int2onehot(noisy_labels)
+    y_train = int2onehot(noisy_labels, K=num_classes)
     clf = MultiOutputClassifier(LogisticRegression())
     pyi = cross_val_predict(clf, X_train, y_train, method="predict_proba")
     pred_probs = np.zeros(y_train.shape)
@@ -310,7 +311,7 @@ def test_calibrate_joint_multilabel():
         labels=dataset["labels"],
         multi_label=True,
     )
-    y_one = int2onehot(dataset["labels"])
+    y_one = int2onehot(dataset["labels"], K=dataset["pred_probs"].shape[1])
     # Check calibration
     for class_num in range(0, len(calibrated_cj)):
         label_counts = np.bincount(y_one[:, class_num])

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -813,25 +813,8 @@ def test_issue_158():
     assert not np.any(np.isnan(inv_noise_matrix))
 
 
-def test_toofew_classes():
-    try:
-        labels = np.array([0, 0])
-        pred_probs = np.array([[0.3, 0.7], [0.2, 0.8]])
-        issues = filter.find_label_issues(labels, pred_probs)
-        assert False
-    except ValueError as e:
-        assert "must contain at least 2 classes" in str(e)
-    else:
-        raise Exception("expected test to raise ValueError")
-
-
-def test_missing_classes():  # TODO: can remove this test once missing classes are supported
-    try:
-        labels = np.array([0, 0, 1, 1])
-        pred_probs = np.array([[0.1, 0.7, 0.2], [0.1, 0.8, 0.1], [0.7, 0.2, 0.1], [0.8, 0.1, 0.1]])
-        issues = filter.find_label_issues(labels, pred_probs)
-        assert False
-    except ValueError as e:
-        assert "All classes" in str(e)
-    else:
-        raise Exception("expected test to raise ValueError")
+def test_missing_classes():
+    labels = np.array([0, 0, 2, 2])
+    pred_probs = np.array([[0.9, 0.1, 0.0], [0.8, 0.1, 0.1], [0.1, 0.0, 0.9], [0.95, 0.0, 0.05]])
+    issues = filter.find_label_issues(labels, pred_probs)
+    assert np.all(issues == np.array([False, False, False, True]))

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -818,3 +818,32 @@ def test_missing_classes():
     pred_probs = np.array([[0.9, 0.1, 0.0], [0.8, 0.1, 0.1], [0.1, 0.0, 0.9], [0.95, 0.0, 0.05]])
     issues = filter.find_label_issues(labels, pred_probs)
     assert np.all(issues == np.array([False, False, False, True]))
+
+
+def test_removing_class_consistent_results():
+    # Note that only one label is class 1 (we're going to change it to class 2 later...)
+    labels = np.array([0, 0, 0, 0, 1, 2, 2, 2])
+    # Third example is a label error
+    pred_probs = np.array([
+        [0.9, 0.1, 0.0], [0.8, 0.1, 0.1], [0.1, 0.0, 0.9], [0.9, 0.0, 0.1],
+        [0.1, 0.3, 0.6], [0.1, 0.0, 0.9], [0.1, 0.0, 0.9], [0.1, 0.0, 0.9],
+    ])
+    cj_with1 = count.compute_confident_joint(labels, pred_probs)
+    issues_with1 = filter.find_label_issues(labels, pred_probs)
+
+    labels_no1 = labels = np.array([0, 0, 0, 0, 2, 2, 2, 2])  # change 1 to 2 (class 1 is missing!)
+    cj_no1 = count.compute_confident_joint(labels, pred_probs)
+    issues_no1 = filter.find_label_issues(labels, pred_probs)
+
+    assert np.all(issues_with1 == issues_no1)
+    assert np.all(cj_with1 == [
+        [3, 0, 1],
+        [0, 1, 0],
+        [0, 0, 3],
+    ])
+    # Check that the 1, 1 entry goes away and moves to 2, 2 (since we changed label 1 to 2)
+    assert np.all(cj_no1 == [
+        [3, 0, 1],
+        [0, 0, 0],
+        [0, 0, 4],
+    ])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -79,8 +79,9 @@ def test_round_preserving_sum():
 
 
 def test_one_hot():
+    num_classes = 4
     labels = [[0], [0, 1], [0, 1], [2], [0, 2, 3]]
-    assert onehot2int(int2onehot(labels)) == labels
+    assert onehot2int(int2onehot(labels, K=num_classes)) == labels
 
 
 def test_num_unique():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,8 +3,14 @@
 from cleanlab.internal import util
 import numpy as np
 
-from cleanlab.internal.util import onehot2int, int2onehot, num_unique_classes, format_labels
 from cleanlab.internal.validation import assert_valid_class_labels
+from cleanlab.internal.util import (
+    onehot2int,
+    int2onehot,
+    num_unique_classes,
+    format_labels,
+    get_missing_classes,
+)
 
 noise_matrix = np.array([[1.0, 0.0, 0.2], [0.0, 0.7, 0.2], [0.0, 0.3, 0.6]])
 
@@ -89,6 +95,12 @@ def test_num_unique():
     assert num_unique_classes(labels) == 4
 
 
+def test_missing_classes():
+    labels = [0, 1]  # class 2 is missing
+    pred_probs = np.array([[0.8, 0.1, 0.1], [0.4, 0.5, 0.1]])
+    assert get_missing_classes(labels, pred_probs=pred_probs) == [2]
+
+
 def test_round_preserving_row_totals():
     mat = np.array(
         [
@@ -133,10 +145,8 @@ def test_format_labels():
     # test 1D labels
     str_labels = np.array(["b", "b", "a", "c", "a"])
     labels, label_map = format_labels(str_labels)
-
     assert all(labels == np.array([1, 1, 0, 2, 0]))
     assert label_map[0] == "a"
     assert label_map[1] == "b"
     assert label_map[2] == "c"
-
     assert_valid_class_labels(labels)


### PR DESCRIPTION
## Extends cleanlab to support missing classes

This PR adds support when `pred_probs.shape[1] > len(set(labels))` for most of the main methods in the `count` and `filter` modules. See examles below.

## Completed

* Missing classes should now work for both single-labeled data and multi-labeled data (list of lists) for methods in `count` and `filter` modules. I tested `compute_confident_joint`, `find_label_issues`, and `get_confident_thresholds`.
* Added two tests to verify basic functionality.
* All other tests still pass.

If you're curious, the most complicated parts of this PR was getting everything to work smoothly with multi_label which we did not plan for in advance (including parallelization). It should work now, but more testing is needed.

## TODO

- [] Did not check if `CleanLearning` works with new functionality. Only supported `filter` and `count` modules.
- [] Much more extensive testing should be added. (recommended tests below)

## Tests TODO (strongly recommend adding/checking these tests)
* Check that all functions in `count` and `filter` work with missing classes, not just the three main ones I checked.
* Check that `CleanLearning` works with missing classes.
* Check that this works for all combinations of hyper-parameters, particularly al filter_by methods and for multi_label=True/False
* Check that this works if setting n_jobs=1 versus using parallelization (not setting n_jobs) because I had to edit how the parallelization works with multi_label to get this to work.
* Replicate variations of my sanity checks below (see screenshots)
* Double check that the classes are mapping correctly for all methods.
* Check that cleanlab.count.estimate_py_noise_matrices_and_cv_pred_proba works if you pass in labels [0, 1, 3] 
* (general check for multi_label) Check that for a dataset of 1000 datapoints, replacing the label of a single item from [0] --> [0,1] to make it multi_label does not have a significant impact on the predicted_probabilities produced. (this is how we'll know multi_label seems to work correctly.

## Useful (and illustrative) sanity checks

### 1. removing a class by changing the fifth label from 1 --> 2
 
<img width="716" alt="image" src="https://user-images.githubusercontent.com/27030270/198545430-f24babf7-7a60-44f5-99f2-3bde9c61ccb5.png">

LOOKS GOOD! Confident joint updates correctly. Label errors update correctly.


## 2. Does multi-label work with missing classes?

```python
labels = [[0], [0], [0], [0, 2], [2], [2], [2], [2]]
# Third and fourth examples are the label errors
pred_probs = np.array([[0.9, 0.1, 0.0], [0.8, 0.1, 0.1], [0.1, 0.0, 0.9], [0.9, 0.0, 0.1],
                       [0.1, 0.3, 0.6], [0.1, 0.0, 0.9], [0.1, 0.0, 0.9], [0.1, 0.0, 0.9],
                      ])
cj = cleanlab.count.compute_confident_joint(labels, pred_probs, multi_label=True)
issues = cleanlab.filter.find_label_issues(labels, pred_probs, multi_label=True, filter_by='prune_by_class')
print('label issues found:', issues)
print(cj)
```
OUTPUT (looks good!)
```
label issues found: [False False  True  True False False False False]
[[3 0 1]
 [0 0 0]
 [1 0 4]]
 ```

## Two logical issues to be aware of (this PR does NOT renormalize predicted probabilities)

These are not errors, but consider alternatives... currently if the predicted probabilities are high on a missing class, a label error will not be detected since there are no labels in that class and thus no data for cleanlab to work with for that class. That probability mass is effectively lost. I left as is because I recommend merging this PR first. This PR handles the software mechanics of supporting missing classes. Its complicated enough as is. Easy to decide if you want to renormalize once this PR is merged.


## 1. Example of label error not counted because prob mass on missing class

<img width="891" alt="image" src="https://user-images.githubusercontent.com/27030270/198546646-e78d563d-6f97-4910-810d-111bf9f544e0.png">


### 2. Example of label error no longer being detected as probability mass shifts to a missing class
<img width="738" alt="image" src="https://user-images.githubusercontent.com/27030270/198546376-c9873938-9223-4879-a451-27a8d1da3857.png">

See the fourth True/False value