### PR TITLE
Fix unbound knn variable in NonIIDIssueManager

### DIFF
--- a/cleanlab/datalab/issue_manager/noniid.py
+++ b/cleanlab/datalab/issue_manager/noniid.py
@@ -123,6 +123,8 @@ class NonIIDIssueManager(IssueManager):
         old_knn_metric = self.datalab.get_info("statistics").get("knn_metric")
         metric_changes = self.metric and self.metric != old_knn_metric
 
+        knn = None  # Won't be used if knn_graph is not None
+
         if knn_graph is None or metric_changes:
             if features is None:
                 raise ValueError(


### PR DESCRIPTION
This PR really just fixed one bug where the `knn` object isn't set within the NonIIDIssuemanager if a `knn_graph` is already accessible.

It's a simple as just initializing the parameter to None. That's already the expected type for `knn` when just the `knn_graph` is used.

Along with this change, I've added some end-to-end tests in Datalab that ensure the summary is updated appropriately with incremental search.
That's how the `knn` bug was discovered in the first place, because the IssueManagers would otherwise fail silently when calling `Datalab.find_issues`.