### PR TITLE
Update near-duplicate sets

### DIFF
--- a/cleanlab/datalab/issue_manager/duplicate.py
+++ b/cleanlab/datalab/issue_manager/duplicate.py
@@ -135,6 +135,15 @@ class NearDuplicateIssueManager(IssueManager):
         indices = knn_graph.indices[mask.ravel()]
         near_duplicate_sets = [indices[indptr[i] : indptr[i + 1]] for i in range(N)]
 
+        # Second pass over the data is required to ensure each item is included in the near-duplicate sets of its own near-duplicates.
+        # This is important because a "near-duplicate" relationship is reciprocal.
+        # For example, if item A is a near-duplicate of item B, then item B should also be considered a near-duplicate of item A.
+        # NOTE: This approach does not assure that the sets are ordered by increasing distance.
+        for i, near_duplicates in enumerate(near_duplicate_sets):
+            for j in near_duplicates:
+                if i not in near_duplicate_sets[j]:
+                    near_duplicate_sets[j] = np.append(near_duplicate_sets[j], i)
+
         return near_duplicate_sets
 
     def _process_knn_graph_from_inputs(self, kwargs: Dict[str, Any]) -> Union[csr_matrix, None]:

--- a/cleanlab/datalab/issue_manager/duplicate.py
+++ b/cleanlab/datalab/issue_manager/duplicate.py
@@ -113,7 +113,7 @@ class NearDuplicateIssueManager(IssueManager):
         self.info = self.collect_info(knn_graph=knn_graph)
 
     @staticmethod
-    def _neighbors_within_radius(knn_graph: csr_matrix, radius: float):
+    def _neighbors_within_radius(knn_graph: csr_matrix, threshold: float):
         """Returns a list of lists of indices of near-duplicate examples.
 
         Each list of indices represents a set of near-duplicate examples.
@@ -125,7 +125,7 @@ class NearDuplicateIssueManager(IssueManager):
         N = knn_graph.shape[0]
         distances = knn_graph.data.reshape(N, -1)
         # Create a mask for the threshold
-        mask = distances < radius
+        mask = distances < threshold * np.median(distances[:, 0])
 
         # Update the indptr to reflect the new number of neighbors
         indptr = np.zeros(knn_graph.indptr.shape, dtype=knn_graph.indptr.dtype)

--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -1,9 +1,33 @@
 import numpy as np
 import pytest
+from hypothesis import given, strategies as st
+from hypothesis.strategies import composite
+from hypothesis.extra.numpy import arrays
 
+
+from cleanlab import Datalab
 from cleanlab.datalab.issue_manager.duplicate import NearDuplicateIssueManager
 
 SEED = 42
+
+
+@composite
+def embeddings_strategy(draw):
+    shape_strategy = st.tuples(
+        st.integers(min_value=3, max_value=20), st.integers(min_value=2, max_value=2)
+    )
+    element_strategy = st.floats(
+        min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+    )
+    embeddings = draw(
+        arrays(
+            dtype=np.float64,
+            shape=shape_strategy,
+            elements=element_strategy,
+            unique=True,
+        )
+    )
+    return embeddings
 
 
 class TestNearDuplicateIssueManager:
@@ -80,3 +104,49 @@ class TestNearDuplicateIssueManager:
             verbosity=3,
         )
         assert "Additional Information: " in report
+
+    @given(embeddings=embeddings_strategy())
+    def test_near_duplicates_are_symmetric(self, embeddings):
+
+        data = {"metadata": ["" for _ in range(len(embeddings))]}
+        lab = Datalab(data)
+        issue_manager = NearDuplicateIssueManager(
+            datalab=lab,
+            metric="euclidean",
+            k=2,
+        )
+        embeddings = np.array(embeddings)
+        issue_manager.find_issues(features=embeddings)
+        near_duplicate_sets = issue_manager.info["near_duplicate_sets"]
+        all_symmetric = all(
+            i in near_duplicate_sets[j]
+            for i, near_duplicates in enumerate(near_duplicate_sets)
+            for j in near_duplicates
+        )
+        assert all_symmetric, "Some near duplicate sets are not symmetric"
+
+    @given(embeddings=embeddings_strategy())
+    def test_near_duplicate_sets_for_issues(self, embeddings):
+        data = {"metadata": ["" for _ in range(len(embeddings))]}
+        lab = Datalab(data)
+        issue_manager = NearDuplicateIssueManager(
+            datalab=lab,
+            metric="euclidean",
+            k=2,
+        )
+        embeddings = np.array(embeddings)
+        issue_manager.find_issues(features=embeddings)
+        issues = issue_manager.issues["is_near_duplicate_issue"]
+        near_duplicate_sets = issue_manager.info["near_duplicate_sets"]
+
+        # if an example is not a near duplicate issue, then the near_duplicate_set should be empty and vice versa
+        assert all(
+            len(near_duplicate_set) == 0
+            for i, near_duplicate_set in enumerate(near_duplicate_sets)
+            if not issues[i]
+        ), "Non-issue examples should not have near duplicate sets"
+        assert all(
+            len(near_duplicate_set) > 0
+            for i, near_duplicate_set in enumerate(near_duplicate_sets)
+            if issues[i]
+        ), "Issue examples should have near duplicate sets"

--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -106,8 +106,7 @@ class TestNearDuplicateIssueManager:
         assert "Additional Information: " in report
 
     @given(embeddings=embeddings_strategy())
-    def test_near_duplicates_are_symmetric(self, embeddings):
-
+    def test_near_duplicate_sets(self, embeddings):
         data = {"metadata": ["" for _ in range(len(embeddings))]}
         lab = Datalab(data)
         issue_manager = NearDuplicateIssueManager(
@@ -118,6 +117,9 @@ class TestNearDuplicateIssueManager:
         embeddings = np.array(embeddings)
         issue_manager.find_issues(features=embeddings)
         near_duplicate_sets = issue_manager.info["near_duplicate_sets"]
+        issues = issue_manager.issues["is_near_duplicate_issue"]
+
+        # Test: Near duplicates are symmetric
         all_symmetric = all(
             i in near_duplicate_sets[j]
             for i, near_duplicates in enumerate(near_duplicate_sets)
@@ -125,21 +127,7 @@ class TestNearDuplicateIssueManager:
         )
         assert all_symmetric, "Some near duplicate sets are not symmetric"
 
-    @given(embeddings=embeddings_strategy())
-    def test_near_duplicate_sets_for_issues(self, embeddings):
-        data = {"metadata": ["" for _ in range(len(embeddings))]}
-        lab = Datalab(data)
-        issue_manager = NearDuplicateIssueManager(
-            datalab=lab,
-            metric="euclidean",
-            k=2,
-        )
-        embeddings = np.array(embeddings)
-        issue_manager.find_issues(features=embeddings)
-        issues = issue_manager.issues["is_near_duplicate_issue"]
-        near_duplicate_sets = issue_manager.info["near_duplicate_sets"]
-
-        # if an example is not a near duplicate issue, then the near_duplicate_set should be empty and vice versa
+        # Test: Near duplicate sets for issues
         assert all(
             len(near_duplicate_set) == 0
             for i, near_duplicate_set in enumerate(near_duplicate_sets)

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -858,6 +858,28 @@ class TestDatalabFindNearDuplicateIssues:
         return X
 
     @pytest.fixture
+    def fixed_embeddings(self):
+        near_duplicate_scale = 0.0001
+        non_duplicate_scale = 100
+        X = np.array(
+            [[0, 0]] * 4  # Points with 3 exact duplicates
+            + [[1, 1]] * 2  # Points with 1 exact duplicate
+            + [[1, 0]] * 3
+            + [[1 + near_duplicate_scale, 0]]
+            + [
+                [1, 0 + near_duplicate_scale]
+            ]  # Points with 2 exact duplicates and 2 near duplicates
+            + [
+                [-1, -1] + np.random.rand(2) * near_duplicate_scale for _ in range(5)
+            ]  # Points with 5 near duplicates
+            + [
+                [-1, 0] + np.random.rand(2) * near_duplicate_scale for _ in range(2)
+            ]  # Points with 1 near duplicate
+            + (np.random.rand(20, 2) * non_duplicate_scale).tolist()  # Random points
+        )
+        return X
+
+    @pytest.fixture
     def pred_probs(self):
         np.random.seed(SEED)
         pred_probs_array = np.random.rand(100, 2)
@@ -876,6 +898,66 @@ class TestDatalabFindNearDuplicateIssues:
         assert "near_duplicate" in summary["issue_type"].values
         near_duplicate_summary = lab.get_issue_summary("near_duplicate")
         assert near_duplicate_summary["num_issues"].values[0] > 1
+
+    def test_fixed_embeddings_outputs(self, fixed_embeddings):
+        lab = Datalab(data={"a": ["" for _ in range(len(fixed_embeddings))]})
+        lab.find_issues(features=fixed_embeddings, issue_types={"near_duplicate": {}})
+        issues = lab.get_issues("near_duplicate")
+
+        assert issues["is_near_duplicate_issue"].sum() == 18
+        assert all(
+            issues["is_near_duplicate_issue"].values
+            == [True] * 18 + [False] * (len(fixed_embeddings) - 18)
+        )
+
+        # Test the first set of near duplicates (only 3 exact duplicates)
+        near_duplicate_sets = issues["near_duplicate_sets"].values
+
+        expected_near_duplicate_sets = np.array(
+            [
+                # 3 exact duplicates
+                np.array([3, 1, 2]),
+                np.array([0, 3, 2]),
+                np.array([0, 3, 1]),
+                np.array([0, 1, 2]),
+                # 1 exact duplicate
+                np.array([5]),
+                np.array([4]),
+                # 2 exact duplicates and 2 near duplicates
+                np.array([8, 7, 9, 10]),
+                np.array([8, 6, 9, 10]),
+                np.array([6, 7, 9, 10]),
+                np.array([8, 6, 7, 10]),
+                np.array([7, 8, 6, 9]),
+                # 4 near duplicates
+                np.array([15, 13, 14, 12]),
+                np.array([13, 14, 15, 11]),
+                np.array([14, 12, 15, 11]),
+                np.array([13, 12, 15, 11]),
+                np.array([11, 13, 14, 12]),
+                # 1 near duplicate
+                np.array([17]),
+                np.array([16]),
+            ]
+            +
+            # Random points
+            [np.array([])] * 20,
+            dtype=object,
+        )
+
+        # Exact duplicates may have arbitrary order, so sort the sets before comparing
+        equal_sets = [
+            np.array_equal(sorted(a), sorted(b))
+            for a, b in zip(near_duplicate_sets, expected_near_duplicate_sets)
+        ]
+        assert all(equal_sets)
+
+        # Assert self-idx is not included in near duplicate sets
+        assert all([i not in s for i, s in enumerate(near_duplicate_sets)])
+
+        # Assert near duplicate sets are unique, ignoring empty sets
+        unique_non_empty_sets = [tuple(s) for s in near_duplicate_sets if len(s) > 0]
+        assert len(set(unique_non_empty_sets)) == 18
 
 
 class TestDatalabWithoutLabels:


### PR DESCRIPTION
After this PR:
- Examples that are not flagged with `is_near_duplicate_issue = True` will have an empty near-duplicate set.
- The near-duplicates are now symmetric.