### PR TITLE
Pin Ubuntu version in CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
           - windows-latest
         python:
@@ -20,8 +20,8 @@ jobs:
           - "3.9"
           - "3.10"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install cleanlab
@@ -42,8 +42,8 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -57,7 +57,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: psf/black@stable
   pylint:
     name: Check for unused/wildcard imports
@@ -75,7 +75,7 @@ jobs:
     name: Lint Notebooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cleanlab/nblint-action@v1
         with:
           directory: 'docs'


### PR DESCRIPTION
`ubuntu-latest` now resolves to `ubuntu-22.04` on GitHub actions, and `ubuntu-22.04` + `actions/setup-python` doesn't support Python 3.6. While we still want to support Python 3.6, we should test against it, so we have to stick with an older version of Ubuntu (that we were previously using, as `ubuntu-latest` resolved to `ubuntu-20.04`).