### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -17,12 +17,13 @@ jobs:
           find . -name '*.html' -delete
       - run: |
           find . -name '*.md' -exec pandoc -i {} -o {}.html \;
-      - uses: anishathalye/proof-html@v1
+      - uses: anishathalye/proof-html@v2
         with:
           directory: .
+          check_html: false
           check_favicon: false
-          empty_alt_ignore: true
-          url_ignore_re: |
-            ^https:\/\/docs\.github\.com\/
-            ^https:\/\/github\.com\/cleanlab\/cleanlab\/projects
-            ^https:\/\/twitter.com\/CleanlabAI
+          ignore_missing_alt: true
+          tokens: |
+            {"https://github.com": "${{ secrets.GITHUB_TOKEN }}"}
+          swap_urls: |
+            {"^\.\/\(.*\).md": "\\1.md.html"}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -228,7 +228,7 @@ endings match the project style.
 ## Documentation
 
 You can build the docs from your local cleanlab version by following [these
-instructions](docs/README.md#build-the-cleanlab-docs-locally).
+instructions](./docs/README.md#build-the-cleanlab-docs-locally).
 
 If editing existing docs or adding new tutorials, please first read through our [guidelines](https://github.com/cleanlab/cleanlab/tree/master/docs#tips-for-editing-docstutorials).
 


### PR DESCRIPTION
Among other changes, this patch also disables HTML validation. This is a bit tricky to get right, because when the Markdown is processed by GitHub, it does some transformations that aren't mimicked by Pandoc. The result of converting the existing Markdown to HTML using Pandoc is in fact invalid HTML5.

The best way to fix this would be to use the [GitHub Markdown API](https://docs.github.com/en/rest/markdown) to render the Markdown, but that doesn't seem worth the effort right now. Instead, this patch just disables HTML validation but preserves the link checking functionality (and makes it start passing again).