### PR TITLE
Fix Imbalance Score: Use rare class proportion instead of mean score

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -60,8 +60,9 @@ class ClassImbalanceIssueManager(IssueManager):
         labels = self.datalab.labels
         K = len(self.datalab.class_names)
         class_probs = np.bincount(labels) / len(labels)
-        imbalance_exists = class_probs.min() < self.threshold * (1 / K)
-        rarest_class = int(np.argmin(class_probs)) if imbalance_exists else -1
+        rarest_class_idx = int(np.argmin(class_probs))
+        imbalance_exists = class_probs[rarest_class_idx] < self.threshold * (1 / K)
+        rarest_class = rarest_class_idx if imbalance_exists else -1
         is_issue_column = labels == rarest_class
         scores = np.where(is_issue_column, class_probs[rarest_class], 1)
 
@@ -71,7 +72,7 @@ class ClassImbalanceIssueManager(IssueManager):
                 self.issue_score_key: scores,
             },
         )
-        self.summary = self.make_summary(score=scores.mean())
+        self.summary = self.make_summary(score=class_probs[rarest_class_idx])
         self.info = self.collect_info()
 
     def collect_info(self) -> dict:

--- a/tests/datalab/issue_manager/test_imbalance.py
+++ b/tests/datalab/issue_manager/test_imbalance.py
@@ -53,7 +53,7 @@ class TestClassImbalanceIssueManager:
         ), "Issue mask should be correct"
         assert np.all(issues["class_imbalance_score"] == np.ones(N)), "Scores should be correct"
         assert summary["issue_type"][0] == "class_imbalance"
-        assert summary["score"][0] == pytest.approx(expected=0.45, abs=1e-7)
+        assert summary["score"][0] == pytest.approx(expected=0.47, abs=1e-7)
 
     def test_find_issues_more_imbalance(self, lab, labels, create_issue_manager):
         K = lab.get_info("statistics")["num_classes"]

--- a/tests/datalab/issue_manager/test_imbalance.py
+++ b/tests/datalab/issue_manager/test_imbalance.py
@@ -39,7 +39,7 @@ class TestClassImbalanceIssueManager:
             issues["class_imbalance_score"], expected_scores, err_msg="Scores should be correct"
         )
         assert summary["issue_type"][0] == "class_imbalance"
-        assert summary["score"][0] == pytest.approx(expected=0.01, abs=1e-7)
+        assert summary["score"][0] == 0.01
 
     def test_find_issues_no_imbalance(self, labels, create_issue_manager):
         N = len(labels)
@@ -53,7 +53,7 @@ class TestClassImbalanceIssueManager:
         ), "Issue mask should be correct"
         assert np.all(issues["class_imbalance_score"] == np.ones(N)), "Scores should be correct"
         assert summary["issue_type"][0] == "class_imbalance"
-        assert summary["score"][0] == pytest.approx(expected=0.47, abs=1e-7)
+        assert summary["score"][0] == 0.47
 
     def test_find_issues_more_imbalance(self, lab, labels, create_issue_manager):
         K = lab.get_info("statistics")["num_classes"]
@@ -73,7 +73,7 @@ class TestClassImbalanceIssueManager:
             issues["class_imbalance_score"], expected_scores, err_msg="Scores should be correct"
         )
         assert summary["issue_type"][0] == "class_imbalance"
-        assert summary["score"][0] == pytest.approx(expected=0.01, abs=1e-7)
+        assert summary["score"][0] == 0.01
 
     def test_report(self, create_issue_manager):
         issue_manager = create_issue_manager()

--- a/tests/datalab/issue_manager/test_imbalance.py
+++ b/tests/datalab/issue_manager/test_imbalance.py
@@ -38,7 +38,7 @@ class TestClassImbalanceIssueManager:
             issues["class_imbalance_score"], expected_scores, err_msg="Scores should be correct"
         )
         assert summary["issue_type"][0] == "class_imbalance"
-        assert summary["score"][0] == pytest.approx(expected=0.9900999, abs=1e-7)
+        assert summary["score"][0] == pytest.approx(expected=0.01, abs=1e-7)
 
     def test_find_issues_no_imbalance(self, labels, create_issue_manager):
         N = len(labels)
@@ -52,7 +52,7 @@ class TestClassImbalanceIssueManager:
         ), "Issue mask should be correct"
         assert np.all(issues["class_imbalance_score"] == np.ones(N)), "Scores should be correct"
         assert summary["issue_type"][0] == "class_imbalance"
-        assert summary["score"][0] == pytest.approx(expected=1.0, abs=1e-7)
+        assert summary["score"][0] == pytest.approx(expected=0.45, abs=1e-7)
 
     def test_find_issues_more_imbalance(self, lab, labels, create_issue_manager):
         K = lab.get_info("statistics")["num_classes"]
@@ -72,7 +72,7 @@ class TestClassImbalanceIssueManager:
             issues["class_imbalance_score"], expected_scores, err_msg="Scores should be correct"
         )
         assert summary["issue_type"][0] == "class_imbalance"
-        assert summary["score"][0] == pytest.approx(expected=0.9900999, abs=1e-7)
+        assert summary["score"][0] == pytest.approx(expected=0.01, abs=1e-7)
 
     def test_report(self, create_issue_manager):
         issue_manager = create_issue_manager()

--- a/tests/datalab/issue_manager/test_imbalance.py
+++ b/tests/datalab/issue_manager/test_imbalance.py
@@ -9,6 +9,7 @@ SEED = 42
 class TestClassImbalanceIssueManager:
     @pytest.fixture
     def labels(self, lab):
+        np.random.seed(SEED)
         K = lab.get_info("statistics")["num_classes"]
         N = lab.get_info("statistics")["num_examples"] * 20
         labels = np.random.choice(np.arange(K - 1), size=N, p=[0.5] * (K - 1))


### PR DESCRIPTION
 Use proportion of rarest class for overall dataset score for the class imbalance issue type. Further, small changes have been to remove function call to `min()` and instead  only use `argmin` for finding the minimum value. Using the example mentioned in https://github.com/cleanlab/cleanlab/pull/758, the output of summary score is as follows:

**Before Fix**
```
Overall dataset quality in terms of this issue: 0.9756
```

**After Fix**
```
Overall dataset quality in terms of this issue: 0.0250
```
