### PR TITLE
Move mypy configuration to config file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           pip install .  # install dependencies
           pip install -r requirements-dev.txt  # install development dependencies and type stubs
       - name: Type check
-        run: mypy --install-types --non-interactive --allow-redefinition cleanlab
+        run: mypy --install-types --non-interactive cleanlab
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+allow_redefinition = True
 
 [mypy-sklearn.*]
 ignore_missing_imports = True


### PR DESCRIPTION
This patch moves the `--allow-redefinition` into the `.mypi.ini` file. Centralizing our mypy config in a single file makes sense, and this way, if people want to run mypy locally, they don't need to remember to supply this command-line argument.