### PR TITLE
Catch specific exception for knn in datalab issue managers

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/duplicate.py
+++ b/cleanlab/datalab/internal/issue_manager/duplicate.py
@@ -22,6 +22,7 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
 from sklearn.neighbors import NearestNeighbors
+from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
 
 from cleanlab.datalab.internal.issue_manager import IssueManager
@@ -91,7 +92,7 @@ class NearDuplicateIssueManager(IssueManager):
 
             try:
                 check_is_fitted(knn)
-            except:
+            except NotFittedError:
                 knn.fit(features)
 
             knn_graph = knn.kneighbors_graph(mode="distance")

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
 from sklearn.neighbors import NearestNeighbors
+from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
 
 from cleanlab.datalab.internal.issue_manager import IssueManager
@@ -89,9 +90,9 @@ class NonIIDIssueManager(IssueManager):
     description: ClassVar[
         str
     ] = """Whether the dataset exhibits statistically significant
-    violations of the IID assumption like: 
+    violations of the IID assumption like:
     changepoints or shift, drift, autocorrelation, etc.
-    The specific violation considered is whether the 
+    The specific violation considered is whether the
     examples are ordered such that almost adjacent examples
     tend to have more similar feature values.
     """
@@ -150,7 +151,7 @@ class NonIIDIssueManager(IssueManager):
 
             try:
                 check_is_fitted(knn)
-            except:
+            except NotFittedError:
                 knn.fit(features)
 
             self.neighbor_index_choices = self._get_neighbors(knn=knn)


### PR DESCRIPTION
Mimic exception handling performed in [outlier.py](https://github.com/cleanlab/cleanlab/blob/0adce8290fbe7527cc9c7d3652da6ed68cc5afc4/cleanlab/outlier.py#L434-L437) for duplicate and non-iid issue managers