### PR TITLE
change inspect.getfullargspec to signature

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -676,7 +676,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             X = force_two_dimensions(X)
         if hasattr(self.clf, "score"):
             # Check if sample_weight in clf.score()
-            if "sample_weight" in inspect.signature(self.clf.fit).parameters:
+            if "sample_weight" in inspect.signature(self.clf.score).parameters:
                 return self.clf.score(X, y, sample_weight=sample_weight)
             else:
                 return self.clf.score(X, y)

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -470,7 +470,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             )
 
         if sample_weight is not None:
-            if "sample_weight" not in inspect.getfullargspec(self.clf.fit).args:
+            if "sample_weight" not in inspect.signature(self.clf.fit).parameters:
                 raise ValueError(
                     "sample_weight must be a supported fit() argument for your model in order to be specified here"
                 )
@@ -528,7 +528,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         if sample_weight is None:
             # Check if sample_weight in args of clf.fit()
             if (
-                "sample_weight" in inspect.getfullargspec(self.clf.fit).args
+                "sample_weight" in inspect.signature(self.clf.fit).parameters
                 and "sample_weight" not in self.clf_final_kwargs
                 and self.noise_matrix is not None
             ):
@@ -564,7 +564,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
                         print("Fitting final model on the clean data with custom sample_weight ...")
                     else:
                         if (
-                            "sample_weight" in inspect.getfullargspec(self.clf.fit).args
+                            "sample_weight" in inspect.signature(self.clf.fit).parameters
                             and self.noise_matrix is None
                         ):
                             print(
@@ -676,7 +676,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
             X = force_two_dimensions(X)
         if hasattr(self.clf, "score"):
             # Check if sample_weight in clf.score()
-            if "sample_weight" in inspect.getfullargspec(self.clf.score).args:
+            if "sample_weight" in inspect.signature(self.clf.fit).parameters:
                 return self.clf.score(X, y, sample_weight=sample_weight)
             else:
                 return self.clf.score(X, y)

--- a/cleanlab/regression/learn.py
+++ b/cleanlab/regression/learn.py
@@ -363,7 +363,7 @@ class CleanLearning(BaseEstimator):
             Number quantifying the performance of this regression model on the test data.
         """
         if hasattr(self.model, "score"):
-            if "sample_weight" in inspect.signature(self.model.fit).parameters:
+            if "sample_weight" in inspect.signature(self.model.score).parameters:
                 return self.model.score(X, y, sample_weight=sample_weight)
             else:
                 return self.model.score(X, y)

--- a/cleanlab/regression/learn.py
+++ b/cleanlab/regression/learn.py
@@ -265,7 +265,7 @@ class CleanLearning(BaseEstimator):
             )
 
         if sample_weight is not None:
-            if "sample_weight" not in inspect.getfullargspec(self.model.fit).args:
+            if "sample_weight" not in inspect.signature(self.model.fit).parameters:
                 raise ValueError(
                     "sample_weight must be a supported fit() argument for your model in order to be specified here"
                 )
@@ -363,7 +363,7 @@ class CleanLearning(BaseEstimator):
             Number quantifying the performance of this regression model on the test data.
         """
         if hasattr(self.model, "score"):
-            if "sample_weight" in inspect.getfullargspec(self.model.score).args:
+            if "sample_weight" in inspect.signature(self.model.fit).parameters:
                 return self.model.score(X, y, sample_weight=sample_weight)
             else:
                 return self.model.score(X, y)


### PR DESCRIPTION
sklearn's recent [v1.3 release](https://github.com/scikit-learn/scikit-learn/releases/tag/1.3.0) added decorators in some of the model's fit function (eg. [here](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/linear_model/_base.py#L650) in `linear_model`).

The `inspect.getfullargspec()` function we use to get the arguments of a function does not handle decorated functions properly (ref: https://github.com/joblib/joblib/issues/1164) and hence some checks are not working as intended in some `CleanLeaning` methods. Updating these methods to call `inspect.signature()` instead to better handle getting args from these decorated functions.