### PR TITLE
Drop summary scores from Datalab.report()

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -273,6 +273,7 @@ class Datalab:
         num_examples: int = 5,
         verbosity: Optional[int] = None,
         include_description: bool = True,
+        show_summary_score: bool = False,
     ) -> None:
         """Prints informative summary of all issues.
 
@@ -300,6 +301,7 @@ class Datalab:
             data_issues=self.data_issues,
             verbosity=verbosity,
             include_description=include_description,
+            show_summary_score=show_summary_score,
         )
         reporter.report(num_examples=num_examples)
 

--- a/cleanlab/datalab/report.py
+++ b/cleanlab/datalab/report.py
@@ -127,17 +127,18 @@ class Reporter:
         if num_classes is not None:
             dataset_information += f", num_classes: {num_classes}"
 
-        if not self.show_summary_score:
+        if self.show_summary_score:
             return (
                 "Here is a summary of the different kinds of issues found in the data:\n\n"
-                + summary.drop(columns=["score"]).to_string(index=False)
+                + summary.to_string(index=False)
                 + "\n\n"
+                + "(Note: A lower score indicates a more severe issue across all examples in the dataset.)\n\n"
                 + f"{dataset_information}\n\n\n"
             )
+
         return (
             "Here is a summary of the different kinds of issues found in the data:\n\n"
-            + summary.to_string(index=False)
+            + summary.drop(columns=["score"]).to_string(index=False)
             + "\n\n"
-            + "(Note: A lower score indicates a more severe issue across all examples in the dataset.)\n\n"
             + f"{dataset_information}\n\n\n"
         )

--- a/cleanlab/datalab/report.py
+++ b/cleanlab/datalab/report.py
@@ -54,11 +54,16 @@ class Reporter:
     """
 
     def __init__(
-        self, data_issues: "DataIssues", verbosity: int = 1, include_description: bool = True
+        self,
+        data_issues: "DataIssues",
+        verbosity: int = 1,
+        include_description: bool = True,
+        show_summary_score: bool = False,
     ):
         self.data_issues = data_issues
         self.verbosity = verbosity
         self.include_description = include_description
+        self.show_summary_score = show_summary_score
 
     def report(self, num_examples: int) -> None:
         """Prints a report about identified issues in the data.
@@ -121,6 +126,14 @@ class Reporter:
         dataset_information = f"Dataset Information: num_examples: {num_examples}"
         if num_classes is not None:
             dataset_information += f", num_classes: {num_classes}"
+
+        if not self.show_summary_score:
+            return (
+                "Here is a summary of the different kinds of issues found in the data:\n\n"
+                + summary.drop(columns=["score"]).to_string(index=False)
+                + "\n\n"
+                + f"{dataset_information}\n\n\n"
+            )
         return (
             "Here is a summary of the different kinds of issues found in the data:\n\n"
             + summary.to_string(index=False)

--- a/tests/datalab/test_report.py
+++ b/tests/datalab/test_report.py
@@ -32,6 +32,7 @@ class TestReporter:
         assert reporter.data_issues == data_issues
         assert reporter.verbosity == 1
         assert reporter.include_description == True
+        assert reporter.show_summary_score == False
 
         another_reporter = Reporter(data_issues=data_issues, verbosity=2)
         assert another_reporter.verbosity == 2


### PR DESCRIPTION
The issue summary has a "scores" column that's useful for comparing differents runs of the same issue checks.

It may be too confusing for users looking at the top of the report, so by default we just omit it.


### Before

```
lab.report()
Here is a summary of the different kinds of issues found in the data:

    issue_type    score  num_issues
         label 0.909091          11
       outlier 0.522080           6
near_duplicate 0.246459           4

(Note: A lower score indicates a more severe issue across all examples in the dataset.)

Dataset Information: num_examples: 132, num_classes: 3
...
``` 

### After

```
lab.report()
Here is a summary of the different kinds of issues found in the data:

    issue_type  num_issues
         label          11
       outlier           6
near_duplicate           4

Dataset Information: num_examples: 132, num_classes: 3
...
```