### PR TITLE
Update docs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,8 +15,6 @@ matplotlib==3.5.1
 skorch==0.11.0
 tensorflow-datasets==4.5.2
 tensorflow==2.9.1
-scikeras==0.9.0
-scikit-learn<1.2.0
 speechbrain==0.5.12
 tensorflow-io==0.26.0
 huggingface_hub==0.7


### PR DESCRIPTION
Misc cleanup of doc dependencies after text tutorial revamp in https://github.com/cleanlab/cleanlab/pull/584

note: since we are no longer pinning sklearn version, it does not need to be specified here anymore because it is installed when installing cleanlab