### PR TITLE
Make a public method for multilabel quality scores 

### DIFF
--- a/cleanlab/__init__.py
+++ b/cleanlab/__init__.py
@@ -8,3 +8,4 @@ from . import dataset
 from . import multiannotator
 from . import outlier
 from . import token_classification
+from . import multilabel_classification

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -286,7 +286,8 @@ class Aggregator:
 
     @staticmethod
     def _validate_method(method) -> None:
-        assert callable(method), f"Expected callable method, got {type(method)}"
+        if not callable(method):
+            raise TypeError(f"Expected callable method, got {type(method)}")
 
     @staticmethod
     def _validate_scores(scores: np.ndarray) -> None:

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -251,9 +251,12 @@ class Aggregator:
     ----------
     method:
         The method to compute the label quality scores for each class.
+        If passed as a callable, your function should take in a 1D array of K scores and return a single aggregated score.
+        See :py:func:`exponential_moving_average <cleanlab.internal.multilabel_scorer.exponential_moving_average>` for an example of such a function.
+        Alternatively, this can be a str value to specify a built-in function, possible values are the keys of the ``Aggregator``'s `possible_methods` attribute.
 
     kwargs:
-        Additional keyword arguments to pass to the method when called.
+        Additional keyword arguments to pass to the aggregation function when it is called.
     """
 
     possible_methods = {

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -264,7 +264,7 @@ class Aggregator:
         Additional keyword arguments to pass to the aggregation function when it is called.
     """
 
-    possible_methods: dict[str, Callable[..., np.ndarray]] = {
+    possible_methods: dict[str, Callable] = {
         "exponential_moving_average": exponential_moving_average,
         "softmin": softmin,
     }

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -219,7 +219,7 @@ def exponential_moving_average(
 def softmin(
     s: np.ndarray,
     *,
-    temperature: Optional[float] = 0.1,
+    temperature: float = 0.1,
     axis: int = 1,
     **_,
 ) -> np.ndarray:
@@ -240,8 +240,6 @@ def softmin(
     -------
         Softmin score.
     """
-    if temperature is None:  # pragma: no cover
-        temperature = 1.0  # this primarily exists to satisfy mypy
 
     def softmax(scores: np.ndarray) -> np.ndarray:
         """Softmax function."""
@@ -266,7 +264,7 @@ class Aggregator:
         Additional keyword arguments to pass to the aggregation function when it is called.
     """
 
-    possible_methods = {
+    possible_methods: dict[str, Callable[..., np.ndarray]] = {
         "exponential_moving_average": exponential_moving_average,
         "softmin": softmin,
     }

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -144,56 +144,6 @@ class ClassLabelScorer(Enum):
             raise ValueError(f"Invalid method name: {method}")
 
 
-class Aggregator:
-    """Helper class for aggregating the label quality scores for each class into a single score for each datapoint.
-
-    Parameters
-    ----------
-    method:
-        The method to compute the label quality scores for each class.
-
-    kwargs:
-        Additional keyword arguments to pass to the method when called.
-    """
-
-    def __init__(self, method, **kwargs):
-        self._validate_method(method)
-        self.method = method
-        self.kwargs = kwargs
-
-    @staticmethod
-    def _validate_method(method) -> None:
-        assert callable(method), f"Expected callable method, got {type(method)}"
-
-    @staticmethod
-    def _validate_scores(scores: np.ndarray) -> None:
-        if not (isinstance(scores, np.ndarray) and scores.ndim == 2):
-            raise ValueError(
-                f"Expected 2D array for scores, got {type(scores)} with shape {scores.shape}"
-            )
-
-    def __call__(self, scores: np.ndarray, **kwargs) -> np.ndarray:
-        """Returns the label quality scores for each datapoint based on the given label quality scores for each class.
-
-        Parameters
-        ----------
-        scores:
-            The label quality scores for each class.
-
-        Returns
-        -------
-        aggregated_scores:
-            A single label quality score for each datapoint.
-        """
-        self._validate_scores(scores)
-        kwargs["axis"] = 1
-        updated_kwargs = {**self.kwargs, **kwargs}
-        return self.method(scores, **updated_kwargs)
-
-    def __repr__(self):
-        return f"Aggregator(method={self.method.__name__}, kwargs={self.kwargs})"
-
-
 def exponential_moving_average(
     s: np.ndarray,
     *,
@@ -201,7 +151,7 @@ def exponential_moving_average(
     axis: int = 1,
     **_,
 ) -> np.ndarray:
-    """Exponential moving average (EMA) score function.
+    r"""Exponential moving average (EMA) score aggregation function.
 
     For a score vector s = (s_1, ..., s_K) with K scores, the values
     are sorted in *descending* order and the exponential moving average
@@ -264,6 +214,97 @@ def exponential_moving_average(
     for s_i in s_next:
         s_ema = alpha * s_i + (1 - alpha) * s_ema
     return s_ema
+
+
+def softmin(
+    s: np.ndarray,
+    *,
+    temperature: Optional[float] = 0.1,
+    axis: int = 1,
+    **_,
+) -> np.ndarray:
+    """Softmin score aggregation function.
+
+    Args:
+        s: Input array.
+        temperature: Temperature parameter. Too small values may cause numerical underflow and NaN scores.
+        axis: Axis along which to apply the function.
+
+    Returns:
+        Softmin score.
+    """
+    if temperature is None:
+        temperature = 1.0
+
+    def softmax(scores: np.ndarray) -> np.ndarray:
+        """Softmax function."""
+        exp_scores = np.exp(scores / temperature)
+        return exp_scores / np.sum(exp_scores, axis=axis, keepdims=True)
+
+    return np.einsum("ij,ij->i", s, softmax(1 - s))
+
+
+class Aggregator:
+    """Helper class for aggregating the label quality scores for each class into a single score for each datapoint.
+
+    Parameters
+    ----------
+    method:
+        The method to compute the label quality scores for each class.
+
+    kwargs:
+        Additional keyword arguments to pass to the method when called.
+    """
+
+    possible_methods = {
+        "exponential_moving_average": exponential_moving_average,
+        "softmin": softmin,
+    }
+
+    def __init__(self, method: Union[str, Callable], **kwargs):
+        if isinstance(method, str):  # convert to callable
+            if method in self.possible_methods:
+                method = self.possible_methods[method]
+            else:
+                raise ValueError(
+                    f"Invalid aggregation method specified: '{method}', must be one of the following: {list(self.possible_methods.keys())}"
+                )
+
+        self._validate_method(method)
+        self.method = method
+        self.kwargs = kwargs
+
+    @staticmethod
+    def _validate_method(method) -> None:
+        assert callable(method), f"Expected callable method, got {type(method)}"
+
+    @staticmethod
+    def _validate_scores(scores: np.ndarray) -> None:
+        if not (isinstance(scores, np.ndarray) and scores.ndim == 2):
+            raise ValueError(
+                f"Expected 2D array for scores, got {type(scores)} with shape {scores.shape}"
+            )
+
+    def __call__(self, scores: np.ndarray, **kwargs) -> np.ndarray:
+        """Returns the label quality scores for each datapoint based on the given label quality scores for each class.
+
+        Parameters
+        ----------
+        scores:
+            The label quality scores for each class.
+
+        Returns
+        -------
+        aggregated_scores:
+            A single label quality score for each datapoint.
+        """
+        self._validate_scores(scores)
+        kwargs["axis"] = 1
+        updated_kwargs = {**self.kwargs, **kwargs}
+        return self.method(scores, **updated_kwargs)
+
+    def __repr__(self):
+        return f"Aggregator(method={self.method.__name__}, kwargs={self.kwargs})"
 
 
 class MultilabelScorer:

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -18,7 +18,7 @@ Helper classes and functions used internally to compute label quality scores in 
 """
 
 from enum import Enum
-from typing import Callable, Optional, Union
+from typing import Callable, Dict, Optional, Union
 
 import numpy as np
 from sklearn.model_selection import cross_val_predict
@@ -264,7 +264,7 @@ class Aggregator:
         Additional keyword arguments to pass to the aggregation function when it is called.
     """
 
-    possible_methods: dict[str, Callable] = {
+    possible_methods: Dict[str, Callable[..., np.ndarray]] = {
         "exponential_moving_average": exponential_moving_average,
         "softmin": softmin,
     }

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -233,8 +233,8 @@ def softmin(
     Returns:
         Softmin score.
     """
-    if temperature is None:
-        temperature = 1.0
+    if temperature is None:  # pragma: no cover
+        temperature = 1.0  # this primarily exists to satisfy mypy
 
     def softmax(scores: np.ndarray) -> np.ndarray:
         """Softmax function."""

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -225,12 +225,19 @@ def softmin(
 ) -> np.ndarray:
     """Softmin score aggregation function.
 
-    Args:
-        s: Input array.
-        temperature: Temperature parameter. Too small values may cause numerical underflow and NaN scores.
-        axis: Axis along which to apply the function.
+    Parameters
+    ----------
+    s :
+        Input array.
 
-    Returns:
+    temperature :
+        Temperature parameter. Too small values may cause numerical underflow and NaN scores.
+
+    axis :
+        Axis along which to apply the function.
+
+    Returns
+    -------
         Softmin score.
     """
     if temperature is None:  # pragma: no cover

--- a/cleanlab/multilabel_classification.py
+++ b/cleanlab/multilabel_classification.py
@@ -51,7 +51,10 @@ def get_label_quality_scores(
     labels : List[List[int]]
       Multi-label classification labels for each example, which is allowed to belong to multiple classes.
       The i-th element of `labels` corresponds to list of classes that i-th example belongs to (e.g. ``labels = [[1,2],[1],[0],..]``).
-      *Format requirements*: for dataset with K classes, individual class labels must be integers in 0, 1, ..., K-1.
+
+      Important
+      ---------
+      *Format requirements*: For dataset with K classes, individual class labels must be integers in 0, 1, ..., K-1.
 
     pred_probs : np.ndarray
       An array of shape ``(N, K)`` of model-predicted probabilities,
@@ -61,7 +64,9 @@ def get_label_quality_scores(
       columns must be ordered such that these probabilities correspond to
       class 0, 1, ..., K-1. In multi-label classification, the rows of `pred_probs` need not sum to 1.
 
-      **Note**: Estimated label quality scores are most accurate when they are computed based on out-of-sample `pred_probs` from your model.
+      Note
+      ----
+      Estimated label quality scores are most accurate when they are computed based on out-of-sample ``pred_probs`` from your model.
       To obtain out-of-sample predicted probabilities for every example in your dataset, you can use :ref:`cross-validation <pred_probs_cross_val>`.
       This is encouraged to get better results.
 
@@ -69,7 +74,10 @@ def get_label_quality_scores(
       Method to calculate separate per class annotation scores that are subsequently aggregated to form an overall label quality score.
       These scores are separately calculated for each class based on the corresponding column of `pred_probs` in a one-vs-rest manner,
       and are standard label quality scores for multi-class classification.
-      See :py:func:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function for details about each option.
+
+      See also
+      --------
+      :py:func:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function for details about each option.
 
     adjust_pred_probs : bool, default = False
       Account for class imbalance in the label-quality scoring by adjusting predicted probabilities

--- a/cleanlab/multilabel_classification.py
+++ b/cleanlab/multilabel_classification.py
@@ -80,7 +80,7 @@ def get_label_quality_scores(
     aggregator_kwargs : dict, default = {"method": "exponential_moving_average", "alpha": 0.8}
       A dictionary of hyperparameter values for aggregating per class scores into an overall label quality score for each example.
       Options for ``"method"`` include: ``"exponential_moving_average"`` or ``"softmin"`` or your own callable function.
-      See :py::class:`internal.multilabel_scorer.Aggregator <cleanlab.internal.multilabel_scorer.Aggregator>` for details about each option and other possible hyperparameters.
+      See :py:class:`internal.multilabel_scorer.Aggregator <cleanlab.internal.multilabel_scorer.Aggregator>` for details about each option and other possible hyperparameters.
 
     Returns
     -------

--- a/cleanlab/multilabel_classification.py
+++ b/cleanlab/multilabel_classification.py
@@ -93,7 +93,7 @@ def get_label_quality_scores(
     Returns
     -------
     label_quality_scores : np.ndarray
-      A 1D array of shape (n_examples,) with a label quality score (between 0 and 1) for each example in the dataset.
+      A 1D array of shape ``(N,)`` with a label quality score (between 0 and 1) for each example in the dataset.
       Lower scores indicate examples whose label is more likely to contain annotation errors.
 
 

--- a/cleanlab/multilabel_classification.py
+++ b/cleanlab/multilabel_classification.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2017-2022  Cleanlab Inc.
+# This file is part of cleanlab.
+#
+# cleanlab is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cleanlab is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Methods to rank the severity of label issues in multi-label classification datasets.
+Here each example can belong to one or more classes, or none of the classes at all.
+Unlike in multi-class classification, predicted class probabilities from model need not sum to 1 for each row.
+"""
+
+import numpy as np
+from typing import List
+
+from cleanlab.internal.validation import assert_valid_inputs
+from cleanlab.internal.util import get_num_classes
+from cleanlab.internal.multilabel_scorer import MultilabelScorer, ClassLabelScorer, Aggregator
+from cleanlab.internal.multilabel_utils import int2onehot
+
+
+def get_label_quality_scores(
+    labels: List,
+    pred_probs: np.ndarray,
+    *,
+    method: str = "self_confidence",
+    adjust_pred_probs: bool = False,
+    aggregator_kwargs: dict = {"method": "exponential_moving_average", "alpha": 0.8}
+) -> np.ndarray:
+    """Returns a label quality score for each datapoint.
+
+    This is a function to compute label quality scores for multi-label classification datasets,
+    where lower scores indicate labels more likely to contain an error.
+
+    Score is between 0 and 1 with lower values indicating labels inferred to be worse.
+    For each example, this method internally computes a separate score for each individual class
+    and then aggregates these per-class scores into an overall label quality score for the example.
+
+    Parameters
+    ----------
+    labels : List[List[int]]
+      Multi-label classification labels for each example, which is allowed to belong to multiple classes.
+      The i-th element of `labels` corresponds to list of classes that i-th example belongs to (e.g. ``labels = [[1,2],[1],[0],..]``).
+      *Format requirements*: for dataset with K classes, individual class labels must be integers in 0, 1, ..., K-1.
+
+    pred_probs : np.ndarray
+      An array of shape ``(N, K)`` of model-predicted probabilities,
+      ``P(label=k|x)``. Each row of this matrix corresponds
+      to an example `x` and contains the model-predicted probabilities that
+      `x` belongs to each possible class, for each of the K classes. The
+      columns must be ordered such that these probabilities correspond to
+      class 0, 1, ..., K-1. In multi-label classification, the rows of `pred_probs` need not sum to 1.
+
+      **Note**: Estimated label quality scores are most accurate when they are computed based on out-of-sample `pred_probs` from your model.
+      To obtain out-of-sample predicted probabilities for every example in your dataset, you can use :ref:`cross-validation <pred_probs_cross_val>`.
+      This is encouraged to get better results.
+
+    method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default = "self_confidence"
+      Method to calculate separate per class annotation scores that are subsequently aggregated to form an overall label quality score.
+      These scores are separately calculated for each class based on the corresponding column of `pred_probs` in a one-vs-rest manner,
+      and are standard label quality scores for multi-class classification.
+      See :py:func:`rank.get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function for details about each option.
+
+    adjust_pred_probs : bool, default = False
+      Account for class imbalance in the label-quality scoring by adjusting predicted probabilities
+      via subtraction of class confident thresholds and renormalization.
+      Set this to ``True`` if you prefer to account for class-imbalance.
+      See `Northcutt et al., 2021 <https://jair.org/index.php/jair/article/view/12125>`_.
+
+    aggregator_kwargs : dict, default = {"method": "exponential_moving_average", "alpha": 0.8}
+      A dictionary of hyperparameter values for aggregating per class scores into an overall label quality score for each example.
+      Options for ``"method"`` include: ``"exponential_moving_average"`` or ``"softmin"`` or your own callable function.
+      See :py::class:`internal.multilabel_scorer.Aggregator <cleanlab.internal.multilabel_scorer.Aggregator>` for details about each option and other possible hyperparameters.
+
+    Returns
+    -------
+    label_quality_scores : np.ndarray
+      A 1D array of shape (n_examples,) with a label quality score (between 0 and 1) for each example in the dataset.
+      Lower scores indicate examples whose label is more likely to contain annotation errors.
+
+
+    Examples
+    --------
+    >>> from cleanlab.multilabel_classification import get_label_quality_scores
+    >>> import numpy as np
+    >>> labels = [[1], [0,2]]
+    >>> pred_probs = np.array([[0.1, 0.9, 0.1], [0.4, 0.1, 0.9]])
+    >>> scores = get_label_quality_scores(labels, pred_probs)
+    >>> scores
+    array([0.9, 0.5])
+    """
+
+    assert_valid_inputs(
+        X=None, y=labels, pred_probs=pred_probs, multi_label=True, allow_one_class=True
+    )
+    num_classes = get_num_classes(labels=labels, pred_probs=pred_probs, multi_label=True)
+    binary_labels = int2onehot(labels, K=num_classes)
+    base_scorer = ClassLabelScorer.from_str(method)
+    base_scorer_kwargs = {"adjust_pred_probs": adjust_pred_probs}
+    aggregator = Aggregator(**aggregator_kwargs)
+    scorer = MultilabelScorer(base_scorer, aggregator)
+    return scorer(binary_labels, pred_probs, base_scorer_kwargs=base_scorer_kwargs)

--- a/docs/source/cleanlab/multilabel_classification.rst
+++ b/docs/source/cleanlab/multilabel_classification.rst
@@ -1,0 +1,8 @@
+multilabel_classification
+=========================
+
+.. automodule:: cleanlab.multilabel_classification
+   :autosummary:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -139,6 +139,7 @@ Please see our `contributing guidelines <https://github.com/cleanlab/cleanlab/bl
    cleanlab/dataset
    cleanlab/outlier
    cleanlab/multiannotator
+   cleanlab/multilabel_classification
    cleanlab/token_classification/index
    cleanlab/benchmarking/index
    cleanlab/experimental/index

--- a/docs/source/tutorials/multilabel_classification.ipynb
+++ b/docs/source/tutorials/multilabel_classification.ipynb
@@ -503,18 +503,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e55ea01d",
+   "id": "32465521",
    "metadata": {},
    "source": [
     "### Label quality scores\n",
     "\n",
-    "The above code identifies which examples have label issues and sorts them by their label quality score. We can also directly compute these label quality scores for each example in the dataset, which roughly estimates the likelihood this example has been correctly labeled. These scores range between 0 and 1 with smaller values indicating examples whose label seems more suspect."
+    "The above code identifies which examples have label issues and sorts them by their label quality score. We can also directly compute this label quality score for each example in the dataset, which estimates our confidence that this example has been correctly labeled. These scores range between 0 and 1 with smaller values indicating examples whose label seems more suspect."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec459d05",
+   "id": "c1198575",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/source/tutorials/multilabel_classification.ipynb
+++ b/docs/source/tutorials/multilabel_classification.ipynb
@@ -503,6 +503,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e55ea01d",
+   "metadata": {},
+   "source": [
+    "### Label quality scores\n",
+    "\n",
+    "The above code identifies which examples have label issues and sorts them by their label quality score. We can also directly compute these label quality scores for each example in the dataset, which roughly estimates the likelihood this example has been correctly labeled. These scores range between 0 and 1 with smaller values indicating examples whose label seems more suspect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec459d05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cleanlab.multilabel_classification import get_label_quality_scores\n",
+    "\n",
+    "scores = get_label_quality_scores(labels, pred_probs)\n",
+    "\n",
+    "print(f\"Label quality scores of the first 10 examples in dataset:\\n{scores[:10]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d65af827-aeda-4b6b-9ae7-b1f0b84700d5",
    "metadata": {},
    "source": [
@@ -567,7 +591,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,

--- a/tests/test_multilabel_classification.py
+++ b/tests/test_multilabel_classification.py
@@ -145,18 +145,18 @@ def test_public_label_quality_scores(labels, pred_probs):
         aggregator_kwargs={"method": np.min},
     )
     assert np.isclose(scores6, scores7, rtol=1e-3).all()
-    try:
+
+    with pytest.raises(ValueError) as e:
         _ = multilabel_classfication.get_label_quality_scores(
             formatted_labels, pred_probs, method="badchoice"
         )
-    except Exception as e:
-        assert "Invalid" in str(e)
-    try:
+        assert "Invalid method name: badchoice" in str(e.value)
+
+    with pytest.raises(ValueError) as e:
         _ = multilabel_classfication.get_label_quality_scores(
             formatted_labels, pred_probs, aggregator_kwargs={"method": "invalid"}
         )
-    except Exception as e:
-        assert "Invalid" in str(e)
+        assert "Invalid aggregation method specified: 'invalid'" in str(e.value)
 
 
 class TestMultilabelScorer:


### PR DESCRIPTION
Adds it in module: cleanlab.multilabel_classification.
We eventually want to standardize on modules being named for ML tasks and avoid mixing multiple ML tasks in the same module like is currently done for cleanlab.filter (hence why all its functions require the `multi_label = True/False` arg and split logic) 