### PR TITLE
Add two methods to filter.find_label_issues

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -181,7 +181,7 @@ def _num_label_issues_multilabel(
         pred_probs=pred_probs,
         confident_joint=confident_joint,
         multi_label=True,
-        filter_by="confident_learning",
+        filter_by="confident_learning",  # specified to match num_label_issues
     )
     return sum(issues_idx)
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -169,12 +169,19 @@ def _num_label_issues_multilabel(
     -------
     num_issues : int
        The estimated number of examples with label issues in the multi-label dataset.
+
+    Note: We set the filter_by method as 'confident_learning' to match the non-multilabel case
+    (analog to the off_diagonal estimation method)
     """
 
     from cleanlab.filter import find_label_issues
 
     issues_idx = find_label_issues(
-        labels=labels, pred_probs=pred_probs, confident_joint=confident_joint, multi_label=True
+        labels=labels,
+        pred_probs=pred_probs,
+        confident_joint=confident_joint,
+        multi_label=True,
+        filter_by="confident_learning",
     )
     return sum(issues_idx)
 

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -127,7 +127,7 @@ def find_label_issues(
       label quality score (see :py:func:`rank.get_label_quality_scores
       <cleanlab.rank.get_label_quality_scores>`).
 
-    filter_by : {'prune_by_class', 'prune_by_noise_rate', 'both', 'confident_learning', 'predicted_neq_given'}, default='prune_by_noise_rate'
+    filter_by : {'prune_by_class', 'prune_by_noise_rate', 'both', 'confident_learning', 'predicted_neq_given', 'low_normalized_margin', 'low_self_confidence'}, default='prune_by_noise_rate'
       Method to determine which examples are flagged as having label issue, so you can filter/prune them from the dataset. Options:
 
       - ``'prune_by_noise_rate'``: filters examples with *high probability* of being mislabeled for every non-diagonal in the confident joint (see `prune_counts_matrix` in `filter.py`). These are the examples where (with high confidence) the given label is unlikely to match the predicted label for the example.

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -316,7 +316,6 @@ def find_label_issues(
         )
         # Find label issues O(nlogn) solution (mapped to boolean mask later in the method)
         cl_error_indices = np.argsort(scores)[:num_errors]
-        # TODO: delete the comment below (or keep anything you want in docs/comments)
         # The following is the O(n) fastest solution (check for one-off errors), but the problem is if lots of the scores are identical you will overcount,
         # you can end up returning more or less and they aren't ranked in the boolean form so there's no way to drop the highest scores randomly
         #     boundary = np.partition(scores, num_errors)[num_errors]  # O(n) solution

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -1018,10 +1018,54 @@ def test_low_filter_by_methods():
     label_issues_nm = filter.find_label_issues(
         dataset["labels"], dataset["pred_probs"], filter_by="low_normalized_margin"
     )
-    assert np.sum(label_issues_nm) == num_issues
+    assert sum(label_issues_nm) == num_issues
 
     # test filter by low_self_confidence, check num issues is same as using count.num_label_issues
     label_issues_sc = filter.find_label_issues(
-        dataset["labels"], dataset["pred_probs"], filter_by="low_self_confidence"
+        dataset["labels"],
+        dataset["pred_probs"],
+        filter_by="low_self_confidence",
+        return_indices_ranked_by="normalized_margin",
     )
-    assert np.sum(label_issues_sc) == num_issues
+    assert len(label_issues_sc) == num_issues
+
+    label_issues_sc_sort = filter.find_label_issues(
+        dataset["labels"],
+        dataset["pred_probs"],
+        filter_by="low_self_confidence",
+        return_indices_ranked_by="confidence_weighted_entropy",
+    )
+    assert set(label_issues_sc) == set(label_issues_sc_sort)
+
+
+def test_low_filter_by_methods_multilabel():
+    dataset = multilabel_data
+    num_issues = count.num_label_issues(dataset["labels"], dataset["pred_probs"], multi_label=True)
+
+    # test filter by low_normalized_margin, check num issues is same as using count.num_label_issues
+    label_issues_nm = filter.find_label_issues(
+        dataset["labels"],
+        dataset["pred_probs"],
+        filter_by="low_normalized_margin",
+        multi_label=True,
+    )
+    assert sum(label_issues_nm) == num_issues
+
+    # test filter by low_self_confidence, check num issues is same as using count.num_label_issues
+    label_issues_sc = filter.find_label_issues(
+        dataset["labels"],
+        dataset["pred_probs"],
+        filter_by="low_self_confidence",
+        multi_label=True,
+        return_indices_ranked_by="confidence_weighted_entropy",
+    )
+    assert len(label_issues_sc) == num_issues
+
+    label_issues_sc_sort = filter.find_label_issues(
+        dataset["labels"],
+        dataset["pred_probs"],
+        filter_by="low_self_confidence",
+        multi_label=True,
+        return_indices_ranked_by="self_confidence",
+    )
+    assert set(label_issues_sc) == set(label_issues_sc_sort)

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -793,6 +793,7 @@ def test_num_label_issues_multilabel(confident_joint):
         labels=dataset["labels"],
         pred_probs=dataset["pred_probs"],
         confident_joint=dataset["cj"] if confident_joint else None,
+        filter_by="confident_learning",
         multi_label=True,
     )
     assert sum(f) == n

--- a/tests/test_filter_count.py
+++ b/tests/test_filter_count.py
@@ -1008,3 +1008,20 @@ def test_estimate_py_and_noise_matrices_missing_classes():
         ]
     )
     _ = estimate_py_and_noise_matrices_from_probabilities(labels, pred_probs3)
+
+
+def test_low_filter_by_methods():
+    dataset = data
+    num_issues = count.num_label_issues(dataset["labels"], dataset["pred_probs"])
+
+    # test filter by low_normalized_margin, check num issues is same as using count.num_label_issues
+    label_issues_nm = filter.find_label_issues(
+        dataset["labels"], dataset["pred_probs"], filter_by="low_normalized_margin"
+    )
+    assert np.sum(label_issues_nm) == num_issues
+
+    # test filter by low_self_confidence, check num issues is same as using count.num_label_issues
+    label_issues_sc = filter.find_label_issues(
+        dataset["labels"], dataset["pred_probs"], filter_by="low_self_confidence"
+    )
+    assert np.sum(label_issues_sc) == num_issues


### PR DESCRIPTION
Base code to add two new (the methods used in the pervasive label errors paper and used in labelerrors.com) to `filter.find_label_issues`.

TODOs are list. Other TODOs:
* update docs to include these new names anywhere that all the find_label_issues `filter_by` methods are listed (e.g. in `CleanLearning.find_label_issues`)
* Add tests
* test this thoroughly

I have not tested this code or even tried it (I haven't even checked if its runnable). I wrote entirely from memory just to get a draft up. Please take from here.