### PR TITLE
Seed noniid permutation tests

### DIFF
--- a/cleanlab/datalab/issue_manager/noniid.py
+++ b/cleanlab/datalab/issue_manager/noniid.py
@@ -103,6 +103,7 @@ class NonIIDIssueManager(IssueManager):
         metric: Optional[str] = None,
         k: int = 10,
         num_permutations: int = 25,
+        seed: Optional[int] = None,
         **_,
     ):
         super().__init__(datalab)
@@ -113,6 +114,7 @@ class NonIIDIssueManager(IssueManager):
             "ks": simplified_kolmogorov_smirnov_test,
         }
         self.background_distribution = None
+        self.seed = seed
 
     def find_issues(self, features: Optional[npt.NDArray] = None, **kwargs) -> None:
         knn_graph = self._process_knn_graph_from_inputs(kwargs)
@@ -239,6 +241,8 @@ class NonIIDIssueManager(IssueManager):
     def _permutation_test(self, num_permutations) -> float:
         N = self.N
 
+        if self.seed is not None:
+            np.random.seed(self.seed)
         perms = np.fromiter(
             itertools.chain.from_iterable(
                 np.random.permutation(N) for i in range(num_permutations)

--- a/cleanlab/datalab/issue_manager/noniid.py
+++ b/cleanlab/datalab/issue_manager/noniid.py
@@ -103,7 +103,7 @@ class NonIIDIssueManager(IssueManager):
         metric: Optional[str] = None,
         k: int = 10,
         num_permutations: int = 25,
-        seed: Optional[int] = None,
+        seed: Optional[int] = 0,
         **_,
     ):
         super().__init__(datalab)

--- a/docs/source/cleanlab/datalab/guide/issue_type_description.rst
+++ b/docs/source/cleanlab/datalab/guide/issue_type_description.rst
@@ -203,6 +203,7 @@ Non-IID Issue Parameters
     "metric": # `metric` argument to constructor of `NonIIDIssueManager`. String for the distance metric used for nearest neighbors search if necessary. `metric` argument to constructor of `sklearn.neighbors.NearestNeighbors`,
     "k": # `k` argument to constructor of `NonIIDIssueManager`. Integer representing the number of nearest neighbors for nearest neighbors search if necessary. `n_neighbors` argument to constructor of `sklearn.neighbors.NearestNeighbors`
     "num_permutations": # `num_permutations` argument to constructor of `NonIIDIssueManager`.
+    "seed": # seed for numpy's random number generator (used for permutation tests)
     }
 
 .. note::

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -155,7 +155,15 @@ class TestNonIIDIssueManager:
         assert info["metric"] == "euclidean"
         assert info["k"] == 10
 
-    @pytest.mark.parametrize("seed", [SEED, None], ids=["seed", "no_seed"])
+    @pytest.mark.parametrize(
+        "seed",
+        [
+            "default",
+            SEED,
+            None,
+        ],
+        ids=["default", "seed", "no_seed"],
+    )
     def test_seed(self, lab, seed):
         num_classes = 10
         means = [
@@ -186,12 +194,19 @@ class TestNonIIDIssueManager:
         embeddings = dataset["features"]
 
         # Create new issue manager, ignore the lab assigned for this test
-        issue_manager = NonIIDIssueManager(
-            datalab=lab,
-            metric="euclidean",
-            k=10,
-            seed=seed,
-        )
+        if seed == "default":
+            issue_manager = NonIIDIssueManager(
+                datalab=lab,
+                metric="euclidean",
+                k=10,
+            )
+        else:
+            issue_manager = NonIIDIssueManager(
+                datalab=lab,
+                metric="euclidean",
+                k=10,
+                seed=seed,
+            )
         issue_manager.find_issues(features=embeddings)
         p_value = issue_manager.info["p-value"]
 
@@ -200,7 +215,7 @@ class TestNonIIDIssueManager:
         p_value2 = issue_manager.info["p-value"]
 
         assert p_value > 0.0
-        if seed is not None:
+        if seed is not None or seed == "default":
             assert p_value == p_value2
         else:
             assert p_value != p_value2

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -157,7 +157,6 @@ class TestNonIIDIssueManager:
 
     @pytest.mark.parametrize("seed", [SEED, None], ids=["seed", "no_seed"])
     def test_seed(self, lab, seed):
-
         num_classes = 10
         means = [
             np.array([np.random.uniform(high=10), np.random.uniform(high=10)])


### PR DESCRIPTION
This PR adds a `seed` argument to the constructor of `NonIIDIssueManager` that can be used to reproduce the results of the permutation tests run when calling the `find_issues` method of the class.