### PR TITLE
Add back testing Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,12 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+        include:
+          - os: ubuntu-20.04 # latest that works with setup-python / Python 3.6
+            python: "3.6"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install cleanlab
@@ -42,8 +45,8 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -57,7 +60,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: psf/black@stable
   pylint:
     name: Check for unused/wildcard imports
@@ -75,7 +78,7 @@ jobs:
     name: Lint Notebooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cleanlab/nblint-action@v1
         with:
           directory: 'docs'


### PR DESCRIPTION
If we want to continue supporting Python 3.6 (as we claim in the README), we should make sure we keep testing with it.