### PR TITLE
Pass confident joint computed in CleanLearning to filter.find_label_issues

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -839,11 +839,6 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                 pred_probs=pred_probs,
                 thresholds=thresholds,
             )
-        # Add confident joint to find label issue args if it is not previously specified
-        if "confident_joint" not in self.find_label_issues_kwargs.keys():
-            # however does not add if users specify filter_by="confident_learning", as it will throw a warning
-            if not self.find_label_issues_kwargs.get("filter_by") == "confident_learning":
-                self.find_label_issues_kwargs["confident_joint"] = self.confident_joint
 
         # if pulearning == the integer specifying the class without noise.
         if self.num_classes == 2 and self.pulearning is not None:  # pragma: no cover
@@ -856,6 +851,12 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             # pulearning = 1 (no error in 1 class) implies p(label=1,true_label=0) = 0
             self.confident_joint[self.pulearning][1 - self.pulearning] = 0
             self.confident_joint[1 - self.pulearning][1 - self.pulearning] = 1
+
+        # Add confident joint to find label issue args if it is not previously specified
+        if "confident_joint" not in self.find_label_issues_kwargs.keys():
+            # however does not add if users specify filter_by="confident_learning", as it will throw a warning
+            if not self.find_label_issues_kwargs.get("filter_by") == "confident_learning":
+                self.find_label_issues_kwargs["confident_joint"] = self.confident_joint
 
         labels = labels_to_array(labels)
         if self.verbose:

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -841,7 +841,9 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             )
         # Add confident joint to find label issue args if it is not previously specified
         if "confident_joint" not in self.find_label_issues_kwargs.keys():
-            self.find_label_issues_kwargs["confident_joint"] = self.confident_joint
+            # however does not add if users specify filter_by="confident_learning", as it will throw a warning
+            if not self.find_label_issues_kwargs.get("filter_by") == "confident_learning":
+                self.find_label_issues_kwargs["confident_joint"] = self.confident_joint
 
         # if pulearning == the integer specifying the class without noise.
         if self.num_classes == 2 and self.pulearning is not None:  # pragma: no cover

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -839,6 +839,10 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                 pred_probs=pred_probs,
                 thresholds=thresholds,
             )
+        # Add confident joint to find label issue args if it is not previously specified
+        if "confident_joint" not in self.find_label_issues_kwargs.keys():
+            self.find_label_issues_kwargs["confident_joint"] = self.confident_joint
+
         # if pulearning == the integer specifying the class without noise.
         if self.num_classes == 2 and self.pulearning is not None:  # pragma: no cover
             # pulearning = 1 (no error in 1 class) implies p(label=1|true_label=0) = 0

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -27,7 +27,11 @@ from cleanlab.classification import CleanLearning
 from cleanlab.benchmarking.noise_generation import generate_noise_matrix_from_trace
 from cleanlab.benchmarking.noise_generation import generate_noisy_labels
 from cleanlab.internal.latent_algebra import compute_inv_noise_matrix
-from cleanlab.count import compute_confident_joint, estimate_cv_predicted_probabilities
+from cleanlab.count import (
+    compute_confident_joint,
+    estimate_cv_predicted_probabilities,
+    get_confident_thresholds,
+)
 from cleanlab.filter import find_label_issues
 
 SEED = 1
@@ -774,6 +778,65 @@ def test_cj_in_find_label_issues_kwargs(filter_by, seed):
     # Chceck that the same exact number of issues are found regardless if the confident joint
     # is computed during find_label_issues or precomputed and provided as a kwargs parameter.
     assert num_issues[0] == num_issues[1]
+
+
+def test_find_label_issues_uses_thresholds():
+    X = DATA["X_train"]
+    labels = DATA["labels"]
+    pred_probs = estimate_cv_predicted_probabilities(X=X, labels=labels)
+
+    confident_thresholds = get_confident_thresholds(labels=labels, pred_probs=pred_probs)
+    confident_joint = compute_confident_joint(labels=labels, pred_probs=pred_probs)
+
+    # regular find label issues with no args
+    cl = CleanLearning()
+    label_issues_reg = cl.find_label_issues(labels=labels, pred_probs=pred_probs)
+
+    # find label issues with specified confident thresholds
+    cl = CleanLearning()
+    label_issues_thres = cl.find_label_issues(
+        labels=labels, pred_probs=pred_probs, thresholds=confident_thresholds
+    )
+
+    # find label issues with specified confident joint
+    cl = CleanLearning(
+        find_label_issues_kwargs={
+            "confident_joint": confident_joint,
+        }
+    )
+    label_issues_cj = cl.find_label_issues(labels=labels, pred_probs=pred_probs)
+
+    # the labels issues in above three calls should be the same
+    assert np.sum(label_issues_reg["is_label_issue"]) == np.sum(
+        label_issues_thres["is_label_issue"]
+    )
+    assert np.sum(label_issues_reg["is_label_issue"]) == np.sum(label_issues_cj["is_label_issue"])
+
+    # find label issues with different specified confident thresholds
+    confident_thresholds_alt = np.full(pred_probs.shape[1], 0.25)
+    cl = CleanLearning()
+    label_issues_thres_alt = cl.find_label_issues(
+        labels=labels, pred_probs=pred_probs, thresholds=confident_thresholds_alt
+    )
+
+    # find label issues with different specified confident joint
+    confident_joint_alt = compute_confident_joint(
+        labels=labels, pred_probs=pred_probs, thresholds=confident_thresholds_alt
+    )
+    cl = CleanLearning(
+        find_label_issues_kwargs={
+            "confident_joint": confident_joint_alt,
+        }
+    )
+    label_issues_cj_alt = cl.find_label_issues(labels=labels, pred_probs=pred_probs)
+
+    # the number of issues for these 2 alt calls should be same as one another, but different from above 3
+    assert np.sum(label_issues_thres_alt["is_label_issue"]) == np.sum(
+        label_issues_cj_alt["is_label_issue"]
+    )
+    assert np.sum(label_issues_thres_alt["is_label_issue"]) != np.sum(
+        label_issues_reg["is_label_issue"]
+    )
 
 
 def test_find_issues_missing_classes():


### PR DESCRIPTION
Prior to this `filter.find_label_issues` will recompute the confident joint that has already been computed once in `CleanLearning`