### PR TITLE
Add Example codeblock to the docstrings of important functions in the dataset module

### DIFF
--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -142,16 +142,21 @@ def find_overlapping_classes(
     Examples
     --------
     >>> from cleanlab.dataset import find_overlapping_classes
-    >>> from cleanlab.classification import CleanLearning
     >>> from sklearn.linear_model import LogisticRegression
+    >>> from sklearn.model_selection import cross_val_predict
     >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
     >>> yourFavoriteModel = LogisticRegression()
-    >>> cl = CleanLearning(yourFavoriteModel)
-    >>> _ = cl.fit(data, labels) # fit model to cleaned data
+    >>> num_crossval_folds = 3
+    >>> pred_probs = cross_val_predict(
+            yourFavoriteModel,
+            data,
+            labels,
+            cv=num_crossval_folds,
+            method="predict_proba",
+        )
     >>> df = find_overlapping_classes(
             labels=labels,
-            confident_joint=cl.confident_joint,
-            class_names=class_names,
+            pred_probs=pred_probs,
         )
     >>> df # output pairs of classes that are often mislabeled
 

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -39,7 +39,7 @@ def rank_classes_by_label_quality(
     multi_label=False,
 ) -> pd.DataFrame:
     """
-    Returns a Pandas DataFrame with all classes and three overall class label quality scores
+    Returns a Pony Pandas DataFrame with all classes and three overall class label quality scores
     (details about each score are listed in the Returns parameter). By default, classes are ordered
     by "Label Quality Score", ascending, so the most problematic classes are reported first.
 

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -139,11 +139,21 @@ def find_overlapping_classes(
     issues via the approach published in `Northcutt et al.,
     2021 <https://jair.org/index.php/jair/article/view/12125>`_.
 
-    Example using ``labels`` and ``pred_probs``
+    Example using ``confident_joint``
     ----
-    >>> yourFavoriteModel = LogisticRegression(verbose=0, random_state=SEED)
-    >>> issues = CleanLearning(yourFavoriteModel, seed=SEED).find_label_issues(data, labels)
-    >>> issues.head()
+    >>> from cleanlab.dataset import find_overlapping_classes
+    >>> from cleanlab.classification import CleanLearning
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
+    >>> yourFavoriteModel = LogisticRegression()
+    >>> cl = CleanLearning(yourFavoriteModel)
+    >>> _ = cl.fit(data, labels) # fit model to cleaned data
+    >>> df = find_overlapping_classes(
+            labels=labels,
+            confident_joint=cl.confident_joint,
+            class_names=class_names,
+        )
+    >>> df # output pairs of classes that are often mislabeled
 
     Note
     ----

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -139,8 +139,8 @@ def find_overlapping_classes(
     issues via the approach published in `Northcutt et al.,
     2021 <https://jair.org/index.php/jair/article/view/12125>`_.
 
-    Example using ``confident_joint``
-    ----
+    Examples
+    --------
     >>> from cleanlab.dataset import find_overlapping_classes
     >>> from cleanlab.classification import CleanLearning
     >>> from sklearn.linear_model import LogisticRegression

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -157,8 +157,7 @@ def find_overlapping_classes(
     >>> df = find_overlapping_classes(
             labels=labels,
             pred_probs=pred_probs,
-        )
-    >>> df # output pairs of classes that are often mislabeled
+        )  # lists pairs of classes that are often mislabeled as one another
 
     Note
     ----

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -39,7 +39,7 @@ def rank_classes_by_label_quality(
     multi_label=False,
 ) -> pd.DataFrame:
     """
-    Returns a Pony Pandas DataFrame with all classes and three overall class label quality scores
+    Returns a Pandas DataFrame with all classes and three overall class label quality scores
     (details about each score are listed in the Returns parameter). By default, classes are ordered
     by "Label Quality Score", ascending, so the most problematic classes are reported first.
 
@@ -138,6 +138,12 @@ def find_overlapping_classes(
     This method uses the joint distribution of noisy and true labels to compute ontological
     issues via the approach published in `Northcutt et al.,
     2021 <https://jair.org/index.php/jair/article/view/12125>`_.
+
+    Example using ``labels`` and ``pred_probs``
+    ----
+    >>> yourFavoriteModel = LogisticRegression(verbose=0, random_state=SEED)
+    >>> issues = CleanLearning(yourFavoriteModel, seed=SEED).find_label_issues(data, labels)
+    >>> issues.head()
 
     Note
     ----


### PR DESCRIPTION
Added a code example to the docstring for the `find_overlapping_classes` method in the cleanlab.dataset module.

The code block is not currently runnable because of the arbitrary `get_data_labels_from_dataset(yourFavoriteDataset)`. I can define the `get_data_labels_from_dataset` using a simple dataset, but I am not sure where to put this function since other docstring examples will also benefit from having this function.

Before addition:
<img width="300" alt="before" src="https://user-images.githubusercontent.com/60683228/230243021-37bd8038-78ac-4205-81a7-5faa694604de.png">
After addition:
<img width="300" alt="after" src="https://user-images.githubusercontent.com/60683228/230243040-5fe97525-e298-4792-8e15-9ecb703818e1.png">
