### PR TITLE
Make labels optional in Datalab

### DIFF
--- a/cleanlab/datalab/data.py
+++ b/cleanlab/datalab/data.py
@@ -161,7 +161,7 @@ class Data:
         return self._data_hash
 
     @property
-    def class_names(self) -> list:
+    def class_names(self) -> List[str]:
         return self.labels.class_names
 
     @property
@@ -225,7 +225,8 @@ class Label:
     def __init__(self, *, data: Dataset, label_name: Optional[str] = None) -> None:
         self._data = data
         self.label_name = label_name
-        self.labels, self.label_map = [], {}
+        self.labels = labels_to_array([])
+        self.label_map: Mapping[str, Any] = {}
         if label_name is not None:
             self.labels, self.label_map = _extract_labels(data, label_name)
             self._validate_labels()
@@ -250,7 +251,7 @@ class Label:
         return self.is_available
 
     @property
-    def class_names(self) -> list:
+    def class_names(self) -> List[str]:
         """A list of class names that are present in the dataset.
 
         Without labels, this will return an empty list.

--- a/cleanlab/datalab/data.py
+++ b/cleanlab/datalab/data.py
@@ -16,7 +16,7 @@
 """Classes and methods for datasets that are loaded into Datalab."""
 
 import os
-from typing import Any, Callable, Dict, List, Mapping, Tuple, Union, cast, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union, cast, TYPE_CHECKING
 
 try:
     import datasets
@@ -126,13 +126,11 @@ class Data:
         :py:class:`Datalab <cleanlab.datalab.datalab.Datalab>` to work.
     """
 
-    def __init__(self, data: "DatasetLike", label_name: str) -> None:
+    def __init__(self, data: "DatasetLike", label_name: Optional[str] = None) -> None:
         self._validate_data(data)
-        self._label_name = label_name
         self._data = self._load_data(data)
-        self._validate_data_and_labels(self._data, self._data[label_name])
         self._data_hash = hash(self._data)
-        self._labels, self._label_map = _extract_labels(self._data, label_name)
+        self.labels = Label(data=self._data, label_name=label_name)
 
     def _load_data(self, data: "DatasetLike") -> Dataset:
         """Checks the type of dataset and uses the correct loader method and
@@ -154,11 +152,9 @@ class Data:
     def __eq__(self, other) -> bool:
         if isinstance(other, Data):
             # Equality checks
-            hashes = self._data_hash == other._data_hash
-            labels = np.array_equal(self._labels, other._labels)
-            label_names = self._label_name == other._label_name
-            label_maps = self._label_map == other._label_map
-            return all([hashes, labels, label_names, label_maps])
+            hashes_are_equal = self._data_hash == other._data_hash
+            labels_are_equal = self.labels == other.labels
+            return all([hashes_are_equal, labels_are_equal])
         return False
 
     def __hash__(self) -> int:
@@ -166,7 +162,12 @@ class Data:
 
     @property
     def class_names(self) -> list:
-        return list(self._label_map.values())
+        return self.labels.class_names
+
+    @property
+    def has_labels(self) -> bool:
+        """Check if labels are available."""
+        return self.labels.is_available
 
     @staticmethod
     def _validate_data(data) -> None:
@@ -174,11 +175,6 @@ class Data:
             raise DatasetDictError()
         if not isinstance(data, (Dataset, pd.DataFrame, dict, list, str)):
             raise DataFormatError(data)
-
-    @staticmethod
-    def _validate_data_and_labels(data, labels) -> None:
-        assert isinstance(labels, (np.ndarray, list))
-        assert len(labels) == len(data)
 
     @staticmethod
     def _load_dataset_from_dict(data_dict: Dict[str, Any]) -> Dataset:
@@ -216,6 +212,64 @@ class Data:
         dataset = factory[extension](data_string)
         dataset_cast = cast(Dataset, dataset)
         return dataset_cast
+
+
+class Label:
+    """
+    Class to represent labels in a dataset.
+
+    Parameters
+    ----------
+    """
+
+    def __init__(self, *, data: Dataset, label_name: Optional[str] = None) -> None:
+        self._data = data
+        self.label_name = label_name
+        self.labels, self.label_map = [], {}
+        if label_name is not None:
+            self.labels, self.label_map = _extract_labels(data, label_name)
+            self._validate_labels()
+
+    def __len__(self) -> int:
+        if self.labels is None:
+            return 0
+        return len(self.labels)
+
+    def __eq__(self, __value: object) -> bool:
+        if isinstance(__value, Label):
+            labels_are_equal = np.array_equal(self.labels, __value.labels)
+            names_are_equal = self.label_name == __value.label_name
+            maps_are_equal = self.label_map == __value.label_map
+            return all([labels_are_equal, names_are_equal, maps_are_equal])
+        return False
+
+    def __getitem__(self, __index: Union[int, slice, np.ndarray]) -> np.ndarray:
+        return self.labels[__index]
+
+    def __bool__(self) -> bool:
+        return self.is_available
+
+    @property
+    def class_names(self) -> list:
+        """A list of class names that are present in the dataset.
+
+        Without labels, this will return an empty list.
+        """
+        return list(self.label_map.values())
+
+    @property
+    def is_available(self) -> bool:
+        """Check if labels are available."""
+        empty_labels = self.labels is None or len(self.labels) == 0
+        empty_label_map = self.label_map is None or len(self.label_map) == 0
+        return not (empty_labels or empty_label_map)
+
+    def _validate_labels(self) -> None:
+        if self.label_name not in self._data.column_names:
+            raise ValueError(f"Label column '{self.label_name}' not found in dataset.")
+        labels = self._data[self.label_name]
+        assert isinstance(labels, (np.ndarray, list))
+        assert len(labels) == len(self._data)
 
 
 def _extract_labels(data: Dataset, label_name: str) -> Tuple[np.ndarray, Mapping]:

--- a/cleanlab/datalab/data_issues.py
+++ b/cleanlab/datalab/data_issues.py
@@ -269,7 +269,7 @@ class DataIssues:
         self.info["statistics"]["health_score"] = self.issue_summary["score"].mean()
 
 
-def get_data_statistics(data: Data):
+def get_data_statistics(data: Data) -> Dict[str, Any]:
     """Get statistics about a dataset.
 
     This function is called to initialize the "statistics" info in all `Datalab` objects.
@@ -279,7 +279,7 @@ def get_data_statistics(data: Data):
     data : Data
         Data object containing the dataset.
     """
-    statistics = {
+    statistics: Dict[str, Any] = {
         "num_examples": len(data),
         "multi_label": False,
         "health_score": None,

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -88,14 +88,15 @@ class Datalab:
     def __init__(
         self,
         data: "DatasetLike",
-        label_name: str,
+        label_name: Optional[str] = None,
         verbosity: int = 1,
     ) -> None:
         self._data = Data(data, label_name)
         self.data = self._data._data
-        self._labels, self._label_map = self._data._labels, self._data._label_map
+        self._labels = self._data.labels
+        self._label_map = self._labels.label_map
+        self.label_name = self._labels.label_name
         self._data_hash = self._data._data_hash
-        self.label_name = self._data._label_name
         self.data_issues = DataIssues(self._data)
         self.cleanlab_version = cleanlab.version.__version__
         self.verbosity = verbosity
@@ -109,12 +110,20 @@ class Datalab:
     @property
     def labels(self) -> np.ndarray:
         """Labels of the dataset, in a [0, 1, ..., K-1] format."""
-        return self._labels
+        return self._labels.labels
+
+    @property
+    def has_labels(self) -> bool:
+        """Whether the dataset has labels."""
+        return self._labels.is_available
 
     @property
     def class_names(self) -> List[str]:
-        """Names of the classes in the dataset."""
-        return self._data.class_names
+        """Names of the classes in the dataset.
+
+        If the dataset has no labels, returns an empty list.
+        """
+        return self._labels.class_names
 
     def find_issues(
         self,

--- a/cleanlab/datalab/issue_finder.py
+++ b/cleanlab/datalab/issue_finder.py
@@ -349,4 +349,22 @@ class IssueFinder:
                 if issue in issue_types_copy
             }
 
+        drop_label_check = "label" in issue_types_copy and not self.datalab.has_labels
+        if drop_label_check:
+            warnings.warn("No labels were provided. " "The 'label' issue type will not be run.")
+            issue_types_copy.pop("label")
+
+        outlier_check_needs_features = "outlier" in issue_types_copy and not self.datalab.has_labels
+        if outlier_check_needs_features:
+            no_features = features is None
+            no_knn_graph = knn_graph is None
+            pred_probs_given = issue_types_copy["outlier"].get("pred_probs", None) is not None
+
+            only_pred_probs_given = pred_probs_given and no_features and no_knn_graph
+            if only_pred_probs_given:
+                warnings.warn(
+                    "No labels were provided. " "The 'outlier' issue type will not be run."
+                )
+                issue_types_copy.pop("outlier")
+
         return issue_types_copy

--- a/cleanlab/datalab/issue_manager/label.py
+++ b/cleanlab/datalab/issue_manager/label.py
@@ -103,7 +103,7 @@ class LabelIssueManager(IssueManager):
         if not self.health_summary_parameters:
             statistics_dict = self.datalab.get_info("statistics")
             self.health_summary_parameters = {
-                "labels": self.datalab._labels,
+                "labels": self.datalab.labels,
                 "class_names": list(self.datalab._label_map.values()),
                 "num_examples": statistics_dict.get("num_examples"),
                 "joint": statistics_dict.get("joint", None),
@@ -124,7 +124,7 @@ class LabelIssueManager(IssueManager):
         self.health_summary_parameters.update({"pred_probs": pred_probs})
         # Find examples with label issues
         self.issues = self.cl.find_label_issues(
-            labels=self.datalab._labels,
+            labels=self.datalab.labels,
             pred_probs=pred_probs,
             **self._process_find_label_issues_kwargs(kwargs),
         )
@@ -180,7 +180,7 @@ class LabelIssueManager(IssueManager):
         else:
             summary_parameters = {
                 "pred_probs": pred_probs,
-                "labels": self.datalab._labels,
+                "labels": self.datalab.labels,
             }
 
         summary_parameters["class_names"] = self.health_summary_parameters["class_names"]
@@ -223,4 +223,4 @@ class LabelIssueManager(IssueManager):
         return info_dict
 
     def _validate_pred_probs(self, pred_probs) -> None:
-        assert_valid_inputs(X=None, y=self.datalab._labels, pred_probs=pred_probs)
+        assert_valid_inputs(X=None, y=self.datalab.labels, pred_probs=pred_probs)

--- a/cleanlab/datalab/issue_manager/outlier.py
+++ b/cleanlab/datalab/issue_manager/outlier.py
@@ -268,7 +268,7 @@ class OutlierIssueManager(IssueManager):
     def _score_with_pred_probs(self, pred_probs: np.ndarray, **kwargs) -> np.ndarray:
         # Remove "threshold" from kwargs if it exists
         kwargs.pop("threshold", None)
-        scores = self.ood.fit_score(pred_probs=pred_probs, labels=self.datalab._labels, **kwargs)
+        scores = self.ood.fit_score(pred_probs=pred_probs, labels=self.datalab.labels, **kwargs)
         return scores
 
     def _score_with_features(self, features: npt.NDArray, **kwargs) -> npt.NDArray:

--- a/tests/datalab/issue_manager/test_label.py
+++ b/tests/datalab/issue_manager/test_label.py
@@ -58,9 +58,6 @@ class TestLabelIssueManager:
             "confident_joint": [1 / 3, 1 / 3, 1 / 3],
             "multi_label": False,
         }
-        monkeypatch.setattr(
-            issue_manager.datalab, "_labels", mock_health_summary_parameters["labels"]
-        )
         pred_probs = np.random.rand(3, 3)
         monkeypatch.setattr(
             issue_manager, "health_summary_parameters", mock_health_summary_parameters
@@ -89,6 +86,9 @@ class TestLabelIssueManager:
 
         # Test missing "joint" key
         mock_health_summary_parameters.pop("joint")
+        monkeypatch.setattr(
+            issue_manager.datalab._labels, "labels", mock_health_summary_parameters["labels"]
+        )
         monkeypatch.setattr(
             issue_manager, "health_summary_parameters", mock_health_summary_parameters
         )

--- a/tests/datalab/test_data.py
+++ b/tests/datalab/test_data.py
@@ -52,12 +52,12 @@ class TestData:
         assert data._data == dataset
 
         # All elements in the _labels attribute are integers in the range [0, num_classes - 1]
-        num_classes = len(set(data._label_map))
-        all_labels_are_ints = np.issubdtype(data._labels.dtype, np.integer)
-        assert all_labels_are_ints, f"{data._labels} should be a list of integers"
-        assert all(0 <= label < num_classes for label in data._labels)
+        num_classes = len(set(data.labels.label_map))
+        all_labels_are_ints = np.issubdtype(data.labels.labels.dtype, np.integer)
+        assert all_labels_are_ints, f"{data.labels.labels} should be a list of integers"
+        assert all(0 <= label < num_classes for label in data.labels.labels)
 
-        assert all(isinstance(label, int) for label in data._label_map.keys())
+        assert all(isinstance(label, int) for label in data.labels.label_map.keys())
 
     def test_init_data(self, dataset_and_label_name):
         dataset, label_name = dataset_and_label_name

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -879,7 +879,6 @@ class TestDatalabFindNearDuplicateIssues:
 
 
 class TestDatalabWithoutLabels:
-
     num_examples = 100
     num_features = 10
     K = 2

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -906,7 +906,7 @@ class TestDatalabWithoutLabels:
 
     def test_init(self, lab, features):
         assert np.array_equal(lab.data["X"], features)
-        assert lab.labels == []
+        assert np.array_equal(lab.labels, [])
 
     def test_find_issues(self, lab, features, pred_probs):
         lab = Datalab(data={"X": features})

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -93,7 +93,7 @@ class TestDatalab:
         for attr in ["data", "label_name", "_labels", "info", "issues"]:
             assert hasattr(lab, attr), f"Missing attribute {attr}"
 
-        assert all(lab._labels == np.array([1, 1, 2, 0, 2]))
+        assert all(lab.labels == np.array([1, 1, 2, 0, 2]))
         assert isinstance(lab.issues, pd.DataFrame), "Issues should by in a dataframe"
         assert isinstance(lab.issue_summary, pd.DataFrame), "Issue summary should be a dataframe"
 
@@ -876,3 +876,60 @@ class TestDatalabFindNearDuplicateIssues:
         assert "near_duplicate" in summary["issue_type"].values
         near_duplicate_summary = lab.get_issue_summary("near_duplicate")
         assert near_duplicate_summary["num_issues"].values[0] > 1
+
+
+class TestDatalabWithoutLabels:
+
+    num_examples = 100
+    num_features = 10
+    K = 2
+
+    @pytest.fixture
+    def features(self):
+        np.random.seed(SEED)
+        return np.random.rand(self.num_examples, self.num_features)
+
+    @pytest.fixture
+    def pred_probs(self):
+        np.random.seed(SEED)
+        pred_probs_array = np.random.rand(self.num_examples, self.K)
+        return pred_probs_array / pred_probs_array.sum(axis=1, keepdims=True)
+
+    @pytest.fixture
+    def lab(self, features):
+        return Datalab(data={"X": features})
+
+    @pytest.fixture
+    def labels(self):
+        np.random.seed(SEED)
+        return np.random.randint(0, self.K, self.num_examples)
+
+    def test_init(self, lab, features):
+        assert np.array_equal(lab.data["X"], features)
+        assert lab.labels == []
+
+    def test_find_issues(self, lab, features, pred_probs):
+        lab = Datalab(data={"X": features})
+        lab.find_issues(pred_probs=pred_probs)
+        assert lab.issues.empty
+
+        lab = Datalab(data={"X": features})
+        lab.find_issues(features=features)
+        assert not lab.issues.empty
+
+    def test_find_issues_features_works_with_and_without_labels(self, features, labels):
+        lab_without_labels = Datalab(data={"X": features})
+        lab_without_labels.find_issues(features=features)
+
+        lab_with_labels = Datalab(data={"X": features, "labels": labels}, label_name="labels")
+        lab_with_labels.find_issues(features=features)
+
+        lab_without_label_name = Datalab(data={"X": features, "labels": labels})
+        lab_without_label_name.find_issues(features=features)
+
+        issues_without_labels = lab_without_labels.issues
+        issues_with_labels = lab_with_labels.issues
+        issues_without_label_name = lab_without_label_name.issues
+
+        pd.testing.assert_frame_equal(issues_without_labels, issues_with_labels)
+        pd.testing.assert_frame_equal(issues_without_labels, issues_without_label_name)


### PR DESCRIPTION
In this PR, we make the `label_name` argument optional in the constructor of `Datalab`.

Some label logic (that used to reside in the `Data` class) has been extracted to a new `Label` class (working title).  I didn't bother to move it to a separate module (as it's only used by the `Data` class for now).

A new test class has been added, where we start testing Datalab instances with no labels.