### PR TITLE
Fix report output formatting

### DIFF
--- a/cleanlab/datalab/issue_manager/duplicate.py
+++ b/cleanlab/datalab/issue_manager/duplicate.py
@@ -45,8 +45,8 @@ class NearDuplicateIssueManager(IssueManager):
     issue_name: ClassVar[str] = "near_duplicate"
     verbosity_levels = {
         0: [],
-        1: ["threshold"],
-        2: [],
+        1: [],
+        2: ["threshold"],
     }
 
     def __init__(

--- a/cleanlab/datalab/issue_manager/issue_manager.py
+++ b/cleanlab/datalab/issue_manager/issue_manager.py
@@ -287,7 +287,7 @@ class IssueManager(ABC, metaclass=IssueManagerMeta):
             report_str += "About this issue:\n\t" + description + "\n\n"
         report_str += (
             f"Number of examples with this issue: {issues[f'is_{cls.issue_name}_issue'].sum()}\n"
-            f"Overall dataset quality in terms of this issue: : {score:.4f}\n\n"
+            f"Overall dataset quality in terms of this issue: {score:.4f}\n\n"
         )
 
         info_to_print: Set[str] = set()

--- a/cleanlab/datalab/report.py
+++ b/cleanlab/datalab/report.py
@@ -112,7 +112,6 @@ class Reporter:
         return report_str
 
     def _write_summary(self, summary: pd.DataFrame) -> str:
-
         statistics = self.data_issues.get_info("statistics")
         num_examples = statistics["num_examples"]
         num_classes = statistics.get(

--- a/cleanlab/datalab/report.py
+++ b/cleanlab/datalab/report.py
@@ -112,9 +112,20 @@ class Reporter:
         return report_str
 
     def _write_summary(self, summary: pd.DataFrame) -> str:
+
+        statistics = self.data_issues.get_info("statistics")
+        num_examples = statistics["num_examples"]
+        num_classes = statistics.get(
+            "num_classes"
+        )  # This may not be required for all types of datasets  in the future (e.g. unlabeled/regression)
+
+        dataset_information = f"Dataset Information: num_examples: {num_examples}"
+        if num_classes is not None:
+            dataset_information += f", num_classes: {num_classes}"
         return (
             "Here is a summary of the different kinds of issues found in the data:\n\n"
             + summary.to_string(index=False)
             + "\n\n"
-            + "(Note: A lower score indicates a more severe issue across all examples in the dataset.)\n\n\n"
+            + "(Note: A lower score indicates a more severe issue across all examples in the dataset.)\n\n"
+            + f"{dataset_information}\n\n\n"
         )

--- a/docs/source/cleanlab/datalab/guide/custom_issue_manager.rst
+++ b/docs/source/cleanlab/datalab/guide/custom_issue_manager.rst
@@ -199,7 +199,7 @@ The report will look something like this:
     ------------------------------------------- basic issues -------------------------------------------
 
     Number of examples with this issue: 2
-    Overall dataset quality in terms of this issue: : 0.4778
+    Overall dataset quality in terms of this issue: 0.4778
 
     Examples representing most severe instances of this issue:
         is_basic_issue  basic_score
@@ -216,7 +216,7 @@ The report will look something like this:
     	Intermediate issues are a bit more involved than basic issues.
 
     Number of examples with this issue: 0
-    Overall dataset quality in terms of this issue: : 0.2865
+    Overall dataset quality in terms of this issue: 0.2865
 
     Examples representing most severe instances of this issue:
         is_intermediate_issue  intermediate_score    kernel


### PR DESCRIPTION
This PR refines the source code for report outputs with Datalab, primarily by adjusting the verbosity level required to display the `threshold` used in near-duplicate checks.

## Minor change

```python
lab.report()
```

gives us extra info on the datasets passed to Datalab.

#### Changed output
```diff
Here is a summary of the different kinds of issues found in the data:

    issue_type    score  num_issues
         label 0.909091          11
       outlier 0.522080           6
near_duplicate 0.246459           4

(Note: A lower score indicates a more severe issue across all examples in the dataset.)
+
+ Dataset Information: num_examples: 132, num_classes: 3

...
```
