### PR TITLE
Fix for not specifying labels in find_overlapping_issues

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -388,7 +388,12 @@ def estimate_joint(
             multi_label=multi_label,
         )
     else:
-        calibrated_cj = calibrate_confident_joint(confident_joint, labels, multi_label=multi_label)
+        if labels is not None:
+            calibrated_cj = calibrate_confident_joint(
+                confident_joint, labels, multi_label=multi_label
+            )
+        else:
+            calibrated_cj = confident_joint
 
     assert isinstance(calibrated_cj, np.ndarray)
     if multi_label:

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -22,6 +22,7 @@ which classes to remove (see :py:func:`rank_classes_by_label_quality <cleanlab.d
 and which classes to merge (see :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`).
 """
 
+from typing import Optional, cast
 import numpy as np
 import pandas as pd
 from cleanlab.count import estimate_joint
@@ -444,7 +445,7 @@ def health_summary(
     }
 
 
-def _get_num_examples(labels=None, confident_joint=None) -> int:
+def _get_num_examples(labels=None, confident_joint: Optional[np.ndarray] = None) -> int:
     """Helper method that finds the number of examples from the parameters or throws an error
     if neither parameter is provided.
 
@@ -462,13 +463,11 @@ def _get_num_examples(labels=None, confident_joint=None) -> int:
     ValueError
         If `labels` is None."""
 
-    if labels is not None:
-        num_examples = len(labels)
-    elif confident_joint is not None:
-        num_examples = np.sum(confident_joint)
-    else:
+    if labels is None and confident_joint is None:
         raise ValueError(
             "Error: num_examples is None. You must either provide confident_joint, "
             "or provide both num_example and joint as input parameters."
         )
+    _confident_joint = cast(np.ndarray, confident_joint)
+    num_examples = len(labels) if labels is not None else cast(int, np.sum(_confident_joint))
     return num_examples

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -248,7 +248,7 @@ def find_overlapping_classes(
             multi_label=multi_label,
         )
     if num_examples is None:
-        num_examples = _get_num_examples(labels=labels)
+        num_examples = _get_num_examples(labels=labels, confident_joint=confident_joint)
     if asymmetric:
         rcv_list = _2d_matrix_to_row_column_value_list(joint)
         # Remove diagonal elements
@@ -444,7 +444,7 @@ def health_summary(
     }
 
 
-def _get_num_examples(labels=None) -> int:
+def _get_num_examples(labels=None, confident_joint=None) -> int:
     """Helper method that finds the number of examples from the parameters or throws an error
     if neither parameter is provided.
 
@@ -464,9 +464,11 @@ def _get_num_examples(labels=None) -> int:
 
     if labels is not None:
         num_examples = len(labels)
+    elif confident_joint is not None:
+        num_examples = np.sum(confident_joint)
     else:
         raise ValueError(
-            "Error: num_examples is None. You must provide a value for num_examples "
-            "when calling this method using the joint as an input parameter."
+            "Error: num_examples is None. You must either provide confident_joint, "
+            "or provide both num_example and joint as input parameters."
         )
     return num_examples

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # Python dependencies for development
 coverage != 6.3, != 6.3.*
+hypothesis
 mypy
 pandas-stubs
 pre-commit

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -500,7 +500,7 @@ def test_value_error_missing_num_examples_with_joint(use_num_examples, use_label
 confident_joint_strategy = npst.arrays(
     np.int32,
     shape=npst.array_shapes(min_dims=2, max_dims=2, min_side=2, max_side=10),
-    elements=st.integers(min_value=0, max_value=np.iinfo(np.int32).max),
+    elements=st.integers(min_value=0, max_value=int(1e6)),
 ).filter(lambda arr: arr.shape[0] == arr.shape[1])
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -16,8 +16,11 @@
 
 import requests
 import pytest
+import hypothesis.extra.numpy as npst
+import hypothesis.strategies as st
 import io
 import numpy as np
+from hypothesis import given
 from cleanlab.dataset import (
     health_summary,
     find_overlapping_classes,
@@ -492,3 +495,43 @@ def test_value_error_missing_num_examples_with_joint(use_num_examples, use_label
             joint=joint,
             num_examples=len(labels) if use_num_examples else None,
         )
+
+
+confident_joint_strategy = npst.arrays(
+    np.int64,
+    shape=npst.array_shapes(min_dims=2, max_dims=2, min_side=2, max_side=10),
+    elements=st.integers(min_value=0, max_value=int(1e12)),
+).filter(lambda arr: arr.shape[0] == arr.shape[1])
+
+
+@given(confident_joint=confident_joint_strategy)
+def test_find_overlapping_classes_with_confident_joint(confident_joint):
+
+    # Setup
+    K = confident_joint.shape[0]
+    overlapping_classes = find_overlapping_classes(confident_joint=confident_joint)
+
+    # Test that the output dataframe has the expected columns
+    expected_columns = [
+        "Class Index A",
+        "Class Index B",
+        "Num Overlapping Examples",
+        "Joint Probability",
+    ]
+    assert set(overlapping_classes.columns) == set(expected_columns)
+
+    # Class indices must be valid
+    assert overlapping_classes["Class Index A"].between(0, K - 1).all()
+    assert overlapping_classes["Class Index B"].between(0, K - 1).all()
+
+    # Overlapping example count should be non-negative integers
+    assert (overlapping_classes["Num Overlapping Examples"] >= 0).all()
+    assert overlapping_classes["Num Overlapping Examples"].dtype == int
+
+    # Joint probabilities should be between 0 and 1
+    assert (overlapping_classes["Joint Probability"] >= 0).all()
+    assert (overlapping_classes["Joint Probability"] <= 1).all()
+
+    # Joint probabilities sorted in descending order
+    if K > 2:
+        assert (overlapping_classes["Joint Probability"].diff()[1:] <= 0).all()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -507,7 +507,6 @@ confident_joint_strategy = npst.arrays(
 @pytest.mark.issue_651
 @given(confident_joint=confident_joint_strategy)
 def test_find_overlapping_classes_with_confident_joint(confident_joint):
-
     # Setup
     K = confident_joint.shape[0]
     overlapping_classes = find_overlapping_classes(confident_joint=confident_joint)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -498,9 +498,9 @@ def test_value_error_missing_num_examples_with_joint(use_num_examples, use_label
 
 
 confident_joint_strategy = npst.arrays(
-    np.int64,
+    np.int32,
     shape=npst.array_shapes(min_dims=2, max_dims=2, min_side=2, max_side=10),
-    elements=st.integers(min_value=0, max_value=int(1e12)),
+    elements=st.integers(min_value=0, max_value=np.iinfo(np.int32).max),
 ).filter(lambda arr: arr.shape[0] == arr.shape[1])
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -504,6 +504,7 @@ confident_joint_strategy = npst.arrays(
 ).filter(lambda arr: arr.shape[0] == arr.shape[1])
 
 
+@pytest.mark.issue_651
 @given(confident_joint=confident_joint_strategy)
 def test_find_overlapping_classes_with_confident_joint(confident_joint):
 


### PR DESCRIPTION
## Changes in this PR

- _get_num_examples accepts `confident_joint` as a fallback argument.
- `confident_joint` won't be "calibrated" in `count.estimate_joint()` without provided `labels`.
- Property-based tests for `find_overlapping_classes(confident_joint=confident_joint)` added.

## New dependencies

[Hypothesis](https://hypothesis.readthedocs.io/en/latest/) is used for property-based testing. This is added as a dev dependency.

Resolves https://github.com/cleanlab/cleanlab/issues/651