### PR TITLE
Switch CI cron schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 8 * * 6'
+    - cron: '0 12 * * 1'
 jobs:
   test:
     name: "Test: Python ${{ matrix.python }} on ${{ matrix.os }}"


### PR DESCRIPTION
Previously, the CI cron schedule, copy-pasted from a personal project, ran jobs at 8am UTC (3am EST or 4am EDT) on Saturday. This isn't a great time to get emails about CI breakages.

This patch switches the schedule so it runs on Monday morning (7am EST / 8am EDT).