### PR TITLE
Fix links and link checker for Markdown files

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -26,4 +26,4 @@ jobs:
           tokens: |
             {"https://github.com": "${{ secrets.GITHUB_TOKEN }}"}
           swap_urls: |
-            {"^\.\/\(.*\).md": "\\1.md.html"}
+            {"^\(\..*\)\.md\(#?.*\)$": "\\1.md.html\\2"}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -230,7 +230,7 @@ endings match the project style.
 You can build the docs from your local cleanlab version by following [these
 instructions](./docs/README.md#build-the-cleanlab-docs-locally).
 
-If editing existing docs or adding new tutorials, please first read through our [guidelines](https://github.com/cleanlab/cleanlab/tree/master/docs#tips-for-editing-docstutorials).
+If editing existing docs or adding new tutorials, please first read through our [guidelines](./docs/README.md#tips-for-editing-docstutorials).
 
 
 ## Documentation style

--- a/docs/README.md
+++ b/docs/README.md
@@ -293,6 +293,6 @@ All of our tutorials are quickstart guides that should run quite fast. Longer/co
 
 ## API Documentation
 
-1. Verify your new docstrings adhere to our [documentation format guidelines](https://github.com/cleanlab/cleanlab/blob/master/DEVELOPMENT.md#documentation-style)
+1. Verify your new docstrings adhere to our [documentation format guidelines](../DEVELOPMENT.md#documentation-style)
 
 2. To ensure documentation for new source code files is linked from the main page, don't forget to update: **docs/source/index.rst**


### PR DESCRIPTION
This patch improves the regex so it matches paths starting with "../" and paths with hashes.