### PR TITLE
Provide more tips on understanding issue types in datalab tutorial

### DIFF
--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -556,9 +556,7 @@
     "We create a `Datalab` object from the dataset, also providing the name of the label column in the dataset. Only instantiate one `Datalab` object per dataset, and note that only classification datasets are supported for now.\n",
     "\n",
     "All that is need to audit your data is to call `find_issues()`.\n",
-    "This method accepts various inputs like: predicted class probabilities, numeric feature representations of the data. The more information you provide here, the more thoroughly `Datalab` will audit your data! Note that `features` should be some numeric representation of each example, either obtained through preprocessing transformation of your raw data or embeddings from a (pre)trained model. In this case, our data is already entirely numeric so we just provide the features directly.\n",
-    "\n",
-    "`find_issues()` can be configured to find different types of issues, with more fine-grained control. Check out the [Issue Type Descriptions](../../cleanlab/datalab/guide/issue_type_description.html) page for more details."
+    "This method accepts various inputs like: predicted class probabilities, numeric feature representations of the data. The more information you provide here, the more thoroughly `Datalab` will audit your data! Note that `features` should be some numeric representation of each example, either obtained through preprocessing transformation of your raw data or embeddings from a (pre)trained model. In this case, our data is already entirely numeric so we just provide the features directly."
    ]
   },
   {
@@ -599,8 +597,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are several methods to get more details about a particular issue.\n",
+    "Datalab detects all sorts of issues in a dataset and what to do with the findings will vary case-by-case. For automated improvement of a dataset via best practices to handle auto-detected issues, try [Cleanlab Studio](https://cleanlab.ai/?utm_source=internal&utm_medium=blog&utm_campaign=clostostudio).\n",
     "\n",
+    "To conceptually understand how each type of issue is defined and what it means if detected in your data, check out the [Issue Type Descriptions](../../cleanlab/datalab/guide/issue_type_description.html) page. The [Datalab Issue Types](https://docs.cleanlab.ai/stable/cleanlab/datalab/guide/issue_type_description.html) page also lists additional types of issues that `Datalab.find_issues()` can detect, as well as optional parameters you can specify for greater control over how your data are checked.\n",  
+    "\n",
+    "Datalab offers several methods to understand more details about a particular issue in your dataset.\n",
     "The `get_issue_summary()` method fetches summary statistics regarding how severe each type of issue is overall across the whole dataset."
    ]
   },
@@ -633,7 +634,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `get_issues()` method returns information for each individual example about: whether or not it is plagued by this issue, as well as a *quality score* quantifying how severe this issue appears to be for that particular example. "
+    "The `get_issues()` method returns information for each individual example in the dataset including: whether or not it is plagued by this issue, as well as a *quality score* quantifying how severe this issue appears to be for this particular example. "
    ]
   },
   {
@@ -649,9 +650,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similar to above, we can pass the type of issue as a argument to `get_issues()` to get the information for that particular issue.\n",
+    "Similar to above, we can pass the type of issue as a argument to `get_issues()` to get the information for one particular issue.\n",
     "\n",
-    "Each example receives a separate *quality score* (betweeen 0 to 1) for each issue type. Lower scores indicate more severe instances of the issue, so you can sort by these values to see the most concerning examples in your dataset for each type of issue. The quality scores are directly comparable between examples/datasets, but not across different issue types. Here we show an example of how to get the examples that have been identified as having the most severe label issues."
+    "Each example receives a separate *quality score* (betweeen 0 to 1) for each issue type. Lower scores indicate more severe instances of the issue, so you can sort by these values to see the most concerning examples in your dataset for each type of issue. The quality scores are directly comparable between examples/datasets, but not across different issue types. Here we show an example of how to get the examples identified as having the most severe label issues."
    ]
   },
   {


### PR DESCRIPTION
I purposefully included two types of links to the [Datalab Issue Types](https://docs.cleanlab.ai/stable/cleanlab/datalab/guide/issue_type_description.html) page, because its nontrivial to get a link that will work for both stable & development version, as well as on docs.cleanlab.ai & local jupyter notebook / colab.

If you have other tips on how to better include a link we are sure will be optimal across all types of use-cases, please suggest!