### PR TITLE
Fix passing of kwargs to get_label_quality_scores

### DIFF
--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -158,7 +158,7 @@ def get_label_quality_multiannotator(
             consensus_label=majority_vote_label,
             quality_method=quality_method,
             verbose=verbose,
-            **label_quality_score_kwargs,
+            label_quality_score_kwargs=label_quality_score_kwargs,
         )
 
     label_quality = pd.DataFrame({"num_annotations": num_annotations})
@@ -200,7 +200,7 @@ def get_label_quality_multiannotator(
                 consensus_label=consensus_label,
                 quality_method=quality_method,
                 verbose=verbose,
-                **label_quality_score_kwargs,
+                label_quality_score_kwargs=label_quality_score_kwargs,
             )
 
         else:
@@ -245,7 +245,7 @@ def get_label_quality_multiannotator(
                 detailed_label_quality = labels_multiannotator.apply(
                     _get_annotator_label_quality_score,
                     pred_probs=post_pred_probs,
-                    **label_quality_score_kwargs,
+                    label_quality_score_kwargs=label_quality_score_kwargs,
                 )
                 detailed_label_quality = detailed_label_quality.add_prefix("quality_annotator_")
 
@@ -519,7 +519,7 @@ def _get_consensus_stats(
         num_annotations=num_annotations,
         annotator_agreement=annotator_agreement,
         quality_method=quality_method,
-        **label_quality_score_kwargs,
+        label_quality_score_kwargs=label_quality_score_kwargs,
     )
 
     return (

--- a/tests/test_multiannotator.py
+++ b/tests/test_multiannotator.py
@@ -164,6 +164,11 @@ def test_label_quality_scores_multiannotator():
         labels, pred_probs, consensus_method=["majority_vote", "best_quality"]
     )
 
+    # test passing arguments for get_label_quality_scores
+    multiannotator_dict = get_label_quality_multiannotator(
+        labels, pred_probs, label_quality_score_kwargs={"method": "normalized_margin"}
+    )
+
     # test different quality_methods
     # also testing passing labels as np.ndarray
     multiannotator_dict = get_label_quality_multiannotator(


### PR DESCRIPTION
The functions `_get_consensus_stats` and `_get_annotator_label_quality_score` take an argument `label_quality_score_kwargs`, a dictionary of keyword arguments to pass to `get_label_quality_scores`. When passing a `label_quality_score_kwargs` dictionary to these functions, using the unpacking operator is incorrect: that would be an extra level of unpacking. The _implementations_ of these functions will unpack the `label_quality_score_kwargs` when calling `get_label_quality_scores`. This patch fixes the issue and adds a basic regression test.