### PR TITLE
Add docs link to description of issue types in tutorial

### DIFF
--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -568,7 +568,7 @@
     "All that is need to audit your data is to call `find_issues()`.\n",
     "This method accepts various inputs like: predicted class probabilities, numeric feature representations of the data. The more information you provide here, the more thoroughly `Datalab` will audit your data! Note that `features` should be some numeric representation of each example, either obtained through preprocessing transformation of your raw data or embeddings from a (pre)trained model. In this case, our data is already entirely numeric so we just provide the features directly.\n",
     "\n",
-    "`find_issues()` can be configured to find different types of issues, with more fine-grained control. Check out https://docs.cleanlab.ai/stable/cleanlab/datalab/guide/issue_type_description.html."
+    "`find_issues()` can be configured to find different types of issues, with more fine-grained control. Check out the [Issue Type Descriptions](../../cleanlab/datalab/guide/issue_type_description.html) page for more details."
    ]
   },
   {

--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -566,7 +566,9 @@
     "We create a `Datalab` object from the dataset, also providing the name of the label column in the dataset. Only instantiate one `Datalab` object per dataset, and note that only classification datasets are supported for now.\n",
     "\n",
     "All that is need to audit your data is to call `find_issues()`.\n",
-    "This method accepts various inputs like: predicted class probabilities, numeric feature representations of the data. The more information you provide here, the more thoroughly `Datalab` will audit your data! Note that `features` should be some numeric representation of each example, either obtained through preprocessing transformation of your raw data or embeddings from a (pre)trained model. In this case, our data is already entirely numeric so we just provide the features directly."
+    "This method accepts various inputs like: predicted class probabilities, numeric feature representations of the data. The more information you provide here, the more thoroughly `Datalab` will audit your data! Note that `features` should be some numeric representation of each example, either obtained through preprocessing transformation of your raw data or embeddings from a (pre)trained model. In this case, our data is already entirely numeric so we just provide the features directly.\n",
+    "\n",
+    "`find_issues()` can be configured to find different types of issues, with more fine-grained control. Check out https://docs.cleanlab.ai/stable/cleanlab/datalab/guide/issue_type_description.html."
    ]
   },
   {


### PR DESCRIPTION
From the quickstart tutorial, users can now find a bit more information about what types of issues to check for.

Merge this after #682 