### PR TITLE
Datalab: Add report method to Reporter

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -301,7 +301,7 @@ class Datalab:
             verbosity=verbosity,
             include_description=include_description,
         )
-        print(reporter.get_report(num_examples=num_examples))
+        reporter.report(num_examples=num_examples)
 
     @property
     def issues(self) -> pd.DataFrame:

--- a/cleanlab/datalab/report.py
+++ b/cleanlab/datalab/report.py
@@ -60,6 +60,16 @@ class Reporter:
         self.verbosity = verbosity
         self.include_description = include_description
 
+    def report(self, num_examples: int) -> None:
+        """Prints a report about identified issues in the data.
+
+        Parameters
+        ----------
+        num_examples :
+            The number of examples to include in the report for each issue type.
+        """
+        print(self.get_report(num_examples=num_examples))
+
     def get_report(self, num_examples: int) -> str:
         """Constructs a report about identified issues in the data.
 

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -503,8 +503,8 @@ class TestDatalab:
                 self.verbosity = kwargs.get("verbosity", None)
                 assert self.verbosity is not None, "Reporter should be initialized with verbosity"
 
-            def get_report(self, *args, **kwargs):
-                return (
+            def report(self, *args, **kwargs) -> None:
+                print(
                     f"Report with verbosity={self.verbosity} and k={kwargs.get('num_examples', 5)}"
                 )
 

--- a/tests/datalab/test_report.py
+++ b/tests/datalab/test_report.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import pandas as pd
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from cleanlab.datalab.report import Reporter
 
@@ -35,6 +35,17 @@ class TestReporter:
 
         another_reporter = Reporter(data_issues=data_issues, verbosity=2)
         assert another_reporter.verbosity == 2
+
+    def test_report(self, reporter):
+        """Test that the report method works. It just wraps the get_report method in a print
+        statement."""
+        mock_get_report = Mock()
+
+        with patch("builtins.print") as mock_print:  # type: ignore
+            with patch.object(reporter, "get_report", mock_get_report):
+                reporter.report(num_examples=3)
+            mock_get_report.assert_called_with(num_examples=3)
+        mock_print.assert_called_with(mock_get_report.return_value)
 
     @pytest.mark.parametrize("include_description", [True, False])
     def test_get_report(self, reporter, data_issues, include_description, monkeypatch):


### PR DESCRIPTION
# New method for `Reporter`

This update provides a more flexible way to display reports in the `Reporter` class about issued identified by Datalab, via a newly added `Reporter.report()` method. It has fewer restrictions than the existing `get_report()` method. 

While the `get_report()` method is a pure function that returns a string as output, the new `report()` method allows for side-effects, such as printing the report directly.

Here's a summary of the changes in this commit:

- Added the `report()` method to the `Reporter` class in cleanlab/datalab/report.py.
- Refactored the Datalab class in cleanlab/datalab/datalab.py to use the new `report()` method.
- Updated test cases in tests/datalab/test_datalab.py and tests/datalab/test_report.py to ensure compatibility with the new method.

This update will enhance the developer experience by providing a more flexible and convenient way to generate and display reports when extending Datalab to other data modalities and formats. Hopefully, this will align more with the `IssueManager.report()` method down the line.