### PR TITLE
Swap import order for speechbrain and tensorflow

### DIFF
--- a/docs/source/tutorials/audio.ipynb
+++ b/docs/source/tutorials/audio.ipynb
@@ -65,7 +65,7 @@
     "You can use `pip` to install all packages required for this tutorial as follows:\n",
     "\n",
     "```ipython3\n",
-    "!pip install speechbrain==0.5.12 tensorflow==2.9.1 sklearn tensorflow_io==0.26.0 huggingface_hub==0.7.0\n",
+    "!pip install tensorflow==2.9.1 sklearn tensorflow_io==0.26.0 huggingface_hub==0.7.0 speechbrain==0.5.12 \n",
     "!pip install \"cleanlab[datalab]\"\n",
     "# Make sure to install the version corresponding to this tutorial\n",
     "# E.g. if viewing master branch documentation:\n",
@@ -82,9 +82,9 @@
    "outputs": [],
    "source": [
     "# Package installation (hidden on docs website).\n",
-    "# Package versions used: tensorflow==2.9.1 speechbrain==0.5.12 tensorflow-io==0.26.0 torch==1.11.0 torchaudio==0.11.0\n",
+    "# Package versions used: tensorflow==2.9.1 tensorflow-io==0.26.0 torch==1.11.0 torchaudio==0.11.0 speechbrain==0.5.12\n",
     "\n",
-    "dependencies = [\"cleanlab\", \"sklearn\", \"speechbrain==0.5.12\", \"tensorflow==2.9.1\", \"tensorflow_io==0.26.0\", \"huggingface_hub==0.7.0\", \"datasets\"]\n",
+    "dependencies = [\"cleanlab\", \"sklearn\", \"tensorflow==2.9.1\", \"tensorflow_io==0.26.0\", \"huggingface_hub==0.7.0\", \"speechbrain==0.5.12\", \"datasets\"]\n",
     "\n",
     "# Supress outputs that may appear if tensorflow happens to be improperly installed: \n",
     "import os \n",
@@ -774,7 +774,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Importing `speechbrain` before `tensorflow` crashes the kernel in the audio tutorial for some reason, this fixes it