### PR TITLE
Update numpy.typing import and annotations

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import numpy as np
-
 import pandas as pd
 
 import cleanlab

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import numpy as np
-import numpy.typing as npt
+
 import pandas as pd
 
 import cleanlab
@@ -36,6 +36,7 @@ from cleanlab.datalab.serialize import _Serializer
 from cleanlab.datalab.report import Reporter
 
 if TYPE_CHECKING:  # pragma: no cover
+    import numpy.typing as npt
     from datasets.arrow_dataset import Dataset
     from scipy.sparse import csr_matrix
 

--- a/cleanlab/datalab/issue_finder.py
+++ b/cleanlab/datalab/issue_finder.py
@@ -27,17 +27,18 @@ and collects the results to :py:class:`DataIssues <cleanlab.datalab.data_issues.
     This module is not intended to be used directly. Instead, use the public-facing
     :py:meth:`Datalab.find_issues <cleanlab.datalab.datalab.Datalab.find_issues>` method.
 """
+from __future__ import annotations
 
 from typing import Any, List, Optional, Dict, TYPE_CHECKING
 import warnings
 
 import numpy as np
-import numpy.typing as npt
 from scipy.sparse import csr_matrix
 
 from cleanlab.datalab.factory import _IssueManagerFactory, REGISTRY
 
 if TYPE_CHECKING:  # pragma: no cover
+    import numpy.typing as npt
     from cleanlab.datalab.datalab import Datalab
 
 

--- a/cleanlab/datalab/issue_manager/duplicate.py
+++ b/cleanlab/datalab/issue_manager/duplicate.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Union
 import warnings
 
 import numpy as np
-import numpy.typing as npt
+
 import pandas as pd
 from scipy.sparse import csr_matrix
 from sklearn.neighbors import NearestNeighbors
@@ -28,6 +28,7 @@ from sklearn.utils.validation import check_is_fitted
 from cleanlab.datalab.issue_manager import IssueManager
 
 if TYPE_CHECKING:  # pragma: no cover
+    import numpy.typing as npt
     from cleanlab.datalab.datalab import Datalab
 
 

--- a/cleanlab/datalab/issue_manager/duplicate.py
+++ b/cleanlab/datalab/issue_manager/duplicate.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Union
 import warnings
 
 import numpy as np
-
 import pandas as pd
 from scipy.sparse import csr_matrix
 from sklearn.neighbors import NearestNeighbors

--- a/cleanlab/datalab/issue_manager/noniid.py
+++ b/cleanlab/datalab/issue_manager/noniid.py
@@ -7,7 +7,6 @@ import itertools
 from scipy.stats import gaussian_kde
 import numpy as np
 import pandas as pd
-import numpy.typing as npt
 from scipy.sparse import csr_matrix
 from sklearn.neighbors import NearestNeighbors
 from sklearn.utils.validation import check_is_fitted
@@ -15,6 +14,7 @@ from sklearn.utils.validation import check_is_fitted
 from cleanlab.datalab.issue_manager import IssueManager
 
 if TYPE_CHECKING:  # pragma: no cover
+    import numpy.typing as npt
     from cleanlab.datalab.datalab import Datalab
 
 

--- a/cleanlab/datalab/issue_manager/outlier.py
+++ b/cleanlab/datalab/issue_manager/outlier.py
@@ -20,13 +20,13 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Union, c
 from scipy.sparse import csr_matrix
 from scipy.stats import iqr
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
 
 from cleanlab.datalab.issue_manager import IssueManager
 from cleanlab.outlier import OutOfDistribution, transform_distances_to_scores
 
 if TYPE_CHECKING:  # pragma: no cover
+    import numpy.typing as npt
     from sklearn.neighbors import NearestNeighbors
     from cleanlab.datalab.datalab import Datalab
 

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -17,16 +17,18 @@
 """
 Helper methods used internally in cleanlab.token_classification
 """
+from __future__ import annotations
 
 import re
 import string
 import numpy as np
 from termcolor import colored
-from typing import List, Optional, Callable, Tuple, TypeVar
-import numpy.typing as npt
+from typing import List, Optional, Callable, Tuple, TypeVar, TYPE_CHECKING
 
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
-T = TypeVar("T", bound=npt.NBitBase)
+    T = TypeVar("T", bound=npt.NBitBase)
 
 
 def get_sentence(words: List[str]) -> str:

--- a/cleanlab/internal/token_classification_utils.py
+++ b/cleanlab/internal/token_classification_utils.py
@@ -25,7 +25,7 @@ import numpy as np
 from termcolor import colored
 from typing import List, Optional, Callable, Tuple, TypeVar, TYPE_CHECKING
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
 
     T = TypeVar("T", bound=npt.NBitBase)

--- a/cleanlab/multilabel_classification/rank.py
+++ b/cleanlab/multilabel_classification/rank.py
@@ -30,7 +30,7 @@ from cleanlab.internal.multilabel_utils import int2onehot
 from cleanlab.internal.multilabel_scorer import MultilabelScorer, ClassLabelScorer, Aggregator
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
 
     T = TypeVar("T", bound=npt.NBitBase)

--- a/cleanlab/multilabel_classification/rank.py
+++ b/cleanlab/multilabel_classification/rank.py
@@ -19,10 +19,10 @@ Methods to rank the severity of label issues in multi-label classification datas
 Here each example can belong to one or more classes, or none of the classes at all.
 Unlike in standard multi-class classification, model-predicted class probabilities need not sum to 1 for each row in multi-label classification.
 """
+from __future__ import annotations
 
 import numpy as np  # noqa: F401: Imported for type annotations
-import numpy.typing as npt
-from typing import List, TypeVar, Dict, Any, Optional, Tuple
+from typing import List, TypeVar, Dict, Any, Optional, Tuple, TYPE_CHECKING
 
 from cleanlab.internal.validation import assert_valid_inputs
 from cleanlab.internal.util import get_num_classes
@@ -30,7 +30,10 @@ from cleanlab.internal.multilabel_utils import int2onehot
 from cleanlab.internal.multilabel_scorer import MultilabelScorer, ClassLabelScorer, Aggregator
 
 
-T = TypeVar("T", bound=npt.NBitBase)
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    T = TypeVar("T", bound=npt.NBitBase)
 
 
 def _labels_to_binary(


### PR DESCRIPTION
## Changes made:

- Moved `import numpy.typing as npt` under if TYPE_CHECKING guard clauses
  - Adjusted related type-hinting code to only be used when TYPE_CHECKING is True
- Added `from __future__ import annotations` to affected files

The code functionality remains unchanged.
This should only be used during type-checking, but not at run time.

## How was this tested

1. Set up a Python 3.7 devcontainer (mcr.microsoft.com/vscode/devcontainers/python:3.7)
1.5 (Optional). Setup a virtual environment.
2. Install dependencies
    ```
    git clone https://github.com/cleanlab/cleanlab.git
    pip install numpy==1.20.0
    cd cleanlab
    pip install -e .
    ```
3. In a python REPL, run import commands like:
    ```python
    from cleanlab.token_classification.filter import find_label_issues
    ```


### Note 
The solution in https://github.com/cleanlab/cleanlab/issues/681#issuecomment-1528125141 is no longer necessary at run time, so there's no reason to bump the lower bound of numpy version atm.