### PR TITLE
Increase deadline for flaky hypothesis test

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -20,7 +20,7 @@ import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
 import io
 import numpy as np
-from hypothesis import given
+from hypothesis import given, settings
 from cleanlab.dataset import (
     health_summary,
     find_overlapping_classes,
@@ -516,6 +516,7 @@ confident_joint_strategy = npst.arrays(
 
 @pytest.mark.issue_651
 @given(confident_joint=confident_joint_strategy)
+@settings(deadline=500)
 def test_find_overlapping_classes_with_confident_joint(confident_joint):
     # Setup
     K = confident_joint.shape[0]


### PR DESCRIPTION
# Increase deadline for flaky hypothesis test

This PR increases the deadline for the `test_find_overlapping_classes_with_confident_joint` test from 200ms to 500ms. The test is part of the code that identifies overlapping classes with a confident joint, and ensures that it returns the correct results.

### Problem

In the continuous integration (CI) environment, the test occasionally exceeded the 200ms deadline on macOS and Windows platforms, causing flaky test behavior and CI failures. 

#### Examples of exceeded deadlines

- https://github.com/cleanlab/cleanlab/actions/runs/4878059556/jobs/8703347123#step:9:1176
- https://github.com/cleanlab/cleanlab/actions/runs/4867392250/jobs/8679929069#step:9:1216
- https://github.com/cleanlab/cleanlab/actions/runs/4866842042/jobs/8678784767#step:9:1216

### Solution

By increasing the deadline to 500ms, we provide more leeway for the test to complete on these platforms without impacting other platforms where the test consistently ran within the original deadline. 


This PR is a quick fix to address the immediate issue and ensure the tests run smoothly across different platforms.