### PR TITLE
Fix multilabel_py dimensionality

### DIFF
--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -419,7 +419,7 @@ def get_label_quality_scores(
 
     Examples
     --------
-    >>> import cleanlab.internal.multilabel_utils as ml_scorer
+    >>> import cleanlab.internal.multilabel_scorer as ml_scorer
     >>> import numpy as np
     >>> labels = np.array([[0, 1, 0], [1, 0, 1]])
     >>> pred_probs = np.array([[0.1, 0.9, 0.1], [0.4, 0.1, 0.9]])
@@ -449,23 +449,34 @@ def multilabel_py(y: np.ndarray) -> np.ndarray:
     Returns
     -------
     py :
-        A 1d array of prior probabilities of shape (2**K,) where 2**K is the number of possible class-assignment configurations.
+        A 2d array of prior probabilities of shape (K,2) where the first column is the probability of the label being 0
+        and the second column is the probability of the label being 1 for each class.
 
     Examples
     --------
+    >>> from cleanlab.internal.multilabel_scorer import multilabel_py
+    >>> import numpy as np
     >>> y = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
     >>> multilabel_py(y)
-    array([0.25, 0.25, 0.25, 0.25])
-    >>> y = np.array([[0, 0], [0, 1], [1, 0], [1, 1], [1, 0]])
+    array([[0.5, 0.5],
+           [0.5, 0.5]])
+    >>> y = np.array([[0, 0], [0, 1], [1, 0], [1, 0], [1, 0]])
     >>> multilabel_py(y)
-    array([0.2, 0.2, 0.4, 0.2])
+    array([[0.4, 0.6],
+           [0.8, 0.2]])
     """
-    # Count the number of unique class-assignment configurations/labels
-    # and the number of times each configuration occurs.
-    N, K = y.shape
-    unique_labels, counts = np.unique(y, axis=0, return_counts=True)
-    counts = _fix_missing_class_count(K, unique_labels, counts)
-    py = counts / N
+
+    def compute_class_py(y_slice: np.ndarray) -> np.ndarray:
+        # Should only consider a single class at a time
+        assert y_slice.ndim == 1
+        unique_values, counts = np.unique(y_slice, axis=0, return_counts=True)
+        N = y_slice.shape[0]
+        if len(unique_values) == 1:
+            # Should be 0 and 1, pad with 0 probability if either is missing.
+            counts = np.array([0, N] if unique_values[0] == 1 else [N, 0])
+        return counts / N
+
+    py = np.apply_along_axis(compute_class_py, axis=1, arr=y.T)
     return py
 
 

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -18,7 +18,6 @@ Helper classes and functions used internally to compute label quality scores in 
 """
 
 from enum import Enum
-import itertools
 from typing import Callable, Optional, Union
 
 import numpy as np

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -480,22 +480,6 @@ def multilabel_py(y: np.ndarray) -> np.ndarray:
     return py
 
 
-def _fix_missing_class_count(K: int, unique_labels: np.ndarray, counts: np.ndarray) -> np.ndarray:
-    """If there are missing configurations, i.e. fewer than 2**K unique label, add them with a count of 0."""
-    if unique_labels.shape[0] < 2**K:
-        # Get the missing labels.
-        all_configurations = itertools.product([0, 1], repeat=K)
-        missing_labels = np.array(list(set(all_configurations) - set(map(tuple, unique_labels))))
-        # Add the missing labels with a count of 0.
-        unique_labels = np.vstack((unique_labels, missing_labels))
-        counts = np.hstack((counts, np.zeros(missing_labels.shape[0])))
-        # Sort the labels and counts by binary representation in
-        # 'big' bit order:  [0, 0] < [0, 1] < [1, 0] < [1, 1])
-        sorted_ids = np.argsort(np.sum(unique_labels * 2 ** np.arange(K)[::-1], axis=1))
-        counts = counts[sorted_ids]
-    return counts
-
-
 # Cross-validation helpers
 
 

--- a/tests/test_multilabel_classification.py
+++ b/tests/test_multilabel_classification.py
@@ -204,13 +204,13 @@ def test_get_label_quality_scores_output(labels, pred_probs, scorer):
     [
         (
             pytest.lazy_fixture("labels"),
-            np.array([1 / 10, 1 / 10, 2 / 10, 1 / 10, 1 / 10, 2 / 10, 1 / 10, 1 / 10]),
+            np.full((3, 2), 0.5),
         ),
-        (np.array([[0, 1], [0, 0], [1, 1]]), np.array([1 / 3, 1 / 3, 0, 1 / 3])),
-        (np.array([[0, 1], [0, 0], [0, 1], [0, 1]]), np.array([1 / 4, 3 / 4, 0, 0])),
+        (np.array([[0, 1], [0, 0], [1, 1]]), np.array([[2 / 3, 1 / 3], [1 / 3, 2 / 3]])),
+        (np.array([[0, 1], [0, 0], [0, 1], [0, 1]]), np.array([[4 / 4, 0 / 4], [1 / 4, 3 / 4]])),
         (
             np.array([[0, 1, 0, 0, 0, 0, 0, 0, 0]]),
-            np.array([0 if i != 2**7 else 1 for i in range(2**9)]),
+            np.array([[1, 0] if i != 1 else [0, 1] for i in range(9)]),
         ),
     ],
     ids=[
@@ -223,7 +223,7 @@ def test_get_label_quality_scores_output(labels, pred_probs, scorer):
 def test_multilabel_py(given_labels, expected):
     py = ml_scorer.multilabel_py(given_labels)
     assert isinstance(py, np.ndarray)
-    assert py.shape == (2 ** given_labels.shape[1],)
+    assert py.shape == (given_labels.shape[1], 2)
     assert np.isclose(py, expected).all()
 
 


### PR DESCRIPTION
`multilabel_py` currently has limited use within the repo itself, but AFAIR it's just used for generating synthetic label noise in some multilabel classification experiments.