### PR TITLE
Segmentation docs fix

### DIFF
--- a/cleanlab/segmentation/filter.py
+++ b/cleanlab/segmentation/filter.py
@@ -44,14 +44,20 @@ def find_label_issues(
     * H - Height of each image
     * W - Width of each image
 
-    Tip: if you encounter the error "pred_probs is not defined", try setting ``n_jobs=1``.
+    Tip
+    ---
+    If you encounter the error "pred_probs is not defined", try setting ``n_jobs=1``.
 
     Parameters
     ----------
     labels:
       A discrete array of shape ``(N,H,W,)`` of noisy labels for a semantic segmentation dataset, i.e. some labels may be erroneous.
-      *Format requirements*: for a dataset with K classes, each pixel must be labeled using an integer in 0, 1, ..., K-1.
-      Tip: If your labels are one hot encoded you can do: ``labels = np.argmax(labels_one_hot,axis=1)`` assuming that `labels_one_hot` is of dimension ``(N,K,H,W)``, in order to get properly formatted `labels`
+
+      *Format requirements*: For a dataset with K classes, each pixel must be labeled using an integer in 0, 1, ..., K-1.
+
+      Tip
+      ---
+      If your labels are one hot encoded you can do: ``labels = np.argmax(labels_one_hot, axis=1)`` assuming that `labels_one_hot` is of dimension ``(N,K,H,W)``, in order to get properly formatted `labels`
 
     pred_probs:
       An array of shape ``(N,K,H,W,)`` of model-predicted class probabilities,

--- a/cleanlab/segmentation/filter.py
+++ b/cleanlab/segmentation/filter.py
@@ -57,7 +57,7 @@ def find_label_issues(
 
       Tip
       ---
-      If your labels are one hot encoded you can do: ``labels = np.argmax(labels_one_hot, axis=1)`` assuming that `labels_one_hot` is of dimension ``(N,K,H,W)``, in order to get properly formatted `labels`
+      If your labels are one hot encoded you can do: ``labels = np.argmax(labels_one_hot, axis=1)`` assuming that `labels_one_hot` is of dimension ``(N,K,H,W)``, in order to get properly formatted `labels`.
 
     pred_probs:
       An array of shape ``(N,K,H,W,)`` of model-predicted class probabilities,

--- a/cleanlab/segmentation/rank.py
+++ b/cleanlab/segmentation/rank.py
@@ -48,21 +48,22 @@ def get_label_quality_scores(
     Parameters
     ----------
     labels:
-      A discrete array of noisy labels for a segmantic segmentation dataset, in the shape``(N,H,W,)``.
+      A discrete array of noisy labels for a segmantic segmentation dataset, in the shape ``(N,H,W,)``,
       where each pixel must be integer in 0, 1, ..., K-1.
-      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segmentation.filter.find_label_issues> for further details.
+      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for further details.
 
     pred_probs:
       An array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
-      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segmentation.filter.find_label_issues> for further details.
+      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for further details.
 
     method: {"softmin", "num_pixel_issues"}, default="softmin"
       Label quality scoring method.
+
       - "softmin" - Calculates the inner product between scores and softmax(1-scores). For efficiency, use instead of "num_pixel_issues".
-      - "num_pixel_issues" - Uses the number of pixels with label issues for each image using :py:func:find_label_issues <cleanlab.segmentation.filter.find_label_issues>
+      - "num_pixel_issues" - Uses the number of pixels with label issues for each image using :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>`
 
     batch_size :
-      Optional size of mini-batches to use for estimating the label issues for 'num_pixel_issues' only, not 'softmin'
+      Optional size of mini-batches to use for estimating the label issues for 'num_pixel_issues' only, not 'softmin'.
       To maximize efficiency, try to use the largest `batch_size` your memory allows. If not provided, a good default is used.
 
     n_jobs:
@@ -151,11 +152,10 @@ def issues_from_scores(
     Only considers as issues those tokens with label quality score lower than `threshold`,
     so this parameter determines the number of issues that are returned.
 
-    Note: This method is intended for converting the most severely mislabeled examples to a format compatible with
-    ``summary`` methods like :py:func:`segmentation.summary.display_issues <cleanlab.segmentation.summary.display_issues>`.
-    This method does not estimate the number of label errors since the `threshold` is arbitrary,
-    for that instead use :py:func:`segmentation.filter.find_label_issues <cleanlab.segmentation.filter.find_label_issues>`,
-    which estimates the label errors via Confident Learning rather than score thresholding.
+    Note
+    ----
+    - This method is intended for converting the most severely mislabeled examples into a format compatible with ``summary`` methods like :py:func:`segmentation.summary.display_issues <cleanlab.segmentation.summary.display_issues>`.
+    - This method does not estimate the number of label errors since the `threshold` is arbitrary, for that instead use :py:func:`segmentation.filter.find_label_issues <cleanlab.segmentation.filter.find_label_issues>`, which estimates the label errors via Confident Learning rather than score thresholding.
 
     Parameters
     ----------

--- a/cleanlab/segmentation/rank.py
+++ b/cleanlab/segmentation/rank.py
@@ -50,16 +50,16 @@ def get_label_quality_scores(
     labels:
       A discrete array of noisy labels for a segmantic segmentation dataset, in the shape``(N,H,W,)``.
       where each pixel must be integer in 0, 1, ..., K-1.
-      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segemntation.filter.find_label_issues> for further details.
+      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segmentation.filter.find_label_issues> for further details.
 
     pred_probs:
       An array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
-      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segemntation.filter.find_label_issues> for further details.
+      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segmentation.filter.find_label_issues> for further details.
 
     method: {"softmin", "num_pixel_issues"}, default="softmin"
       Label quality scoring method.
       - "softmin" - Calculates the inner product between scores and softmax(1-scores). For efficiency, use instead of "num_pixel_issues".
-      - "num_pixel_issues" - Uses the number of pixels with label issues for each image using :py:func:find_label_issues <cleanlab.segemntation.filter.find_label_issues>
+      - "num_pixel_issues" - Uses the number of pixels with label issues for each image using :py:func:find_label_issues <cleanlab.segmentation.filter.find_label_issues>
 
     batch_size :
       Optional size of mini-batches to use for estimating the label issues for 'num_pixel_issues' only, not 'softmin'

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -55,12 +55,12 @@ def display_issues(
       Optional discrete array of noisy labels for a segmantic segmentation dataset, in the shape``(N,H,W,)``.
       where each pixel must be integer in 0, 1, ..., K-1.
       If `labels` is provided, this function also displays given label of the pixel identified with issue.
-      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segmentation.filter.find_label_issues> for more information.
+      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
 
     pred_probs:
       Optional array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
       If `pred_probs` is provided, this function also displays predicted label of the pixel identified with issue.
-      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segmentation.filter.find_label_issues> for more information.
+      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
 
       Tip: If your labels are one hot encoded you can `np.argmax(labels_one_hot,axis=1)` assuming that `labels_one_hot` is of dimension (N,K,H,W)
       before entering in the function

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -55,12 +55,12 @@ def display_issues(
       Optional discrete array of noisy labels for a segmantic segmentation dataset, in the shape``(N,H,W,)``.
       where each pixel must be integer in 0, 1, ..., K-1.
       If `labels` is provided, this function also displays given label of the pixel identified with issue.
-      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segemntation.filter.find_label_issues> for more information.
+      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segmentation.filter.find_label_issues> for more information.
 
     pred_probs:
       Optional array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
       If `pred_probs` is provided, this function also displays predicted label of the pixel identified with issue.
-      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segemntation.filter.find_label_issues> for more information.
+      Refer to documentation for this argument in :py:func:find_label_issues <cleanlab.segmentation.filter.find_label_issues> for more information.
 
       Tip: If your labels are one hot encoded you can `np.argmax(labels_one_hot,axis=1)` assuming that `labels_one_hot` is of dimension (N,K,H,W)
       before entering in the function
@@ -190,11 +190,11 @@ def common_label_issues(
     labels:
       A discrete array of noisy labels for a segmantic segmentation dataset, in the shape``(N,H,W,)``.
       where each pixel must be integer in 0, 1, ..., K-1.
-      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segemntation.filter.find_label_issues>` for more information.
+      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
 
     pred_probs:
       An array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
-      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segemntation.filter.find_label_issues>` for more information.
+      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
 
       Tip: If your labels are one hot encoded you can `np.argmax(labels_one_hot,axis=1)` assuming that `labels_one_hot` is of dimension (N,K,H,W)
       before entering in the function
@@ -284,11 +284,11 @@ def filter_by_class(
     labels:
       A discrete array of noisy labels for a segmantic segmentation dataset, in the shape``(N,H,W,)``.
       where each pixel must be integer in 0, 1, ..., K-1.
-      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segemntation.filter.find_label_issues>` for further details.
+      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for further details.
 
     pred_probs:
       An array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
-      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segemntation.filter.find_label_issues>` for further details.
+      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for further details.
 
     Returns
     ----------

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -222,8 +222,9 @@ def common_label_issues(
     Returns
     -------
     issues_df:
-      DataFrame containing columns ``['given_label', 'predicted_label', 'num_label_issues']`` and each row contains information for a
-      given/predicted label swap, ordered by the number of label issues inferred for this type of label swap.
+      DataFrame with columns ``['given_label', 'predicted_label', 'num_label_issues']``
+      where each row contains information about a particular given/predicted label swap.
+      Rows are ordered by the number of label issues inferred to exhibit this type of label swap.
     """
     try:
         N, K, H, W = pred_probs.shape

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -52,7 +52,7 @@ def display_issues(
       or :py:func:`segmentation.rank.issues_from_scores <cleanlab.segmentation.rank.issues_from_scores>`.
 
     labels:
-      Optional discrete array of noisy labels for a segmantic segmentation dataset, in the shape``(N,H,W,)``.
+      Optional discrete array of noisy labels for a segmantic segmentation dataset, in the shape ``(N,H,W,)``,
       where each pixel must be integer in 0, 1, ..., K-1.
       If `labels` is provided, this function also displays given label of the pixel identified with issue.
       Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
@@ -62,7 +62,9 @@ def display_issues(
       If `pred_probs` is provided, this function also displays predicted label of the pixel identified with issue.
       Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
 
-      Tip: If your labels are one hot encoded you can `np.argmax(labels_one_hot,axis=1)` assuming that `labels_one_hot` is of dimension (N,K,H,W)
+      Tip
+      ---
+      If your labels are one hot encoded you can `np.argmax(labels_one_hot, axis=1)` assuming that `labels_one_hot` is of dimension (N,K,H,W)
       before entering in the function
 
     class_names:
@@ -73,8 +75,11 @@ def display_issues(
       showing the color mapping of each class in the provided colormap.
 
       Example:
-        If there are three classes in your labels, represented by 0, 1, 2, then class_names might look like this:
-        class_names = ['background', 'person', 'dog']
+      If there are three classes in your labels, represented by 0, 1, 2, then class_names might look like this:
+
+      .. code-block:: python
+
+            class_names = ['background', 'person', 'dog']
 
     top:
         Optional maximum number of issues to be printed. If not provided, a good default is used.
@@ -188,7 +193,7 @@ def common_label_issues(
       or :py:func:`segmentation.rank.issues_from_scores <cleanlab.segmentation.rank.issues_from_scores>`.
 
     labels:
-      A discrete array of noisy labels for a segmantic segmentation dataset, in the shape``(N,H,W,)``.
+      A discrete array of noisy labels for a segmantic segmentation dataset, in the shape ``(N,H,W,)``.
       where each pixel must be integer in 0, 1, ..., K-1.
       Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
 
@@ -196,7 +201,9 @@ def common_label_issues(
       An array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
       Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
 
-      Tip: If your labels are one hot encoded you can `np.argmax(labels_one_hot,axis=1)` assuming that `labels_one_hot` is of dimension (N,K,H,W)
+      Tip
+      ---
+      If your labels are one hot encoded you can `np.argmax(labels_one_hot, axis=1)` assuming that `labels_one_hot` is of dimension (N,K,H,W)
       before entering in the function
 
     class_names:
@@ -215,7 +222,7 @@ def common_label_issues(
     Returns
     -------
     issues_df:
-      DataFrame `issues_df` contains columns ``['given_label', 'predicted_label', 'num_label_issues']`` and each row contains information for a
+      DataFrame containing columns ``['given_label', 'predicted_label', 'num_label_issues']`` and each row contains information for a
       given/predicted label swap, ordered by the number of label issues inferred for this type of label swap.
     """
     try:
@@ -282,7 +289,7 @@ def filter_by_class(
       or :py:func:`segmentation.rank.issues_from_scores <cleanlab.segmentation.rank.issues_from_scores>`.
 
     labels:
-      A discrete array of noisy labels for a segmantic segmentation dataset, in the shape``(N,H,W,)``.
+      A discrete array of noisy labels for a segmantic segmentation dataset, in the shape ``(N,H,W,)``,
       where each pixel must be integer in 0, 1, ..., K-1.
       Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for further details.
 


### PR DESCRIPTION
- Some internal links were broken. Should be fixed now.


- Use special block for tips:

![image](https://github.com/cleanlab/cleanlab/assets/18127060/cd8614df-00ae-4e00-88f5-1ad8aa80f60a)

- Format class_names example as a code block:
![image](https://github.com/cleanlab/cleanlab/assets/18127060/95d5cefc-4e6a-47de-849e-8340a33a60a4)


- Put note in a block
![image](https://github.com/cleanlab/cleanlab/assets/18127060/45629b93-d007-44ef-bb4b-f45733d6eff0)
