### PR TITLE
Fix bad indexing

### DIFF
--- a/cleanlab/object_detection/rank.py
+++ b/cleanlab/object_detection/rank.py
@@ -747,13 +747,14 @@ def _compute_badloc_box_scores_for_image(
             scores_badloc[iid] = 1.0
             continue
 
-        idx_at_least_low_probability_threshold = np.where(k_pred > low_probability_threshold)[0]
-        idx_at_least_intersection_threshold = np.where(k_iou > 0)[0]
+        mask_at_least_low_probability_threshold = k_pred > low_probability_threshold
+        mask_at_least_intersection_threshold = k_iou > 0
+        idxs = np.where(
+            mask_at_least_low_probability_threshold & mask_at_least_intersection_threshold
+        )
 
-        k_similarity = k_similarity[idx_at_least_low_probability_threshold][
-            idx_at_least_intersection_threshold
-        ]
-        k_pred = k_pred[idx_at_least_low_probability_threshold][idx_at_least_intersection_threshold]
+        k_similarity = k_similarity[idxs]
+        k_pred = k_pred[idxs]
 
         scores_badloc[iid] = np.max(k_similarity) if len(k_pred) > 0 else 1.0
     return scores_badloc


### PR DESCRIPTION
Indexing in this code block seems incorrect.

Example:
```python3
k_similarity.shape  # (15,)
idx_at_least_low_probability_threshold = [0, 1, 2, 3, 4]
idx_at_least_intersection_threshold = [0,  3,  6,  8, 10, 11, 12]

# then
k_similarity[idx_at_least_low_probability_threshold].shape  # (5,)
k_similarity[idx_at_least_low_probability_threshold][idx_at_least_intersection_threshold]  # error
```

This is because `k_similarity[idx_at_least_low_probability_threshold]` has 5 elements but third element of `idx_at_least_intersection_threshold` is 6, so indexing fails.

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/pdb.py", line 1723, in main
    pdb._runscript(mainpyfile)
  File "/usr/lib/python3.10/pdb.py", line 1583, in _runscript
    self.run(statement)
  File "/usr/lib/python3.10/bdb.py", line 598, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/home/kchachula/safednn-demo/scripts/ecleanlab.py", line 57, in <module>
    scores = get_label_quality_scores(labels, predictions)
  File "/home/kchachula/safednn-demo/venv/lib/python3.10/site-packages/cleanlab/object_detection/rank.py", line 132, in get_label_quality_scores
    return _compute_label_quality_scores(
  File "/home/kchachula/safednn-demo/venv/lib/python3.10/site-packages/cleanlab/object_detection/rank.py", line 202, in _compute_label_quality_scores
    scores = _get_subtype_label_quality_scores(
  File "/home/kchachula/safednn-demo/venv/lib/python3.10/site-packages/cleanlab/object_detection/rank.py", line 1092, in _get_subtype_label_quality_scores
    badloc_scores_per_box = compute_badloc_box_scores(
  File "/home/kchachula/safednn-demo/venv/lib/python3.10/site-packages/cleanlab/object_detection/rank.py", line 830, in compute_badloc_box_scores
    scores_badloc_per_box = _compute_badloc_box_scores_for_image(
  File "/home/kchachula/safednn-demo/venv/lib/python3.10/site-packages/cleanlab/object_detection/rank.py", line 753, in _compute_badloc_box_scores_for_image
    k_similarity = k_similarity[idx_at_least_low_probability_threshold][
IndexError: index 6 is out of bounds for axis 0 with size 5
```