### PR TITLE
Update softmax to more stable variant

### DIFF
--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -243,8 +243,10 @@ def softmin(
 
     def softmax(scores: np.ndarray) -> np.ndarray:
         """Softmax function."""
-        exp_scores = np.exp(scores / temperature)
-        return exp_scores / np.sum(exp_scores, axis=axis, keepdims=True)
+        scores = scores / temperature
+        scores_max = np.amax(scores, axis=axis, keepdims=True)
+        exp_scores_shifted = np.exp(scores - scores_max)
+        return exp_scores_shifted / np.sum(exp_scores_shifted, axis=axis, keepdims=True)
 
     return np.einsum("ij,ij->i", s, softmax(1 - s))
 

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -281,7 +281,7 @@ def _softmin_sentence_score(
         return np.array([np.mean(scores) for scores in token_scores])
 
     def softmax(scores: np.ndarray) -> np.ndarray:
-        scores = = scores / temperature
+        scores = scores / temperature
         scores_max = np.amax(scores, axis=0, keepdims=True)
         exp_scores_shifted = np.exp(scores - scores_max)
         return exp_scores_shifted / np.sum(exp_scores_shifted, axis=0, keepdims=True)

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -281,8 +281,10 @@ def _softmin_sentence_score(
         return np.array([np.mean(scores) for scores in token_scores])
 
     def softmax(scores: np.ndarray) -> np.ndarray:
-        exp_scores = np.exp(scores / temperature)
-        return exp_scores / np.sum(exp_scores)
+        scores = = scores / temperature
+        scores_max = np.amax(scores, axis=0, keepdims=True)
+        exp_scores_shifted = np.exp(scores - scores_max)
+        return exp_scores_shifted / np.sum(exp_scores_shifted, axis=0, keepdims=True)
 
     def fun(scores: np.ndarray) -> float:
         return np.dot(scores, softmax(1 - np.array(scores)))


### PR DESCRIPTION
Additional improvement could be to update softmin to avoid `1 - scores` overflow error like so:
```python3
def softmin(scores, temperature=0.99, axis=0):
    scores = np.array(scores)
    softmax_scores = softmax(-1 * scores, temperature, axis)
    return np.dot(softmax_scores, scores)
```
This however changes the results and its effect on performance would need to be tested further.