### PR TITLE
Fix example in ema docstring

### DIFF
--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -198,7 +198,7 @@ def exponential_moving_average(
     --------
     >>> from cleanlab.internal.multilabel_scorer import exponential_moving_average
     >>> import numpy as np
-    >>> s = np.array([0.1, 0.2, 0.3])
+    >>> s = np.array([[0.1, 0.2, 0.3]])
     >>> exponential_moving_average(s, alpha=0.5)
     np.array([0.175])
     """


### PR DESCRIPTION
This PR fixes the example in the docstring for the `exponential_moving_average` aggregation method.


### Output before change

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/cleanlab/cleanlab/internal/multilabel_scorer.py", line 205, in exponential_moving_average
    K = s.shape[1]
IndexError: tuple index out of range
```

### Output after change

```
array([0.175])
```