### PR TITLE
Added code block examples for methods in the cleanlab.dataset module

### DIFF
--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -427,10 +427,10 @@ def health_summary(
             cv=num_crossval_folds,
             method="predict_proba",
         )
-    >>> df = overall_label_health_score(
+    >>> dict = health_summary(
             labels=labels,
             pred_probs=pred_probs,
-        )  # prints a health summary of your datasets
+        )  # a dictionary containing health summary of your datasets
 
     **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
 

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -72,7 +72,7 @@ def rank_classes_by_label_quality(
     >>> df = rank_classes_by_label_quality(
             labels=labels,
             pred_probs=pred_probs,
-        ) # list all classes and three associated class label quality scores
+        )  # report overall label quality scores summarizing the examples annotated as each class
 
     **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
 

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -142,16 +142,21 @@ def find_overlapping_classes(
     Examples
     --------
     >>> from cleanlab.dataset import find_overlapping_classes
-    >>> from cleanlab.classification import CleanLearning
     >>> from sklearn.linear_model import LogisticRegression
+    >>> from sklearn.model_selection import cross_val_predict
     >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
     >>> yourFavoriteModel = LogisticRegression()
-    >>> cl = CleanLearning(yourFavoriteModel)
-    >>> _ = cl.fit(data, labels) # fit model to cleaned data
+    >>> num_crossval_folds = 3
+    >>> pred_probs = cross_val_predict(
+            yourFavoriteModel,
+            data,
+            labels,
+            cv=num_crossval_folds,
+            method="predict_proba",
+        )
     >>> df = find_overlapping_classes(
             labels=labels,
-            confident_joint=cl.confident_joint,
-            class_names=class_names,
+            pred_probs=pred_probs,
         )
     >>> df # output pairs of classes that are often mislabeled
 

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -39,7 +39,7 @@ def rank_classes_by_label_quality(
     multi_label=False,
 ) -> pd.DataFrame:
     """
-    Returns a Pandas DataFrame with all classes and three overall class label quality scores
+    Returns a Pony Pandas DataFrame with all classes and three overall class label quality scores
     (details about each score are listed in the Returns parameter). By default, classes are ordered
     by "Label Quality Score", ascending, so the most problematic classes are reported first.
 

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -139,11 +139,21 @@ def find_overlapping_classes(
     issues via the approach published in `Northcutt et al.,
     2021 <https://jair.org/index.php/jair/article/view/12125>`_.
 
-    Example using ``labels`` and ``pred_probs``
+    Example using ``confident_joint``
     ----
-    >>> yourFavoriteModel = LogisticRegression(verbose=0, random_state=SEED)
-    >>> issues = CleanLearning(yourFavoriteModel, seed=SEED).find_label_issues(data, labels)
-    >>> issues.head()
+    >>> from cleanlab.dataset import find_overlapping_classes
+    >>> from cleanlab.classification import CleanLearning
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
+    >>> yourFavoriteModel = LogisticRegression()
+    >>> cl = CleanLearning(yourFavoriteModel)
+    >>> _ = cl.fit(data, labels) # fit model to cleaned data
+    >>> df = find_overlapping_classes(
+            labels=labels,
+            confident_joint=cl.confident_joint,
+            class_names=class_names,
+        )
+    >>> df # output pairs of classes that are often mislabeled
 
     Note
     ----

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -427,10 +427,10 @@ def health_summary(
             cv=num_crossval_folds,
             method="predict_proba",
         ) # generate cross-validation estimates for each input data point
-    >>> dic = health_summary(
-            labels=labels,
-            pred_probs=pred_probs,
-        ) # a dictionary containing health summary of your datasets
+    >>> summary = health_summary(
+                labels=labels,
+                pred_probs=pred_probs,
+        )  # dictionary summarizing the overall label quality of the classes in your dataset
 
     **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
 

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -72,7 +72,7 @@ def rank_classes_by_label_quality(
     >>> df = rank_classes_by_label_quality(
             labels=labels,
             pred_probs=pred_probs,
-        )  # list all classes and three associated class label quality scores
+        ) # list all classes and three associated class label quality scores
 
     **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
 
@@ -173,11 +173,11 @@ def find_overlapping_classes(
             labels,
             cv=num_crossval_folds,
             method="predict_proba",
-        )
+        ) # generate cross-validation estimates for each input data point
     >>> df = find_overlapping_classes(
             labels=labels,
             pred_probs=pred_probs,
-        )  # lists pairs of classes that are often mislabeled as one another
+        ) # lists pairs of classes that are often mislabeled as one another
 
     Note
     ----
@@ -351,11 +351,11 @@ def overall_label_health_score(
             labels,
             cv=num_crossval_folds,
             method="predict_proba",
-        )
+        ) # generate cross-validation estimates for each input data point
     >>> score = overall_label_health_score(
             labels=labels,
             pred_probs=pred_probs,
-        )  # a score measuring the overall quality of all labels in a dataset.
+        ) # a score measuring the overall quality of all labels in a dataset.
 
     **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
 
@@ -426,11 +426,11 @@ def health_summary(
             labels,
             cv=num_crossval_folds,
             method="predict_proba",
-        )
-    >>> dict = health_summary(
+        ) # generate cross-validation estimates for each input data point
+    >>> dic = health_summary(
             labels=labels,
             pred_probs=pred_probs,
-        )  # a dictionary containing health summary of your datasets
+        ) # a dictionary containing health summary of your datasets
 
     **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
 

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -54,6 +54,26 @@ def rank_classes_by_label_quality(
 
     Only provide **exactly one of the above input options**, do not provide a combination.
 
+    Examples
+    --------
+    >>> from cleanlab.dataset import rank_classes_by_label_quality
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> from sklearn.model_selection import cross_val_predict
+    >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
+    >>> yourFavoriteModel = LogisticRegression()
+    >>> num_crossval_folds = 3
+    >>> pred_probs = cross_val_predict(
+            yourFavoriteModel,
+            data,
+            labels,
+            cv=num_crossval_folds,
+            method="predict_proba",
+        ) # generate cross-validation estimates for each input data point
+    >>> df = rank_classes_by_label_quality(
+            labels=labels,
+            pred_probs=pred_probs,
+        )  # list all classes and three associated class label quality scores
+
     **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
 
     Returns
@@ -317,6 +337,26 @@ def overall_label_health_score(
 
     Only provide **exactly one of the above input options**, do not provide a combination.
 
+    Examples
+    --------
+    >>> from cleanlab.dataset import overall_label_health_score
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> from sklearn.model_selection import cross_val_predict
+    >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
+    >>> yourFavoriteModel = LogisticRegression()
+    >>> num_crossval_folds = 3
+    >>> pred_probs = cross_val_predict(
+            yourFavoriteModel,
+            data,
+            labels,
+            cv=num_crossval_folds,
+            method="predict_proba",
+        )
+    >>> score = overall_label_health_score(
+            labels=labels,
+            pred_probs=pred_probs,
+        )  # a score measuring the overall quality of all labels in a dataset.
+
     **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
 
     Returns
@@ -371,6 +411,26 @@ def health_summary(
     3. ``confident_joint``
 
     Only provide **exactly one of the above input options**, do not provide a combination.
+
+    Examples
+    --------
+    >>> from cleanlab.dataset import health_summary
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> from sklearn.model_selection import cross_val_predict
+    >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
+    >>> yourFavoriteModel = LogisticRegression()
+    >>> num_crossval_folds = 3
+    >>> pred_probs = cross_val_predict(
+            yourFavoriteModel,
+            data,
+            labels,
+            cv=num_crossval_folds,
+            method="predict_proba",
+        )
+    >>> df = overall_label_health_score(
+            labels=labels,
+            pred_probs=pred_probs,
+        )  # prints a health summary of your datasets
 
     **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
 

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -173,7 +173,7 @@ def find_overlapping_classes(
             labels,
             cv=num_crossval_folds,
             method="predict_proba",
-        ) # generate cross-validation estimates for each input data point
+        )  # generate cross-validation estimates for each input data point
     >>> df = find_overlapping_classes(
             labels=labels,
             pred_probs=pred_probs,

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -139,8 +139,8 @@ def find_overlapping_classes(
     issues via the approach published in `Northcutt et al.,
     2021 <https://jair.org/index.php/jair/article/view/12125>`_.
 
-    Example using ``confident_joint``
-    ----
+    Examples
+    --------
     >>> from cleanlab.dataset import find_overlapping_classes
     >>> from cleanlab.classification import CleanLearning
     >>> from sklearn.linear_model import LogisticRegression

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -157,8 +157,7 @@ def find_overlapping_classes(
     >>> df = find_overlapping_classes(
             labels=labels,
             pred_probs=pred_probs,
-        )
-    >>> df # output pairs of classes that are often mislabeled
+        )  # lists pairs of classes that are often mislabeled as one another
 
     Note
     ----

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -61,14 +61,13 @@ def rank_classes_by_label_quality(
     >>> from sklearn.model_selection import cross_val_predict
     >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
     >>> yourFavoriteModel = LogisticRegression()
-    >>> num_crossval_folds = 3
     >>> pred_probs = cross_val_predict(
             yourFavoriteModel,
             data,
             labels,
-            cv=num_crossval_folds,
+            cv=3,
             method="predict_proba",
-        ) # generate cross-validation estimates for each input data point
+        )  # generate cross-validation estimates for each input data point
     >>> df = rank_classes_by_label_quality(
             labels=labels,
             pred_probs=pred_probs,
@@ -166,18 +165,17 @@ def find_overlapping_classes(
     >>> from sklearn.model_selection import cross_val_predict
     >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
     >>> yourFavoriteModel = LogisticRegression()
-    >>> num_crossval_folds = 3
     >>> pred_probs = cross_val_predict(
             yourFavoriteModel,
             data,
             labels,
-            cv=num_crossval_folds,
+            cv=3,
             method="predict_proba",
         )  # generate cross-validation estimates for each input data point
     >>> df = find_overlapping_classes(
             labels=labels,
             pred_probs=pred_probs,
-        ) # lists pairs of classes that are often mislabeled as one another
+        )  # lists pairs of classes that are often mislabeled as one another
 
     Note
     ----
@@ -344,18 +342,17 @@ def overall_label_health_score(
     >>> from sklearn.model_selection import cross_val_predict
     >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
     >>> yourFavoriteModel = LogisticRegression()
-    >>> num_crossval_folds = 3
     >>> pred_probs = cross_val_predict(
             yourFavoriteModel,
             data,
             labels,
-            cv=num_crossval_folds,
+            cv=3,
             method="predict_proba",
-        ) # generate cross-validation estimates for each input data point
+        )  # generate cross-validation estimates for each input data point
     >>> score = overall_label_health_score(
             labels=labels,
             pred_probs=pred_probs,
-        ) # a score measuring the overall quality of all labels in a dataset.
+        )  # a score measuring the overall quality of all labels in a dataset.
 
     **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
 
@@ -419,14 +416,13 @@ def health_summary(
     >>> from sklearn.model_selection import cross_val_predict
     >>> data, labels = get_data_labels_from_dataset(yourFavoriteDataset)
     >>> yourFavoriteModel = LogisticRegression()
-    >>> num_crossval_folds = 3
     >>> pred_probs = cross_val_predict(
             yourFavoriteModel,
             data,
             labels,
-            cv=num_crossval_folds,
+            cv=3,
             method="predict_proba",
-        ) # generate cross-validation estimates for each input data point
+        )  # generate cross-validation estimates for each input data point
     >>> summary = health_summary(
                 labels=labels,
                 pred_probs=pred_probs,

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -39,7 +39,7 @@ def rank_classes_by_label_quality(
     multi_label=False,
 ) -> pd.DataFrame:
     """
-    Returns a Pony Pandas DataFrame with all classes and three overall class label quality scores
+    Returns a Pandas DataFrame with all classes and three overall class label quality scores
     (details about each score are listed in the Returns parameter). By default, classes are ordered
     by "Label Quality Score", ascending, so the most problematic classes are reported first.
 
@@ -138,6 +138,12 @@ def find_overlapping_classes(
     This method uses the joint distribution of noisy and true labels to compute ontological
     issues via the approach published in `Northcutt et al.,
     2021 <https://jair.org/index.php/jair/article/view/12125>`_.
+
+    Example using ``labels`` and ``pred_probs``
+    ----
+    >>> yourFavoriteModel = LogisticRegression(verbose=0, random_state=SEED)
+    >>> issues = CleanLearning(yourFavoriteModel, seed=SEED).find_label_issues(data, labels)
+    >>> issues.head()
 
     Note
     ----


### PR DESCRIPTION
Added code block examples for three methods: `health_summary`, `overall_label_health_score`, and `rank_classes_by_label_quality`.

The docstring screenshots are shown below:
<img width="300" alt="Screen Shot 2023-04-06 at 10 52 23" src="https://user-images.githubusercontent.com/60683228/230417239-ab55501c-6575-4808-9023-4bb82a32b6da.png">
<img width="300" alt="Screen Shot 2023-04-06 at 10 52 37" src="https://user-images.githubusercontent.com/60683228/230417245-10da6730-7c10-4123-a2ab-ed1d8c956454.png">
<img width="300" alt="Screen Shot 2023-04-06 at 10 52 47" src="https://user-images.githubusercontent.com/60683228/230417248-d8f06e56-6783-42b9-a923-0dd860c33559.png">
