### PR TITLE
Include non-iid in default issue checks

### DIFF
--- a/cleanlab/datalab/issue_finder.py
+++ b/cleanlab/datalab/issue_finder.py
@@ -325,7 +325,7 @@ class IssueFinder:
         --------
         :py:class:`REGISTRY <cleanlab.datalab.factory.REGISTRY>` : All available issue types and their corresponding issue managers can be found here.
         """
-        return ["label", "outlier", "near_duplicate"]
+        return ["label", "outlier", "near_duplicate", "non_iid"]
 
     def get_available_issue_types(self, **kwargs):
         """Returns a dictionary of issue types that can be used in :py:meth:`Datalab.find_issues

--- a/cleanlab/datalab/issue_manager/noniid.py
+++ b/cleanlab/datalab/issue_manager/noniid.py
@@ -79,6 +79,11 @@ class NonIIDIssueManager(IssueManager):
         The number of trials to run when performing permutation testing to determine whether
         the distribution of index-distances between neighbors in the dataset is IID or not.
 
+    Note
+    ----
+    This class will only flag a single example as an issue if the dataset is considered non-IID. This type of issue
+    is more relevant to the entire dataset as a whole, rather than to individual examples.
+
     """
 
     description: ClassVar[

--- a/cleanlab/datalab/issue_manager/noniid.py
+++ b/cleanlab/datalab/issue_manager/noniid.py
@@ -162,11 +162,8 @@ class NonIIDIssueManager(IssueManager):
         self.p_value = self._permutation_test(num_permutations=self.num_permutations)
 
         scores = self._score_dataset()
-        score_median_threshold = np.median(scores) * 0.7
-        issue_mask = scores < score_median_threshold
-        if self.p_value >= self.significance_threshold:
-            issue_mask = np.zeros(self.N, dtype=bool)
-        elif issue_mask.sum() == 0:
+        issue_mask = np.zeros(self.N, dtype=bool)
+        if self.p_value < self.significance_threshold:
             issue_mask[scores.argmin()] = True
         self.issues = pd.DataFrame(
             {

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -772,7 +772,7 @@ class TestDatalabFindNonIIDIssues:
         summary = lab.get_issue_summary()
         assert ["non_iid"] == summary["issue_type"].values
         assert summary["score"].values[0] == 0
-        assert lab.get_issues()["is_non_iid_issue"].sum() > 0
+        assert lab.get_issues()["is_non_iid_issue"].sum() == 1
 
     def test_incremental_search(self, sorted_embeddings):
         data = {"labels": [0, 1, 0]}
@@ -784,7 +784,7 @@ class TestDatalabFindNonIIDIssues:
         assert "non_iid" in summary["issue_type"].values
         non_iid_summary = lab.get_issue_summary("non_iid")
         assert non_iid_summary["score"].values[0] == 0
-        assert non_iid_summary["num_issues"].values[0] > 0
+        assert non_iid_summary["num_issues"].values[0] == 1
 
 
 class TestDatalabFindLabelIssues:


### PR DESCRIPTION
## Changes in this PR

- `Datalab.find_issues` will run a `NonIIDIssueManager by default (currently if feature embeddings are provided).
- The "is_non_iid_issue" column will only flag the "worst" example if the dataset is considered to have a non-iid issue.
  - This means that the issue summary will only count one non-iid issue.