### PR TITLE
Fix outdates links to example notebook for multilabel classification

### DIFF
--- a/docs/source/tutorials/multilabel_classification.ipynb
+++ b/docs/source/tutorials/multilabel_classification.ipynb
@@ -118,7 +118,7 @@
    "id": "6fe047ed",
    "metadata": {},
    "source": [
-    "Here we generate a small multi-label classification dataset for a quick demo. To see cleanlab applied to a real image tagging dataset, check out our [example](https://github.com/cleanlab/examples) notebook [\"Find Label Errors in Multi-Label Classification Data (CelebA Image Tagging)\"](https://github.com/cleanlab/examples/blob/multilabel_tutorial/multilabel_classification/image_tagging.ipynb)."
+    "Here we generate a small multi-label classification dataset for a quick demo. To see cleanlab applied to a real image tagging dataset, check out our [example](https://github.com/cleanlab/examples) notebook [\"Find Label Errors in Multi-Label Classification Data (CelebA Image Tagging)\"](https://github.com/cleanlab/examples/blob/master/multilabel_classification/image_tagging.ipynb)."
    ]
   },
   {
@@ -528,7 +528,7 @@
    "id": "a58200c8",
    "metadata": {},
    "source": [
-    "To see cleanlab applied to a real image tagging dataset, check out our [example](https://github.com/cleanlab/examples) notebook [\"Find Label Errors in Multi-Label Classification Data (CelebA Image Tagging)\"](https://github.com/cleanlab/examples/blob/multilabel_tutorial/multilabel_classification/image_tagging.ipynb). That example also demonstrates how to use a state-of-the-art Pytorch neural network for multi-label classification with image data."
+    "To see cleanlab applied to a real image tagging dataset, check out our [example](https://github.com/cleanlab/examples) notebook [\"Find Label Errors in Multi-Label Classification Data (CelebA Image Tagging)\"](https://github.com/cleanlab/examples/blob/master/multilabel_classification/image_tagging.ipynb). That example also demonstrates how to use a state-of-the-art Pytorch neural network for multi-label classification with image data."
    ]
   },
   {


### PR DESCRIPTION
The image_tagging.ipynb notebook in the examples repo has been merged to master, which is reflected in this PR.