### PR TITLE
allow for kwargs in token find_label_issues

### DIFF
--- a/cleanlab/token_classification/filter.py
+++ b/cleanlab/token_classification/filter.py
@@ -60,7 +60,7 @@ def find_label_issues(
 
         See :py:func:`cleanlab.filter.find_label_issues <cleanlab.filter.find_label_issues>`
         documentation for more details on each label quality scoring method.
-    
+
     kwargs:
         Additional keyword arguments to pass into :py:func:`filter.find_label_issues <cleanlab.filter.find_label_issues>`
         which is internally applied at the token level. Can include values like `n_jobs` to control parallel processing, `frac_noise`, etc.

--- a/cleanlab/token_classification/filter.py
+++ b/cleanlab/token_classification/filter.py
@@ -92,7 +92,10 @@ def find_label_issues(
     pred_probs_flatten = np.array([pred for pred_prob in pred_probs for pred in pred_prob])
 
     issues_main = find_label_issues_main(
-        labels_flatten, pred_probs_flatten, return_indices_ranked_by=return_indices_ranked_by, **kwargs
+        labels_flatten,
+        pred_probs_flatten,
+        return_indices_ranked_by=return_indices_ranked_by,
+        **kwargs
     )
 
     lengths = [len(label) for label in labels]

--- a/cleanlab/token_classification/filter.py
+++ b/cleanlab/token_classification/filter.py
@@ -31,6 +31,7 @@ def find_label_issues(
     pred_probs: list,
     *,
     return_indices_ranked_by: str = "self_confidence",
+    **kwargs,
 ) -> List[Tuple[int, int]]:
     """Identifies tokens with label issues in a token classification dataset.
 
@@ -59,6 +60,10 @@ def find_label_issues(
 
         See :py:func:`cleanlab.filter.find_label_issues <cleanlab.filter.find_label_issues>`
         documentation for more details on each label quality scoring method.
+    
+    kwargs:
+        Additional keyword arguments to pass into :py:func:`filter.find_label_issues <cleanlab.filter.find_label_issues>`
+        which is internally applied at the token level. Can include values like `n_jobs` to control parallel processing, `frac_noise`, etc.
 
     Returns
     -------
@@ -87,7 +92,7 @@ def find_label_issues(
     pred_probs_flatten = np.array([pred for pred_prob in pred_probs for pred in pred_prob])
 
     issues_main = find_label_issues_main(
-        labels_flatten, pred_probs_flatten, return_indices_ranked_by=return_indices_ranked_by
+        labels_flatten, pred_probs_flatten, return_indices_ranked_by=return_indices_ranked_by, **kwargs
     )
 
     lengths = [len(label) for label in labels]

--- a/cleanlab/token_classification/filter.py
+++ b/cleanlab/token_classification/filter.py
@@ -95,7 +95,7 @@ def find_label_issues(
         labels_flatten,
         pred_probs_flatten,
         return_indices_ranked_by=return_indices_ranked_by,
-        **kwargs
+        **kwargs,
     )
 
     lengths = [len(label) for label in labels]

--- a/tests/test_token_classification.py
+++ b/tests/test_token_classification.py
@@ -220,7 +220,7 @@ def test_find_label_issues(test_labels):
     assert len(issues) == 1
     assert issues[0] == (1, 0)
     issues2 = find_label_issues(
-        test_labels, pred_probs, return_indices_ranked_by="normalized_margin"
+        test_labels, pred_probs, return_indices_ranked_by="normalized_margin", n_jobs=1
     )
     assert isinstance(issues2, list)
 


### PR DESCRIPTION
to control things like parallelization. 

May help some users' issues like this: https://github.com/cleanlab/cleanlab/issues/681