### PR TITLE
Set non iid num issues with an extra rule

### DIFF
--- a/cleanlab/datalab/issue_manager/noniid.py
+++ b/cleanlab/datalab/issue_manager/noniid.py
@@ -163,20 +163,15 @@ class NonIIDIssueManager(IssueManager):
         score_median_threshold = np.median(scores) * 0.7
         issue_mask = scores < score_median_threshold
         if self.p_value >= self.significance_threshold:
-            self.issues = pd.DataFrame(
-                {
-                    f"is_{self.issue_name}_issue": np.zeros(self.N, dtype=bool),
-                    self.issue_score_key: scores,
-                },
-            )
+            issue_mask = np.zeros(self.N, dtype=bool)
         elif issue_mask.sum() == 0:
             issue_mask[scores.argmin()] = True
-            self.issues = pd.DataFrame(
-                {
-                    f"is_{self.issue_name}_issue": issue_mask,
-                    self.issue_score_key: scores,
-                },
-            )
+        self.issues = pd.DataFrame(
+            {
+                f"is_{self.issue_name}_issue": issue_mask,
+                self.issue_score_key: scores,
+            },
+        )
 
         self.summary = self.make_summary(score=self.p_value)
 

--- a/cleanlab/datalab/issue_manager/noniid.py
+++ b/cleanlab/datalab/issue_manager/noniid.py
@@ -164,6 +164,16 @@ class NonIIDIssueManager(IssueManager):
             },
         )
 
+        num_issues = self.issues[f"is_{self.issue_name}_issue"].sum()
+        if self.p_value >= 0.05:
+            # Set all issues to False if the p-value is greater than 0.05
+            self.issues[f"is_{self.issue_name}_issue"] = False
+        elif num_issues == 0:
+            # Make the lowest scoring example an issue if there are no issues
+            self.issues.loc[
+                self.issues[self.issue_score_key].idxmin(), f"is_{self.issue_name}_issue"
+            ] = True
+
         self.summary = self.make_summary(score=self.p_value)
 
         if knn_graph is None:

--- a/cleanlab/datalab/issue_manager/noniid.py
+++ b/cleanlab/datalab/issue_manager/noniid.py
@@ -103,6 +103,7 @@ class NonIIDIssueManager(IssueManager):
         metric: Optional[str] = None,
         k: int = 10,
         num_permutations: int = 25,
+        significance_threshold: float = 0.05,
         **_,
     ):
         super().__init__(datalab)
@@ -113,6 +114,7 @@ class NonIIDIssueManager(IssueManager):
             "ks": simplified_kolmogorov_smirnov_test,
         }
         self.background_distribution = None
+        self.significance_threshold = significance_threshold
 
     def find_issues(self, features: Optional[npt.NDArray] = None, **kwargs) -> None:
         knn_graph = self._process_knn_graph_from_inputs(kwargs)
@@ -158,7 +160,7 @@ class NonIIDIssueManager(IssueManager):
         scores = self._score_dataset()
         score_median_threshold = np.median(scores) * 0.7
         issue_mask = scores < score_median_threshold
-        if self.p_value >= 0.05:
+        if self.p_value >= self.significance_threshold:
             self.issues = pd.DataFrame(
                 {
                     f"is_{self.issue_name}_issue": np.zeros(self.N, dtype=bool),

--- a/docs/source/cleanlab/datalab/guide/issue_type_description.rst
+++ b/docs/source/cleanlab/datalab/guide/issue_type_description.rst
@@ -200,9 +200,10 @@ Non-IID Issue Parameters
 .. code-block:: python
 
     non_iid_kwargs = {
-    "metric": # `metric` argument to constructor of `NonIIDIssueManager`. String for the distance metric used for nearest neighbors search if necessary. `metric` argument to constructor of `sklearn.neighbors.NearestNeighbors`,
-    "k": # `k` argument to constructor of `NonIIDIssueManager`. Integer representing the number of nearest neighbors for nearest neighbors search if necessary. `n_neighbors` argument to constructor of `sklearn.neighbors.NearestNeighbors`
-    "num_permutations": # `num_permutations` argument to constructor of `NonIIDIssueManager`.
+    	"metric": # `metric` argument to constructor of `NonIIDIssueManager`. String for the distance metric used for nearest neighbors search if necessary. `metric` argument to constructor of `sklearn.neighbors.NearestNeighbors`,
+    	"k": # `k` argument to constructor of `NonIIDIssueManager`. Integer representing the number of nearest neighbors for nearest neighbors search if necessary. `n_neighbors` argument to constructor of `sklearn.neighbors.NearestNeighbors`,
+		"num_permutations": # `num_permutations` argument to constructor of `NonIIDIssueManager`,
+		"significance_threshold": # `significance_threshold` argument to constructor of `NonIIDIssueManager`. Floating value between 0 and 1 that determines the overall signicance of non-IID issues found in the dataset.
     }
 
 .. note::

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -73,6 +73,7 @@ class TestNonIIDIssueManager:
         assert issue_manager.metric == "euclidean"
         assert issue_manager.k == 10
         assert issue_manager.num_permutations == 25
+        assert issue_manager.significance_threshold == 0.05
 
         issue_manager = NonIIDIssueManager(
             datalab=lab,

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -115,7 +115,8 @@ class TestNonIIDIssueManager:
             issues_perm["is_non_iid_issue"] == expected_permuted_issue_mask
         ), "Issue mask should be correct"
         assert summary_perm["issue_type"][0] == "non_iid"
-        assert summary_perm["score"][0] > 0.05  # cannot easily ensure precise value because random seed has different effects on different OS
+        # ensure score is large, cannot easily ensure precise value because random seed has different effects on different OS:
+        assert summary_perm["score"][0] > 0.05
         assert info_perm.get("p-value", None) is not None, "Should have p-value"
         assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
 

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -89,7 +89,7 @@ class TestNonIIDIssueManager:
             issue_manager.summary,
             issue_manager.info,
         )
-        expected_sorted_issue_mask = np.array([False] * len(embeddings))
+        expected_sorted_issue_mask = np.array([False] * 46 + [True] + [False] * 3)
         assert np.all(
             issues_sort["is_non_iid_issue"] == expected_sorted_issue_mask
         ), "Issue mask should be correct"

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -115,7 +115,7 @@ class TestNonIIDIssueManager:
             issues_perm["is_non_iid_issue"] == expected_permuted_issue_mask
         ), "Issue mask should be correct"
         assert summary_perm["issue_type"][0] == "non_iid"
-        assert summary_perm["score"][0] == pytest.approx(expected=0.310207044, abs=1e-7)
+        assert summary_perm["score"][0] > 0.05  # cannot easily ensure precise value because random seed has different effects on different OS
         assert info_perm.get("p-value", None) is not None, "Should have p-value"
         assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
 


### PR DESCRIPTION
With this PR, we perform an additional check for the number of issues when we have a low p-value (under 0.05), vs a high p-value.

We have to change the number of issues in the `is_non_iid_issue` column for this to take effect in the issue summary.