### PR TITLE
DOC: use default rules for shorter, more readable links

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -293,8 +293,8 @@ Try to adhere to this standardized terminology unless you have good reason not t
 
 Use relative linking to connect information between docs and jupyter notebooks, and make sure links will remain valid in the future as new cleanlab versions are released! Sphinx/html works with relative paths so try to specify relative paths if necessary. For specific situations:
 
-- Link another function of class from within a source code docstring: `` `~cleanlab.file.name` ``.
-  This uses the default role 'py:obj', the leading tilde shortens the link to only display `name`.
+- Link another function or class from within a source code docstring: `` `~cleanlab.file.function_or_class_name` ``.
+  - This uses the [Sphinx's](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-default_role) `default_role = "py:obj"` setting, so the leading tilde shortens the link to only display `function_or_class_name`.
 - Link a tutorial (rst file) from within a source code docstring or rst file: ``:ref:`tutorial_name <tutorial_name>` ``
 - Link a tutorial notebook (ipynb file) from within a source code docstring or rst file: `` `notebook_name <tutorials/notebook_name.ipynb>`_ `` . (If the notebook is not the in the same folder as the source code, use a relative path)
 - Link a function from within a tutorial notebook: `[function_name](../cleanlab/file.rst#cleanlab.file.function_name)`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -293,8 +293,8 @@ Try to adhere to this standardized terminology unless you have good reason not t
 
 Use relative linking to connect information between docs and jupyter notebooks, and make sure links will remain valid in the future as new cleanlab versions are released! Sphinx/html works with relative paths so try to specify relative paths if necessary. For specific situations:
 
-- Link another function from within a source code docstring: ``:py:func:`function_name <cleanlab.file.function_name>` ``
-- Link another class from within a source code docstring: ``:py:class:`class_name <cleanlab.file.class_name>` ``
+- Link another function of class from within a source code docstring: `` `~cleanlab.file.name` ``.
+  This uses the default role 'py:obj', the leading tilde shortens the link to only display `name`.
 - Link a tutorial (rst file) from within a source code docstring or rst file: ``:ref:`tutorial_name <tutorial_name>` ``
 - Link a tutorial notebook (ipynb file) from within a source code docstring or rst file: `` `notebook_name <tutorials/notebook_name.ipynb>`_ `` . (If the notebook is not the in the same folder as the source code, use a relative path)
 - Link a function from within a tutorial notebook: `[function_name](../cleanlab/file.rst#cleanlab.file.function_name)`

--- a/cleanlab/outlier.py
+++ b/cleanlab/outlier.py
@@ -42,7 +42,7 @@ class OutOfDistribution:
     Each example's OOD score lies in [0,1] with smaller values indicating examples that are less typical under the data distribution.
     OOD scores may be estimated from either: numeric feature embeddings or predicted probabilities from a trained classifier.
 
-    To get indices of examples that are the most severe outliers, call :py:func:`find_top_issues <cleanlab.rank.find_top_issues>` function on the returned OOD scores.
+    To get indices of examples that are the most severe outliers, call `~cleanlab.rank.find_top_issues` function on the returned OOD scores.
 
     Parameters
     ----------
@@ -126,22 +126,21 @@ class OutOfDistribution:
         in to calculate scores.
 
         If `features` are passed in a ``NearestNeighbors`` object is fit. If `pred_probs` and 'labels' are passed in a
-        `confident_thresholds` ``np.ndarray`` is fit. For details see :py:func:`fit
-        <cleanlab.outlier.OutOfDistribution.fit>`.
+        `confident_thresholds` ``np.ndarray`` is fit. For details see `~cleanlab.outlier.OutOfDistribution.fit`.
 
         Parameters
         ----------
         features : np.ndarray, optional
           Feature array of shape ``(N, M)``, where N is the number of examples and M is the number of features used to represent each example.
-          For details, `features` in the same format expected by the :py:func:`fit <cleanlab.outlier.OutOfDistribution.fit>` function.
+          For details, `features` in the same format expected by the `~cleanlab.outlier.OutOfDistribution.fit` function.
 
         pred_probs : np.ndarray, optional
           An array of shape ``(N, K)`` of predicted class probabilities output by a trained classifier.
-          For details, `pred_probs` in the same format expected by the :py:func:`fit <cleanlab.outlier.OutOfDistribution.fit>` function.
+          For details, `pred_probs` in the same format expected by the `~cleanlab.outlier.OutOfDistribution.fit` function.
 
         labels : array_like, optional
           A discrete array of given class labels for the data of shape ``(N,)``.
-          For details, `labels` in the same format expected by the :py:func:`fit <cleanlab.outlier.OutOfDistribution.fit>` function.
+          For details, `labels` in the same format expected by the `~cleanlab.outlier.OutOfDistribution.fit` function.
 
         verbose : bool, default = True
           Set to ``False`` to suppress all print statements.
@@ -151,7 +150,7 @@ class OutOfDistribution:
         scores : np.ndarray
           If `features` are passed in, `ood_features_scores` are returned.
           If `pred_probs` are passed in, `ood_predictions_scores` are returned.
-          For details see return of :py:func:`score <cleanlab.outlier.OutOfDistribution.scores>` function.
+          For details see return of `~cleanlab.outlier.OutOfDistribution.scores` function.
 
         """
         scores = self._shared_fit(
@@ -181,7 +180,7 @@ class OutOfDistribution:
 
         If `features` are passed in, a ``NearestNeighbors`` object is fit.
         If `pred_probs` and 'labels' are passed in, a `confident_thresholds` ``np.ndarray`` is fit.
-        For details see :py:class:`OutOfDistribution <cleanlab.outlier.OutOfDistribution>` documentation.
+        For details see `~cleanlab.outlier.OutOfDistribution` documentation.
 
         Parameters
         ----------
@@ -232,11 +231,11 @@ class OutOfDistribution:
         ----------
         features : np.ndarray, optional
           Feature array of shape ``(N, M)``, where N is the number of examples and M is the number of features used to represent each example.
-          For details, see `features` in :py:func:`fit <cleanlab.outlier.OutOfDistribution.fit>` function.
+          For details, see `features` in `~cleanlab.outlier.OutOfDistribution.fit` function.
 
         pred_probs : np.ndarray, optional
           An array of shape ``(N, K)``  of predicted class probabilities output by a trained classifier.
-          For details, see `pred_probs` in :py:func:`fit <cleanlab.outlier.OutOfDistribution.fit>` function.
+          For details, see `pred_probs` in `~cleanlab.outlier.OutOfDistribution.fit` function.
 
         Returns
         -------
@@ -313,8 +312,8 @@ class OutOfDistribution:
         """
         Shared fit functionality between ``fit()`` and ``fit_score()``.
 
-        For details, refer to :py:func:`fit <cleanlab.outlier.OutOfDistribution.fit>`
-        or :py:func:`fit_score <cleanlab.outlier.OutOfDistribution.fit_score>`.
+        For details, refer to `~cleanlab.outlier.OutOfDistribution.fit`
+        or `~cleanlab.outlier.OutOfDistribution.fit_score`.
         """
         self._assert_valid_inputs(features, pred_probs)
         scores = None  # If none scores are returned, fit was skipped
@@ -378,18 +377,18 @@ def _get_ood_features_scores(
     ----------
     features : np.ndarray
       Feature array of shape ``(N, M)``, where N is the number of examples and M is the number of features used to represent each example.
-      For details, `features` in the same format expected by the :py:func:`fit <cleanlab.outlier.OutOfDistribution.fit>` function.
+      For details, `features` in the same format expected by the `~cleanlab.outlier.OutOfDistribution.fit` function.
 
     knn : sklearn.neighbors.NearestNeighbors, default = None
-      For details, see key `knn` in the params dict arg of :py:class:`OutOfDistribution <cleanlab.outlier.OutOfDistribution>`.
+      For details, see key `knn` in the params dict arg of `~cleanlab.outlier.OutOfDistribution`.
 
     k : int, default=None
       Optional number of neighbors to use when calculating outlier score (average distance to neighbors).
-      For details, see key `k` in the params dict arg of :py:class:`OutOfDistribution <cleanlab.outlier.OutOfDistribution>`.
+      For details, see key `k` in the params dict arg of `~cleanlab.outlier.OutOfDistribution`.
 
     t : int, default=1
       Controls transformation of distances between examples into similarity scores that lie in [0,1].
-      For details, see key `t` in the params dict arg of :py:class:`OutOfDistribution <cleanlab.outlier.OutOfDistribution>`.
+      For details, see key `t` in the params dict arg of `~cleanlab.outlier.OutOfDistribution`.
 
     Returns
     -------
@@ -460,21 +459,21 @@ def _get_ood_predictions_scores(
     ----------
     pred_probs : np.ndarray
       An array of shape ``(N, K)`` of model-predicted probabilities,
-      `pred_probs` in the same format expected by the :py:func:`fit <cleanlab.outlier.OutOfDistribution.fit>` function.
+      `pred_probs` in the same format expected by the `~cleanlab.outlier.OutOfDistribution.fit` function.
 
     confident_thresholds : np.ndarray, default = None
-      For details, see key `confident_thresholds` in the params dict arg of :py:class:`OutOfDistribution <cleanlab.outlier.OutOfDistribution>`.
+      For details, see key `confident_thresholds` in the params dict arg of `~cleanlab.outlier.OutOfDistribution`.
 
     labels : array_like, optional
-      `labels` in the same format expected by the :py:func:`fit <cleanlab.outlier.OutOfDistribution.fit>` function.
+      `labels` in the same format expected by the `~cleanlab.outlier.OutOfDistribution.fit` function.
 
     adjust_pred_probs : bool, True
       Account for class imbalance in the label-quality scoring.
-      For details, see key `adjust_pred_probs` in the params dict arg of :py:class:`OutOfDistribution <cleanlab.outlier.OutOfDistribution>`.
+      For details, see key `adjust_pred_probs` in the params dict arg of `~cleanlab.outlier.OutOfDistribution`.
 
     method : {"entropy", "least_confidence"}, default="entropy"
       OOD scoring method.
-      For details see key `method` in the params dict arg of :py:class:`OutOfDistribution <cleanlab.outlier.OutOfDistribution>`.
+      For details see key `method` in the params dict arg of `~cleanlab.outlier.OutOfDistribution`.
 
 
     Returns

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,8 +64,11 @@ exclude_patterns = ["_build"]
 
 autosummary_generate = True
 
+# set the default role of `name` to make cross references
+default_role = "py:obj"
+
 # -- Options for doctest extension ---------------------------------------------
-nbsphinx_allow_errors = True # to allow make doctest to run
+nbsphinx_allow_errors = True  # to allow make doctest to run
 
 # -- Options for apidoc extension ----------------------------------------------
 
@@ -161,7 +164,7 @@ html_context = {
         "v2.3.0",
         "v2.2.0",
         "v2.1.0",
-        "v2.0.0", 
+        "v2.0.0",
         "v1.0.1",
     ],
     # fmt: on
@@ -190,7 +193,7 @@ nbsphinx_prolog = (
         .dataframe {
             background: #D7D7D7;
         }
-    
+
         th {
             color:black;
         }


### PR DESCRIPTION
Use the Spinx setting for [default_role](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-default_role) to shorten links in docstrings.

This way `` `cleanlab.filename.qualifier` `` automatically generates a link, a tilde can be used (`` `~cleanlab.filname.qualifier` ``) to shorten the link only to ``qualifier``.

I exemplarily changed the links in the docstrings of `cleanlab.outlier`. To my mind, this results in more readable doc-strings, if you were e.g. to explore it in an idea (not in the rendered HTML pages).

-----
P.S.: If desired, I could also set up [intersphinx](https://www.sphinx-doc.org/en/master/usage/quickstart.html#intersphinx), to also link to external function, e.g., the `np.ndarray` would link to NumPy's documentation. This is a personal preference of mine, but certainly nothing more than a matter of taste (like the whole pull request).