### PR TITLE
added missing classes test for multilabel

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -93,7 +93,7 @@ def num_label_issues(
       Entry ``(j, k)`` in the matrix is the number of examples confidently counted into the pair of ``(noisy label=j, true label=k)`` classes.
       The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
       If not provided, it is computed from the given (noisy) `labels` and `pred_probs`.
-      If `multi_label` is True, then the `confident_joint` should be a one-vs-rest array of shape ``(K, 2, 2)``, refer to filter.find_label_issues() for details.
+      If `multi_label` is True, then the `confident_joint` should be a one-vs-rest array of shape ``(K, 2, 2)``, refer to filter.find_label_issues() for detailsf.
 
 
     estimation_method :

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -75,6 +75,8 @@ def num_label_issues(
     labels :
       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
+      For multi-label classification where each example can belong to multiple classes,
+      refer to documentation for this argument in filter.find_label_issues() for details.
 
     pred_probs :
       An array of shape ``(N, K)`` of model-predicted probabilities,
@@ -91,6 +93,8 @@ def num_label_issues(
       Entry ``(j, k)`` in the matrix is the number of examples confidently counted into the pair of ``(noisy label=j, true label=k)`` classes.
       The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
       If not provided, it is computed from the given (noisy) `labels` and `pred_probs`.
+      If `multi_label` is True, then the `confident_joint` should be a one-vs-rest array of shape ``(K, 2, 2)``, refer to filter.find_label_issues() for details.
+
 
     estimation_method :
       Method for estimating the number of label issues in dataset by counting the examples in the off-diagonal of the `confident_joint` ``P(label=i, true_label=j)``.
@@ -105,6 +109,10 @@ def num_label_issues(
           2. If you have a custom score to rank your data by label quality and you just need to know the cut-off of likely label issues.
 
        TL;DR: use this method to get the most accurate estimate of number of label issues when you don't need the indices of the label issues.
+
+    multi_label : bool, optional
+       Refer to documentation for this argument in ``count.compute_confident_joint()`` with `multi_label=True` for details.
+
 
     Returns
     -------
@@ -154,23 +162,21 @@ def _num_label_issues_multilabel(
     pred_probs: np.ndarray,
     confident_joint: Optional[np.ndarray] = None,
 ) -> int:
-    """Parameters
-     ----------
-     labels : list
-      Refer to documentation for this argument in filter.find_label_issues() for details.
-
-     pred_probs : np.ndarray
-       Refer to documentation for this argument in count.estimate_joint() for details.
-
-    confident_joint : np.ndarray, optional
-       Refer to documentation for this argument in filter.find_label_issues() with multi_label=True for details.
-
-     Returns
-     -------
-     num_issues : int
-     The estimated number of examples with label issues in the multilabel dataset.
     """
-    
+    Parameters
+    ----------
+
+    labels: list
+       Refer to documentation for this argument in ``count.calibrate_confident_joint()`` with `multi_label=True` for details.
+    pred_probs : np.ndarray
+       Predicted-probabilities in the same format expected by the :py:func:`get_confident_thresholds <cleanlab.count.get_confident_thresholds>` function.
+
+    Returns
+    -------
+    num_issues : int
+       The estimated number of examples with label issues in the multilabel dataset.
+    """
+
     from cleanlab.filter import find_label_issues
 
     issues_idx = find_label_issues(

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -76,7 +76,7 @@ def num_label_issues(
       An array of shape ``(N,)`` of noisy labels, i.e. some labels may be erroneous.
       Elements must be in the set 0, 1, ..., K-1, where K is the number of classes.
       For multi-label classification where each example can belong to multiple classes,
-      refer to documentation for this argument in filter.find_label_issues() for details.
+      refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.filter.find_label_issues>` for details.
 
     pred_probs :
       An array of shape ``(N, K)`` of model-predicted probabilities,
@@ -93,7 +93,7 @@ def num_label_issues(
       Entry ``(j, k)`` in the matrix is the number of examples confidently counted into the pair of ``(noisy label=j, true label=k)`` classes.
       The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
       If not provided, it is computed from the given (noisy) `labels` and `pred_probs`.
-      If `multi_label` is True, then the `confident_joint` should be a one-vs-rest array of shape ``(K, 2, 2)``, refer to filter.find_label_issues() for detailsf.
+      If `multi_label` is True, then the `confident_joint` should be a one-vs-rest array of shape ``(K, 2, 2)``, refer to :py:func:`find_label_issues <cleanlab.filter.find_label_issues>` for details.
 
 
     estimation_method :
@@ -111,7 +111,7 @@ def num_label_issues(
        TL;DR: use this method to get the most accurate estimate of number of label issues when you don't need the indices of the label issues.
 
     multi_label : bool, optional
-       Refer to documentation for this argument in ``count.compute_confident_joint()`` with `multi_label=True` for details.
+       Refer to documentation for this argument in :py:func:`compute_confident_joint <cleanlab.count.compute_confident_joint>` with `multi_label=True` for details.
 
 
     Returns

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -219,8 +219,8 @@ def find_label_issues(
         "predicted_neq_given",
     ]  # TODO: change default to confident_learning ?
     allow_one_class = False
-    if isinstance(labels, np.ndarray):
-        if set(labels) == {0}:
+    if isinstance(labels, np.ndarray) or all(isinstance(lab, int) for lab in labels):
+        if set(labels) == {0}:  # occurs with missing classes in multi-label settings
             allow_one_class = True
     assert_valid_inputs(
         X=None,

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -218,7 +218,21 @@ def find_label_issues(
         "confident_learning",
         "predicted_neq_given",
     ]  # TODO: change default to confident_learning ?
-    assert_valid_inputs(X=None, y=labels, pred_probs=pred_probs, multi_label=multi_label)
+    allow_one_class = False
+    if isinstance(labels, np.ndarray):
+        if set(labels) == {0}:
+            allow_one_class = True
+    try:
+        assert_valid_inputs(
+            X=None,
+            y=labels,
+            pred_probs=pred_probs,
+            multi_label=multi_label,
+            allow_one_class=allow_one_class,
+        )
+    except:
+        breakpoint()
+
     if filter_by in ["confident_learning", "predicted_neq_given"] and (
         frac_noise != 1.0 or num_to_remove_per_class is not None
     ):

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -222,16 +222,13 @@ def find_label_issues(
     if isinstance(labels, np.ndarray):
         if set(labels) == {0}:
             allow_one_class = True
-    try:
-        assert_valid_inputs(
-            X=None,
-            y=labels,
-            pred_probs=pred_probs,
-            multi_label=multi_label,
-            allow_one_class=allow_one_class,
-        )
-    except:
-        breakpoint()
+    assert_valid_inputs(
+        X=None,
+        y=labels,
+        pred_probs=pred_probs,
+        multi_label=multi_label,
+        allow_one_class=allow_one_class,
+    )
 
     if filter_by in ["confident_learning", "predicted_neq_given"] and (
         frac_noise != 1.0 or num_to_remove_per_class is not None

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -89,7 +89,7 @@ def assert_valid_inputs(
         else:
             assert isinstance(y, list)
             assert all(isinstance(y_i, list) for y_i in y)
-            highest_class = max([max(y_i) for y_i in y]) + 1
+            highest_class = max([max(y_i) for y_i in y if len(y_i) != 0]) + 1
         if pred_probs.shape[1] < highest_class:
             raise ValueError(
                 f"pred_probs must have at least {highest_class} columns, based on the largest class index which appears in labels."

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -87,7 +87,17 @@ def order_label_issues(
       ordered by the label-quality scoring method passed to `rank_by`.
     """
 
-    assert_valid_inputs(X=None, y=labels, pred_probs=pred_probs, multi_label=False)
+    allow_one_class = False
+    if isinstance(labels, np.ndarray):
+        if set(labels) == {0}:
+            allow_one_class = True
+    assert_valid_inputs(
+        X=None,
+        y=labels,
+        pred_probs=pred_probs,
+        multi_label=False,
+        allow_one_class=allow_one_class,
+    )
 
     # Convert bool mask to index mask
     label_issues_idx = np.arange(len(labels))[label_issues_mask]

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -88,8 +88,8 @@ def order_label_issues(
     """
 
     allow_one_class = False
-    if isinstance(labels, np.ndarray):
-        if set(labels) == {0}:
+    if isinstance(labels, np.ndarray) or all(isinstance(lab, int) for lab in labels):
+        if set(labels) == {0}:  # occurs with missing classes in multi-label settings
             allow_one_class = True
     assert_valid_inputs(
         X=None,

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -779,6 +779,26 @@ def test_num_label_issues(confident_joint):
             )
 
 
+@pytest.mark.parametrize("confident_joint", [None, True])
+def test_num_label_issues_multilabel(confident_joint):
+    dataset = multilabel_data
+    n = count.num_label_issues(
+        labels=dataset["labels"],
+        pred_probs=dataset["pred_probs"],
+        confident_joint=dataset["cj"] if confident_joint else None,
+        estimation_method="off_diagonal",
+        multi_label=True,
+    )
+    f = filter.find_label_issues(
+        labels=dataset["labels"],
+        pred_probs=dataset["pred_probs"],
+        confident_joint=dataset["cj"] if confident_joint else None,
+        multi_label=True,
+    )
+    assert sum(f) == 53
+    assert sum(f) == n
+
+
 def test_issue_158():
     # ref: https://github.com/cleanlab/cleanlab/issues/158
     pred_probs = np.array(

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -795,7 +795,6 @@ def test_num_label_issues_multilabel(confident_joint):
         confident_joint=dataset["cj"] if confident_joint else None,
         multi_label=True,
     )
-    assert sum(f) == 53
     assert sum(f) == n
 
 

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -884,18 +884,18 @@ def test_missing_classes():
 def test_missing_classes_multilabel(return_indices_ranked_by):
     pred_probs = np.array(
         [
-            [0.9, 0.1, 0.0, 0.4],
-            [0.7, 0.8, 0.2, 0.3],
-            [0.9, 0.8, 0.4, 0.2],
-            [0.1, 0.1, 0.8, 0.3],
-            [0.4, 0.5, 0.1, 0.1],
-            [0.1, 0.1, 0.2, 0.1],
-            [0.8, 0.1, 0.2, 0.1],
+            [0.9, 0.1, 0.0, 0.4, 0.1],
+            [0.7, 0.8, 0.2, 0.3, 0.1],
+            [0.9, 0.8, 0.4, 0.2, 0.1],
+            [0.1, 0.1, 0.8, 0.3, 0.1],
+            [0.4, 0.5, 0.1, 0.1, 0.1],
+            [0.1, 0.1, 0.2, 0.1, 0.1],
+            [0.8, 0.1, 0.2, 0.1, 0.1],
         ]
     )
     labels = [[0], [0, 1], [0, 1], [2], [0, 2, 3], [], []]
     cj = count.compute_confident_joint(labels=labels, pred_probs=pred_probs, multi_label=True)
-    assert cj.shape == (4, 2, 2)
+    assert cj.shape == (5, 2, 2)
     noise_idx = filter.find_label_issues(
         labels=labels,
         pred_probs=pred_probs,


### PR DESCRIPTION
adding missing class labels test for multi-labels
```
pred_probs = np.array(
         [
             [0.9, 0.1, 0.0, 0.4],
             [0.7, 0.8, 0.2, 0.3],
             [0.9, 0.8, 0.4, 0.2],
             [0.1, 0.1, 0.8, 0.3],
             [0.4, 0.5, 0.1, 0.1],
             [0.1, 0.1, 0.2, 0.1],
             [0.8, 0.1, 0.2, 0.1],
         ]
     )
     labels = [[0], [0, 1], [0, 1], [2], [0, 2, 3], [], []]
     noise_idx = filter.find_label_issues(
         labels=labels,
         pred_probs=pred_probs,
         multi_label=True,
         return_indices_ranked_by=return_indices_ranked_by,
     )
```