### PR TITLE
Make sure CI flags any notebook cell exceptions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,7 @@ sys.path.insert(0, os.path.abspath("../../cleanlab"))
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here.
 import pathlib
+
 sys.path.insert(0, pathlib.Path(__file__).parents[2].resolve().as_posix())
 
 # -- Project information -----------------------------------------------------
@@ -46,7 +47,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinxcontrib.katex",
     "sphinx_autodoc_typehints",
-    'sphinx.ext.doctest',
+    "sphinx.ext.doctest",
 ]
 
 numpy_show_class_members = True
@@ -66,9 +67,6 @@ autosummary_generate = True
 
 # set the default role of `name` to make cross references
 default_role = "py:obj"
-
-# -- Options for doctest extension ---------------------------------------------
-nbsphinx_allow_errors = True  # to allow make doctest to run
 
 # -- Options for apidoc extension ----------------------------------------------
 


### PR DESCRIPTION
`nbsphinx_allow_errors` should not be `True` as it will not flag any potential errors in the notebooks and build/push docs regardless 

ref: https://nbsphinx.readthedocs.io/en/0.8.8/allow-errors.html