### PR TITLE
Extract function for computating ood scores from distances

### DIFF
--- a/cleanlab/internal/outlier.py
+++ b/cleanlab/internal/outlier.py
@@ -40,7 +40,8 @@ def transform_distances_to_scores(distances: np.ndarray, k: int, t: int) -> np.n
 
     k : int
         Number of neighbors used to compute the average distance to each example.
-        This assumes that the second dimension of distances is k or greater, to avoid index errors.
+        This assumes that the second dimension of distances is k or greater, but it
+        uses slicing to avoid indexing errors.
 
     t : int
         Controls transformation of distances between examples into similarity scores that lie in [0,1].

--- a/cleanlab/internal/outlier.py
+++ b/cleanlab/internal/outlier.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2017-2023  Cleanlab Inc.
+# This file is part of cleanlab.
+#
+# cleanlab is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cleanlab is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Helper functions used internally for outlier detection tasks.
+"""
+
+import numpy as np
+
+
+def transform_distances_to_scores(distances: np.ndarray, k: int, t: int) -> np.ndarray:
+    """Returns an outlier score for each example based on its average distance to its k nearest neighbors.
+
+    The transformation of a distance, :math:`d` , to a score, :math:`o` , is based on the following formula:
+
+    .. math::
+        o = \\exp\\left(-dt\\right)
+
+    where :math:`t` scales the distance to a score in the range [0,1].
+
+    Parameters
+    ----------
+    distances : np.ndarray
+        An array of distances of shape ``(N, num_neighbors)``, where N is the number of examples.
+        Each row contains the distances to each example's `num_neighbors` nearest neighbors.
+        It is assumed that each row is sorted in ascending order.
+
+    k : int
+        Number of neighbors used to compute the average distance to each example.
+        This assumes that the second dimension of distances is k or greater, to avoid index errors.
+
+    t : int
+        Controls transformation of distances between examples into similarity scores that lie in [0,1].
+
+    Returns
+    -------
+    ood_features_scores : np.ndarray
+        An array of outlier scores of shape ``(N,)`` for N examples.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from cleanlab.outlier import transform_distances_to_scores
+    >>> distances = np.array([[0.0, 0.1, 0.25],
+    ...                       [0.15, 0.2, 0.3]])
+    >>> transform_distances_to_scores(distances, k=2, t=1)
+    array([0.95122942, 0.83945702])
+    """
+    # Calculate average distance to k-nearest neighbors
+    avg_knn_distances = distances[:, :k].mean(axis=1)
+
+    # Map ood_features_scores to range 0-1 with 0 = most concerning
+    ood_features_scores: np.ndarray = np.exp(-1 * avg_knn_distances * t)
+    return ood_features_scores

--- a/cleanlab/outlier.py
+++ b/cleanlab/outlier.py
@@ -450,52 +450,6 @@ def _get_ood_features_scores(
     return (ood_features_scores, knn)
 
 
-def transform_distances_to_scores(distances: np.ndarray, k: int, t: int) -> np.ndarray:
-    """Returns an outlier score for each example based on its average distance to its k nearest neighbors.
-
-    The transformation of a distance, :math:`d` , to a score, :math:`o` , is based on the following formula:
-
-    .. math::
-        o = \\exp\\left(-dt\\right)
-
-    where :math:`t` scales the distance to a score in the range [0,1].
-
-    Parameters
-    ----------
-    distances : np.ndarray
-        An array of distances of shape ``(N, num_neighbors)``, where N is the number of examples.
-        Each row contains the distances to each example's `num_neighbors` nearest neighbors.
-        It is assumed that each row is sorted in ascending order.
-
-    k : int
-        Number of neighbors used to compute the average distance to each example.
-        This assumes that the second dimension of distances is k or greater, to avoid index errors.
-
-    t : int
-        Controls transformation of distances between examples into similarity scores that lie in [0,1].
-
-    Returns
-    -------
-    ood_features_scores : np.ndarray
-        An array of outlier scores of shape ``(N,)`` for N examples.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from cleanlab.outlier import transform_distances_to_scores
-    >>> distances = np.array([[0.0, 0.1, 0.25],
-    ...                       [0.15, 0.2, 0.3]])
-    >>> transform_distances_to_scores(distances, k=2, t=1)
-    array([0.95122942, 0.83945702])
-    """
-    # Calculate average distance to k-nearest neighbors
-    avg_knn_distances = distances[:, :k].mean(axis=1)
-
-    # Map ood_features_scores to range 0-1 with 0 = most concerning
-    ood_features_scores: np.ndarray = np.exp(-1 * avg_knn_distances * t)
-    return ood_features_scores
-
-
 def _get_ood_predictions_scores(
     pred_probs: np.ndarray,
     *,

--- a/cleanlab/outlier.py
+++ b/cleanlab/outlier.py
@@ -30,6 +30,7 @@ from cleanlab.internal.label_quality_utils import (
     _subtract_confident_thresholds,
     get_normalized_entropy,
 )
+from cleanlab.internal.outlier import transform_distances_to_scores
 from cleanlab.internal.validation import assert_valid_inputs, labels_to_array
 from cleanlab.typing import LabelLike
 

--- a/cleanlab/outlier.py
+++ b/cleanlab/outlier.py
@@ -446,12 +446,54 @@ def _get_ood_features_scores(
     # neighbor of each point is the point itself, at a distance of zero.
     distances, _ = knn.kneighbors(features)
 
+    ood_features_scores = transform_distances_to_scores(distances, k, t)
+    return (ood_features_scores, knn)
+
+
+def transform_distances_to_scores(distances: np.ndarray, k: int, t: int) -> np.ndarray:
+    """Returns an outlier score for each example based on its average distance to its k nearest neighbors.
+
+    The transformation of a distance, :math:`d` , to a score, :math:`o` , is based on the following formula:
+
+    .. math::
+        o = \\exp\\left(-dt\\right)
+
+    where :math:`t` scales the distance to a score in the range [0,1].
+
+    Parameters
+    ----------
+    distances : np.ndarray
+        An array of distances of shape ``(N, num_neighbors)``, where N is the number of examples.
+        Each row contains the distances to each example's `num_neighbors` nearest neighbors.
+        It is assumed that each row is sorted in ascending order.
+
+    k : int
+        Number of neighbors used to compute the average distance to each example.
+        This assumes that the second dimension of distances is k or greater, to avoid index errors.
+
+    t : int
+        Controls transformation of distances between examples into similarity scores that lie in [0,1].
+
+    Returns
+    -------
+    ood_features_scores : np.ndarray
+        An array of outlier scores of shape ``(N,)`` for N examples.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from cleanlab.outlier import transform_distances_to_scores
+    >>> distances = np.array([[0.0, 0.1, 0.25],
+    ...                       [0.15, 0.2, 0.3]])
+    >>> transform_distances_to_scores(distances, k=2, t=1)
+    array([0.95122942, 0.83945702])
+    """
     # Calculate average distance to k-nearest neighbors
     avg_knn_distances = distances[:, :k].mean(axis=1)
 
     # Map ood_features_scores to range 0-1 with 0 = most concerning
     ood_features_scores: np.ndarray = np.exp(-1 * avg_knn_distances * t)
-    return (ood_features_scores, knn)
+    return ood_features_scores
 
 
 def _get_ood_predictions_scores(

--- a/cleanlab/outlier.py
+++ b/cleanlab/outlier.py
@@ -25,7 +25,7 @@ import numpy as np
 from cleanlab.count import get_confident_thresholds
 from sklearn.neighbors import NearestNeighbors
 from sklearn.exceptions import NotFittedError
-from typing import Optional, Union, Tuple, Dict
+from typing import Optional, Union, Tuple, Dict, cast
 from cleanlab.internal.label_quality_utils import (
     _subtract_confident_thresholds,
     get_normalized_entropy,
@@ -446,7 +446,7 @@ def _get_ood_features_scores(
     # neighbor of each point is the point itself, at a distance of zero.
     distances, _ = knn.kneighbors(features)
 
-    ood_features_scores = transform_distances_to_scores(distances, k, t)
+    ood_features_scores = transform_distances_to_scores(distances, cast(int, k), t)
     return (ood_features_scores, knn)
 
 

--- a/docs/source/cleanlab/internal/index.rst
+++ b/docs/source/cleanlab/internal/index.rst
@@ -17,5 +17,6 @@ internal
     label_quality_utils
     multilabel_utils
     multilabel_scorer
+    outlier
     token_classification_utils
     validation

--- a/docs/source/cleanlab/internal/outlier.rst
+++ b/docs/source/cleanlab/internal/outlier.rst
@@ -1,0 +1,8 @@
+outlier
+=======
+
+.. automodule:: cleanlab.internal.outlier
+    :autosummary:
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
# Description

In this PR, the `OutOfDistribution._get_ood_features_scores` method is refactored by extracting the logic for converting distances to Out-of-Distribution (OOD) feature scores into a separate function. 

This change makes the code more modular and readable, allowing for easier maintenance and testing.

The newly introduced function is called `transform_distances_to_scores`. Its arguments include:

- An array of (sorted) distances, 
- Number of neighbors (k),
- The scale parameter (t).
 
It returns an array of OOD feature scores.

## Example usage

```python
>>> import numpy as np
>>> from cleanlab.outlier import transform_distances_to_scores
>>> distances = np.array([[0.0, 0.1, 0.25],
...                       [0.15, 0.2, 0.3]])
>>> transform_distances_to_scores(distances, k=2, t=1)
array([0.95122942, 0.83945702])
```

## Other changes
As a result of this refactoring, the `_get_ood_features_scores` method now calls the `transform_distances_to_scores` function to compute the OOD feature scores before returning the final tuple.