### PR TITLE
Handle missing type parameters for generic type "ndarray"

### DIFF
--- a/cleanlab/multilabel_classification.py
+++ b/cleanlab/multilabel_classification.py
@@ -61,12 +61,11 @@ def get_label_quality_scores(
       *Format requirements*: For dataset with K classes, individual class labels must be integers in 0, 1, ..., K-1.
 
     pred_probs : np.ndarray
-      An array of shape ``(N, K)`` of model-predicted probabilities,
-      ``P(label=k|x)``. Each row of this matrix corresponds
-      to an example `x` and contains the model-predicted probabilities that
-      `x` belongs to each possible class, for each of the K classes. The
-      columns must be ordered such that these probabilities correspond to
-      class 0, 1, ..., K-1. In multi-label classification, the rows of `pred_probs` need not sum to 1.
+      A 2D array of shape ``(N, K)`` of model-predicted class probabilities ``P(label=k|x)``.
+      Each row of this matrix corresponds to an example `x` and contains the predicted probabilities
+      that `x` belongs to each possible class, for each of the K classes.
+      The columns of this array must be ordered such that these probabilities correspond to class 0, 1, ..., K-1.
+      In multi-label classification (where classes are not mutually exclusive), the rows of `pred_probs` need not sum to 1.
 
       Note
       ----

--- a/cleanlab/multilabel_classification.py
+++ b/cleanlab/multilabel_classification.py
@@ -20,8 +20,9 @@ Here each example can belong to one or more classes, or none of the classes at a
 Unlike in standard multi-class classification, predicted class probabilities from model need not sum to 1 for each row in multi-label classification.
 """
 
-import numpy as np
-from typing import List
+import numpy as np  # noqa: F401: Imported for type annotations
+import numpy.typing as npt
+from typing import List, TypeVar
 
 from cleanlab.internal.validation import assert_valid_inputs
 from cleanlab.internal.util import get_num_classes
@@ -29,14 +30,17 @@ from cleanlab.internal.multilabel_scorer import MultilabelScorer, ClassLabelScor
 from cleanlab.internal.multilabel_utils import int2onehot
 
 
+T = TypeVar("T", bound=npt.NBitBase)
+
+
 def get_label_quality_scores(
     labels: List,
-    pred_probs: np.ndarray,
+    pred_probs: npt.NDArray["np.floating[T]"],
     *,
     method: str = "self_confidence",
     adjust_pred_probs: bool = False,
     aggregator_kwargs: dict = {"method": "exponential_moving_average", "alpha": 0.8}
-) -> np.ndarray:
+) -> npt.NDArray["np.floating[T]"]:
     """Computes a label quality score each example in a multi-label classification dataset.
 
     Scores are between 0 and 1 with lower scores indicating examples whose label more likely contains an error.


### PR DESCRIPTION
## Description

In this PR, some of the `np.ndarray` type hints are replaced with a `numpy.typing.NDArray[...]` that pass a `mypy --strict` type check.


## Motivation and Context
Some of the functions in this package use the generic type `ndarray` from the `numpy` package, to indicate that the function accepts a numpy array as an argument or a return value. 

Example:
```python
import numpy as np

def power(x: np.ndarray, y: float) -> np.ndarray:
    return x ** y
```

### Problem
To implement stricter type checking, we need to specify the type parameters for the `ndarray` type.
While most of arrays in this package have well defined data types, the shapes of these arrays are not always known.
If we were to run `mypy --strict` on the code snippet above, we would get an error similar to the following:

```
... error: Missing type parameters for generic type "ndarray"
```

### Solution

With support for Python 3.7+, we can use the `numpy.typing` module to address the problem above to provide type hints for generic arrays.


## How Has This Been Tested?

Run `mypy --install-types --non-interactive --strict` on the affected file(s) before and after the PR.

### Before this PR
```bash
$ mypy --install-types --non-interactive --strict cleanlab/multilabel_classification.py 
cleanlab/multilabel_classification.py:33: error: Missing type parameters for generic type "List"
cleanlab/multilabel_classification.py:34: error: Missing type parameters for generic type "ndarray"
cleanlab/multilabel_classification.py:38: error: Missing type parameters for generic type "dict"
cleanlab/multilabel_classification.py:39: error: Missing type parameters for generic type "ndarray"
Found 4 errors in 1 file (checked 1 source file)
```

```bash
$ mypy --install-types --non-interactive --strict cleanlab
...
Found 671 errors in 25 files (checked 32 source files)
```

### After this PR
```bash
$ mypy --install-types --non-interactive --strict cleanlab/multilabel_classification.py 
cleanlab/multilabel_classification.py:40: error: Missing type parameters for generic type "List"
cleanlab/multilabel_classification.py:45: error: Missing type parameters for generic type "dict"
Found 2 errors in 1 file (checked 1 source file)
```

```bash
$ mypy --install-types --non-interactive --strict cleanlab
...
Found 669 errors in 25 files (checked 32 source files)
```