### PR TITLE
Rename get_summary -> get_issue_summary for Datalab.

### DIFF
--- a/cleanlab/datalab/data_issues.py
+++ b/cleanlab/datalab/data_issues.py
@@ -135,7 +135,7 @@ class DataIssues:
             specific_issues = specific_issues.assign(**column_dict)
         return specific_issues
 
-    def get_summary(self, issue_name: Optional[str] = None) -> pd.DataFrame:
+    def get_issue_summary(self, issue_name: Optional[str] = None) -> pd.DataFrame:
         """Summarize the issues found in dataset of a particular type,
         including how severe this type of issue is overall across the dataset.
 
@@ -146,7 +146,7 @@ class DataIssues:
 
         Returns
         -------
-        summary :
+        issue_summary :
             DataFrame where each row corresponds to a type of issue, and columns quantify:
             the number of examples in the dataset estimated to exhibit this type of issue,
             and the overall severity of the issue across the dataset (via a numeric quality score where lower values indicate that the issue is overall more severe).
@@ -154,7 +154,7 @@ class DataIssues:
         if self.issue_summary.empty:
             raise ValueError(
                 "No issues found in the dataset. "
-                "Call `find_issues` before calling `get_summary`."
+                "Call `find_issues` before calling `get_issue_summary`."
             )
 
         if issue_name is None:

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -395,14 +395,14 @@ class Datalab:
         """
         return self.data_issues.get_issues(issue_name=issue_name)
 
-    def get_summary(self, issue_name: Optional[str] = None) -> pd.DataFrame:
+    def get_issue_summary(self, issue_name: Optional[str] = None) -> pd.DataFrame:
         """Summarize the issues found in dataset of a particular type,
         including how severe this type of issue is overall across the dataset.
 
         NOTE
         ----
         This is a wrapper around the
-        :py:meth:`DataIssues.get_summary <cleanlab.datalab.data_issues.DataIssues.get_summary>` method.
+        :py:meth:`DataIssues.get_issue_summary <cleanlab.datalab.data_issues.DataIssues.get_issue_summary>` method.
 
         Parameters
         ----------
@@ -411,12 +411,12 @@ class Datalab:
 
         Returns
         -------
-        summary :
+        issue_summary :
             DataFrame where each row corresponds to a type of issue, and columns quantify:
             the number of examples in the dataset estimated to exhibit this type of issue,
             and the overall severity of the issue across the dataset (via a numeric quality score where lower values indicate that the issue is overall more severe).
         """
-        return self.data_issues.get_summary(issue_name=issue_name)
+        return self.data_issues.get_issue_summary(issue_name=issue_name)
 
     def get_info(self, issue_name: Optional[str] = None) -> Dict[str, Any]:
         """Get the info for the issue_name key.

--- a/cleanlab/datalab/report.py
+++ b/cleanlab/datalab/report.py
@@ -99,7 +99,7 @@ class Reporter:
         issue_reports = [
             _IssueManagerFactory.from_str(issue_type=key).report(
                 issues=self.data_issues.get_issues(issue_name=key),
-                summary=self.data_issues.get_summary(issue_name=key),
+                summary=self.data_issues.get_issue_summary(issue_name=key),
                 info=self.data_issues.get_info(issue_name=key),
                 num_examples=num_examples,
                 verbosity=self.verbosity,

--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -611,7 +611,7 @@
    "source": [
     "There are several methods to get more details about a particular issue.\n",
     "\n",
-    "The `get_summary()` method fetches summary statistics regarding how severe each type of issue is overall across the whole dataset."
+    "The `get_issue_summary()` method fetches summary statistics regarding how severe each type of issue is overall across the whole dataset."
    ]
   },
   {
@@ -620,7 +620,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lab.get_summary()"
+    "lab.get_issue_summary()"
    ]
   },
   {
@@ -636,7 +636,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lab.get_summary(\"label\")"
+    "lab.get_issue_summary(\"label\")"
    ]
   },
   {

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -120,7 +120,7 @@ class TestDatalab:
 
         assert lab.get_info() == lab.info == mock_info
 
-    def test_get_summary(self, lab, monkeypatch):
+    def test_get_issue_summary(self, lab, monkeypatch):
         mock_summary: pd.DataFrame = pd.DataFrame(
             {
                 "issue_type": ["label", "outlier"],
@@ -130,15 +130,15 @@ class TestDatalab:
         )
         monkeypatch.setattr(lab, "issue_summary", mock_summary)
 
-        label_summary = lab.get_summary(issue_name="label")
+        label_summary = lab.get_issue_summary(issue_name="label")
         pd.testing.assert_frame_equal(label_summary, mock_summary.iloc[[0]])
 
-        outlier_summary = lab.get_summary(issue_name="outlier")
+        outlier_summary = lab.get_issue_summary(issue_name="outlier")
         pd.testing.assert_frame_equal(
             outlier_summary, mock_summary.iloc[[1]].reset_index(drop=True)
         )
 
-        summary = lab.get_summary()
+        summary = lab.get_issue_summary()
         pd.testing.assert_frame_equal(summary, mock_summary)
 
     def test_get_issues(self, lab, monkeypatch):


### PR DESCRIPTION
This only affects Datalab/DataIssues. 


## Sidenote

IssueManager has a different method with the get_summary name that is used in a different way.