### PR TITLE
Bug fixes + improvements to multiannotator module

### DIFF
--- a/cleanlab/internal/multiannotator_utils.py
+++ b/cleanlab/internal/multiannotator_utils.py
@@ -144,7 +144,7 @@ def assert_valid_pred_probs(
             if pred_probs.ndim != 3:
                 error_message = "pred_probs must be a 3d array."
                 if pred_probs.ndim == 2:  # pragma: no cover
-                    error_message += " If you have a 2d pred_probs array, use the non-ensemble version of this function."
+                    error_message += " If you have a 2d pred_probs array (ie. only one predictor), use the non-ensemble version of this function."
                 raise ValueError(error_message)
 
         if pred_probs_unlabeled is not None:

--- a/cleanlab/internal/multiannotator_utils.py
+++ b/cleanlab/internal/multiannotator_utils.py
@@ -129,17 +129,23 @@ def assert_valid_inputs_multiannotator(
 
 
 def assert_valid_pred_probs(
-    pred_probs: np.ndarray,
+    pred_probs: Optional[np.ndarray] = None,
     pred_probs_unlabeled: Optional[np.ndarray] = None,
     ensemble: bool = False,
 ):
-    """Validate format of pred_probs for multiannotator functions"""
+    """Validate format of pred_probs for multiannotator active learning functions"""
+    if pred_probs is None and pred_probs_unlabeled is None:
+        raise ValueError(
+            "pred_probs and pred_probs_unlabeled cannot both be None, specify at least one of the two."
+        )
+
     if ensemble:
-        if pred_probs.ndim != 3:
-            error_message = "pred_probs must be a 3d array."
-            if pred_probs.ndim == 2:  # pragma: no cover
-                error_message += " If you have a 2d pred_probs array, use the non-ensemble version of this function."
-            raise ValueError(error_message)
+        if pred_probs is not None:
+            if pred_probs.ndim != 3:
+                error_message = "pred_probs must be a 3d array."
+                if pred_probs.ndim == 2:  # pragma: no cover
+                    error_message += " If you have a 2d pred_probs array, use the non-ensemble version of this function."
+                raise ValueError(error_message)
 
         if pred_probs_unlabeled is not None:
             if pred_probs_unlabeled.ndim != 3:
@@ -148,19 +154,19 @@ def assert_valid_pred_probs(
                     error_message += " If you have a 2d pred_probs_unlabeled array, use the non-ensemble version of this function."
                 raise ValueError(error_message)
 
+        if pred_probs is not None and pred_probs_unlabeled is not None:
             if pred_probs.shape[2] != pred_probs_unlabeled.shape[2]:
                 raise ValueError(
                     "pred_probs and pred_probs_unlabeled must have the same number of classes"
                 )
 
     else:
-        if pred_probs.ndim != 2:
-            error_message = "pred_probs must be a 2d array."
-            if pred_probs.ndim == 3:  # pragma: no cover
-                error_message += (
-                    " If you have a 3d pred_probs array, use the ensemble version of this function."
-                )
-            raise ValueError(error_message)
+        if pred_probs is not None:
+            if pred_probs.ndim != 2:
+                error_message = "pred_probs must be a 2d array."
+                if pred_probs.ndim == 3:  # pragma: no cover
+                    error_message += " If you have a 3d pred_probs array, use the ensemble version of this function."
+                raise ValueError(error_message)
 
         if pred_probs_unlabeled is not None:
             if pred_probs_unlabeled.ndim != 2:
@@ -169,6 +175,7 @@ def assert_valid_pred_probs(
                     error_message += " If you have a 3d pred_probs_unlabeled array, use the non-ensemble version of this function."
                 raise ValueError(error_message)
 
+        if pred_probs is not None and pred_probs_unlabeled is not None:
             if pred_probs.shape[1] != pred_probs_unlabeled.shape[1]:
                 raise ValueError(
                     "pred_probs and pred_probs_unlabeled must have the same number of classes"

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -553,8 +553,8 @@ def get_active_learning_scores(
     To use an annotation budget most efficiently, select a batch of examples with the lowest scores and collect one additional label for each example,
     and repeat this process after retraining your classifier.
 
-    You can use this function to get active learning scores for examples that have one or more labels (specify ``labels_multiannotator`` and ``pred_probs``
-    as arguments), or to get active learning scores for unlabeled examples (specify ``pred_probs_unlabeled``), or both (specify all the above arguments).
+    You can use this function to get active learning scores for: examples that already have one or more labels (specify ``labels_multiannotator`` and ``pred_probs``
+    as arguments), or for unlabeled examples (specify ``pred_probs_unlabeled``), or for both types of examples (specify all of the above arguments).
 
     To analyze a fixed dataset labeled by multiple annotators rather than collecting additional labels, try the
     :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>` (CROWDLAB) function instead.
@@ -567,21 +567,21 @@ def get_active_learning_scores(
         datasets where there is only one annotator (M=1).
         For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
         Note that examples that have no annotator labels should not be included in this DataFrame/array.
-        This argument is optional if ``pred_probs`` is not provided (in cases where you only provide ``pred_probs_unlabeled`` to get active learning scores for unlabeled examples).
+        This argument is optional if ``pred_probs`` is not provided (you might only provide ``pred_probs_unlabeled`` to only get active learning scores for the unlabeled examples).
     pred_probs : np.ndarray, optional
         An array of shape ``(N, K)`` of predicted class probabilities from a trained classifier model.
         Predicted probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
-        This argument is optional if you only want to get active learning scores for unlabeled examples (pass in ``pred_probs_unlabeled`` instead).
+        This argument is optional if you only want to get active learning scores for unlabeled examples (specify only ``pred_probs_unlabeled`` instead).
     pred_probs_unlabeled : np.ndarray, optional
         An array of shape ``(N, K)`` of predicted class probabilities from a trained classifier model for examples that have no annotator labels.
         Predicted probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
-        This argument is optional if you only want to get active learning scores for labeled examples (pass in ``pred_probs`` instead).
+        This argument is optional if you only want to get active learning scores for already-labeled examples (specify only ``pred_probs`` instead).
 
     Returns
     -------
     active_learning_scores : np.ndarray
         Array of shape ``(N,)`` indicating the ActiveLab quality scores for each example.
-        Returns an empty array if no labeled data is provided.
+        This array is empty if no already-labeled data was provided via ``labels_multiannotator``.
         Examples with the lowest scores are those we should label next in order to maximally improve our classifier model.
 
     active_learning_scores_unlabeled : np.ndarray
@@ -597,7 +597,7 @@ def get_active_learning_scores(
         if labels_multiannotator is None:
             raise ValueError(
                 "labels_multiannotator cannot be None when passing in pred_probs. ",
-                "You can either provide labels_multiannotator to obtain active learning scores for the labeled examples, "
+                "Either provide labels_multiannotator to obtain active learning scores for the labeled examples, "
                 "or just pass in pred_probs_unlabeled to get active learning scores for unlabeled examples.",
             )
 

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -593,6 +593,7 @@ def get_active_learning_scores(
 
     assert_valid_pred_probs(pred_probs=pred_probs, pred_probs_unlabeled=pred_probs_unlabeled)
 
+    # compute multiannotator stats if labeled data is provided
     if pred_probs is not None:
         if labels_multiannotator is None:
             raise ValueError(
@@ -624,6 +625,7 @@ def get_active_learning_scores(
             annotator_weight = np.full(labels_multiannotator.shape[1], 1)
             avg_annotator_weight = np.mean(annotator_weight)
 
+        # examples are annotated by multiple annotators
         else:
             optimal_temp = find_best_temp_scaler(labels_multiannotator, pred_probs)
             pred_probs = temp_scale_pred_probs(pred_probs, optimal_temp)
@@ -655,6 +657,7 @@ def get_active_learning_scores(
                 ),
             )
 
+    # no labeled data provided so do not estimate temperature and model/annotator weights
     elif pred_probs_unlabeled is not None:
         num_classes = get_num_classes(pred_probs=pred_probs_unlabeled)
         optimal_temp = 1
@@ -731,6 +734,7 @@ def get_active_learning_scores_ensemble(
         pred_probs=pred_probs, pred_probs_unlabeled=pred_probs_unlabeled, ensemble=True
     )
 
+    # compute multiannotator stats if labeled data is provided
     if pred_probs is not None:
         if labels_multiannotator is None:
             raise ValueError(
@@ -764,6 +768,7 @@ def get_active_learning_scores_ensemble(
             annotator_weight = np.full(labels_multiannotator.shape[1], 1)
             avg_annotator_weight = np.mean(annotator_weight)
 
+        # examples are annotated by multiple annotators
         else:
             optimal_temp = np.full(len(pred_probs), np.NaN)
             for i in range(len(pred_probs)):
@@ -799,6 +804,7 @@ def get_active_learning_scores_ensemble(
                 ),
             )
 
+    # no labeled data provided so do not estimate temperature and model/annotator weights
     elif pred_probs_unlabeled is not None:
         num_classes = get_num_classes(pred_probs=pred_probs_unlabeled[0])
         optimal_temp = np.full(len(pred_probs_unlabeled), 1.0)

--- a/tests/test_multiannotator.py
+++ b/tests/test_multiannotator.py
@@ -654,8 +654,20 @@ def test_get_consensus_label():
             [0.2, 0.4, 0.4],
         ]
     )
-
     consensus_label = get_majority_vote_label(labels_tiebreaks, pred_probs_tiebreaks)
+
+    # more tiebreak testing (without pred_probs + non-overlapping annotators)
+    labels_tiebreaks = np.array(
+        [
+            [1, np.NaN, np.NaN, 2, np.NaN],
+            [np.NaN, 1, 0, np.NaN, np.NaN],
+            [np.NaN, np.NaN, 0, np.NaN, np.NaN],
+            [np.NaN, 2, np.NaN, np.NaN, np.NaN],
+            [2, np.NaN, 0, np.NaN, np.NaN],
+            [np.NaN, np.NaN, np.NaN, 0, 1],
+        ]
+    )
+    consensus_label = get_majority_vote_label(labels_tiebreaks)
 
 
 def test_impute_nonoverlaping_annotators():

--- a/tests/test_multiannotator.py
+++ b/tests/test_multiannotator.py
@@ -663,11 +663,12 @@ def test_get_consensus_label():
             [np.NaN, 1, 0, np.NaN, np.NaN],
             [np.NaN, np.NaN, 0, np.NaN, np.NaN],
             [np.NaN, 2, np.NaN, np.NaN, np.NaN],
-            [2, np.NaN, 0, np.NaN, np.NaN],
-            [np.NaN, np.NaN, np.NaN, 0, 1],
+            [2, np.NaN, 0, 2, np.NaN],
+            [np.NaN, np.NaN, np.NaN, 2, 1],
         ]
     )
     consensus_label = get_majority_vote_label(labels_tiebreaks)
+    assert all(consensus_label == np.array([1, 1, 0, 2, 2, 1]))
 
 
 def test_impute_nonoverlaping_annotators():

--- a/tests/test_multiannotator.py
+++ b/tests/test_multiannotator.py
@@ -434,6 +434,13 @@ def test_get_active_learning_scores():
     assert len(active_learning_scores) == len(pred_probs)
     assert len(active_learning_scores_unlabeled) == 0
 
+    # test case where only passing unlabeled examples
+    active_learning_scores, active_learning_scores_unlabeled = get_active_learning_scores(
+        pred_probs_unlabeled=pred_probs_unlabeled
+    )
+    assert len(active_learning_scores) == 0
+    assert len(active_learning_scores_unlabeled) == len(pred_probs_unlabeled)
+
     # test case where number of classes do not match
     try:
         active_learning_scores, active_learning_scores_unlabeled = get_active_learning_scores(
@@ -484,6 +491,13 @@ def test_get_active_learning_scores_ensemble():
     assert isinstance(active_learning_scores, np.ndarray)
     assert len(active_learning_scores) == len(labels)
     assert len(active_learning_scores_unlabeled) == 0
+
+    # test case where only passing unlabeled examples
+    active_learning_scores, active_learning_scores_unlabeled = get_active_learning_scores_ensemble(
+        pred_probs_unlabeled=pred_probs_unlabeled
+    )
+    assert len(active_learning_scores) == 0
+    assert len(active_learning_scores_unlabeled) == len(labels_unlabeled)
 
     # test case where number of classes do not match
     try:


### PR DESCRIPTION
- Fixed a bug in `get_majority_vote_label` caused by the lack of handling for non-overlapping annotators (thanks @cmauck10 for reporting!)
- Allow for users to pass in `pred_probs=None` for active learning functions when they only want scores for unlabeled data (thanks @ulya-tkch for bringing this use case up!)
- Break ties in `get_majority_vote_label` with minority class instead of majority class to prevent worsening class imbalance)