### PR TITLE
Bump Minimum Required Python Version to 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install flake8
         run: pip install flake8
       - name: Lint with flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -49,7 +48,6 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - name: Install flake8
         run: pip install flake8
       - name: Lint with flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -27,7 +26,7 @@ jobs:
       - name: Install cleanlab
         run: pip install -e ".[all]"
       - name: Install development dependencies
-        run: pip install -vr requirements-dev.txt
+        run: pip install -r requirements-dev.txt
       - name: Overwrite tensorflow version on Windows
         run: |
           pip uninstall -y tensorflow
@@ -49,7 +48,6 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -62,7 +60,7 @@ jobs:
       - name: Install cleanlab
         run: pip install -e ".[all]"
       - name: Install development dependencies
-        run: pip install -vr requirements-dev.txt
+        run: pip install -r requirements-dev.txt
       - name: Install fasttext for non-Windows machines
         run: |
           pip install fasttext

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -46,7 +45,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -78,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install cleanlab
         run: |
           python -m  pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -26,7 +27,7 @@ jobs:
       - name: Install cleanlab
         run: pip install -e ".[all]"
       - name: Install development dependencies
-        run: pip install -r requirements-dev.txt
+        run: pip install -vr requirements-dev.txt
       - name: Overwrite tensorflow version on Windows
         run: |
           pip uninstall -y tensorflow
@@ -48,6 +49,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -60,7 +62,7 @@ jobs:
       - name: Install cleanlab
         run: pip install -e ".[all]"
       - name: Install development dependencies
-        run: pip install -r requirements-dev.txt
+        run: pip install -vr requirements-dev.txt
       - name: Install fasttext for non-Windows machines
         run: |
           pip install fasttext

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -48,6 +49,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Get started with: [documentation](https://docs.cleanlab.ai/), [tutorials](https:
 
 [![pypi](https://img.shields.io/pypi/v/cleanlab.svg)](https://pypi.org/pypi/cleanlab/)
 [![os](https://img.shields.io/badge/platform-noarch-lightgrey)](https://pypi.org/pypi/cleanlab/)
-[![py\_versions](https://img.shields.io/badge/python-3.7%2B-blue)](https://pypi.org/pypi/cleanlab/)
+[![py\_versions](https://img.shields.io/badge/python-3.8%2B-blue)](https://pypi.org/pypi/cleanlab/)
 [![build\_status](https://github.com/cleanlab/cleanlab/workflows/CI/badge.svg)](https://github.com/cleanlab/cleanlab/actions?query=workflow%3ACI)
 [![coverage](https://codecov.io/gh/cleanlab/cleanlab/branch/master/graph/badge.svg)](https://app.codecov.io/gh/cleanlab/cleanlab)
 [![docs](https://img.shields.io/static/v1?logo=github&style=flat&color=pink&label=docs&message=cleanlab)](https://docs.cleanlab.ai/)
@@ -67,7 +67,7 @@ Examples of incorrect given labels in various image datasets <a href="https://l7
 
 ## Run cleanlab
 
-cleanlab supports Linux, macOS, and Windows and runs on Python 3.7+.
+cleanlab supports Linux, macOS, and Windows and runs on Python 3.8+.
 
 - Get started [here](https://docs.cleanlab.ai/)! Install via `pip` or `conda` as described [here](https://docs.cleanlab.ai/).
 - Developers who install the bleeding-edge from source should refer to [this master branch documentation](https://docs.cleanlab.ai/master/index.html).

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         "Natural Language :: English",
         # We believe this package works will these versions, but we do not guarantee it!
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -82,7 +81,7 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     # What does your project relate to?
     keywords="machine_learning data_cleaning confident_learning classification weak_supervision "
     "learning_with_noisy_labels unsupervised_learning datacentric_ai, datacentric",


### PR DESCRIPTION
This PR updates our Continuous Integration (CI) setup, workflows, and documentation to reflect the new minimum required Python version, moving from Python 3.7 to 3.8.

## Changes

- Removed Python 3.7 from the testing matrix in our GitHub workflows (`ci.yml`).
- Updated the `README.md` to indicate that cleanlab now requires Python 3.8+.
- Updated `setup.py` to specify the new minimum Python requirement and removed Python 3.7 from the classifiers.

## Note on Python 3.11 Testing

We initially attempted to introduce testing for Python 3.11 to ensure compatibility with this upcoming Python release. However, we encountered setup issues on both Windows and Ubuntu during testing:

- Windows faced a problem with the Fortran compiler when installing Scipy.
- Ubuntu had issues with openblas, also related to Scipy's installation.

<details> <summary> Click to view CI log for Windows + Python 3.11 </summary>

```
Collecting scipy (from -r requirements-dev.txt (line 13))
  Obtaining dependency information for scipy from https://files.pythonhosted.org/packages/06/15/e73734f9170b66c6a84a0bd7e03586e87e77404e2eb8e34749fc49fa43f7/scipy-1.11.2-cp311-cp311-win_amd64.whl.metadata
  Using cached scipy-1.11.2-cp311-cp311-win_amd64.whl.metadata (59 kB)
  Obtaining dependency information for scipy from https://files.pythonhosted.org/packages/04/b8/947f40706ee2e316fd1a191688f690c4c2b351c2d043fe9deb9b7940e36e/scipy-1.11.1-cp311-cp311-win_amd64.whl.metadata
  Downloading scipy-1.11.1-cp311-cp311-win_amd64.whl.metadata (59 kB)
     ---------------------------------------- 59.1/59.1 kB 3.3 MB/s eta 0:00:00
  Downloading scipy-1.10.1-cp311-cp311-win_amd64.whl (42.2 MB)
     --------------------------------------- 42.2/42.2 MB 20.5 MB/s eta 0:00:00
  Downloading scipy-1.10.0-cp311-cp311-win_amd64.whl (42.2 MB)
     --------------------------------------- 42.2/42.2 MB 17.7 MB/s eta 0:00:00
  Downloading scipy-1.9.3-cp311-cp311-win_amd64.whl (39.9 MB)
     --------------------------------------- 39.9/39.9 MB 19.8 MB/s eta 0:00:00
  Downloading scipy-1.9.2-cp311-cp311-win_amd64.whl (39.9 MB)
     --------------------------------------- 39.9/39.9 MB 27.3 MB/s eta 0:00:00
  Downloading scipy-1.9.1.tar.gz (42.0 MB)
     --------------------------------------- 42.0/42.0 MB 24.2 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: still running...
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  Getting requirements to build wheel did not run successfully.
  exit code: 1
  
  [54 lines of output]
  The Meson build system
  Version: 0.62.2
  Source dir: C:\Users\runneradmin\AppData\Local\Temp\pip-install-7kz0xhvi\scipy_05fcc886ac8941b6b1ae68838123a8f0
  Build dir: C:\Users\runneradmin\AppData\Local\Temp\pip-install-7kz0xhvi\scipy_05fcc886ac8941b6b1ae68838123a8f0\.mesonpy-9h96qy_r\build
  Build type: native build
  Project name: SciPy
  Project version: 1.9.1
  C compiler for the host machine: ccache gcc (gcc 11.2.0 "gcc.exe (MinGW-W64 x86_64-posix-seh, built by Brecht Sanders) 11.2.0")
  C linker for the host machine: gcc ld.bfd 2.37
  C++ compiler for the host machine: ccache c++ (gcc 11.2.0 "c++.exe (MinGW-W64 x86_64-posix-seh, built by Brecht Sanders) 11.2.0")
  C++ linker for the host machine: c++ ld.bfd 2.37
  Host machine cpu family: x86_64
  Host machine cpu: x86_64
  Compiler for C supports arguments -Wno-unused-but-set-variable: YES
  Library m found: YES
  
  ..\..\meson.build:41:0: ERROR: Executables created by Fortran compiler gfortran are not runnable.
  
  A full log can be found at C:\Users\runneradmin\AppData\Local\Temp\pip-install-7kz0xhvi\scipy_05fcc886ac8941b6b1ae68838123a8f0\.mesonpy-9h96qy_r\build\meson-logs\meson-log.txt
  + meson setup --native-file=C:\Users\runneradmin\AppData\Local\Temp\pip-install-7kz0xhvi\scipy_05fcc886ac8941b6b1ae68838123a8f0\.mesonpy-native-file.ini -Ddebug=false -Doptimization=2 --prefix=C:\hostedtoolcache\windows\Python\3.11.4\x64 C:\Users\runneradmin\AppData\Local\Temp\pip-install-7kz0xhvi\scipy_05fcc886ac8941b6b1ae68838123a8f0 C:\Users\runneradmin\AppData\Local\Temp\pip-install-7kz0xhvi\scipy_05fcc886ac8941b6b1ae68838123a8f0\.mesonpy-9h96qy_r\build
  Traceback (most recent call last):
    File "C:\hostedtoolcache\windows\Python\3.11.4\x64\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 353, in <module>
      main()
    File "C:\hostedtoolcache\windows\Python\3.11.4\x64\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 335, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\hostedtoolcache\windows\Python\3.11.4\x64\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 118, in get_requires_for_build_wheel
      return hook(config_settings)
             ^^^^^^^^^^^^^^^^^^^^^
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-yi588u2c\overlay\Lib\site-packages\mesonpy\__init__.py", line 969, in get_requires_for_build_wheel
      with _project(config_settings) as project:
    File "C:\hostedtoolcache\windows\Python\3.11.4\x64\Lib\contextlib.py", line 137, in __enter__
      return next(self.gen)
             ^^^^^^^^^^^^^^
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-yi588u2c\overlay\Lib\site-packages\mesonpy\__init__.py", line 948, in _project
      with Project.with_temp_working_dir(
    File "C:\hostedtoolcache\windows\Python\3.11.4\x64\Lib\contextlib.py", line 137, in __enter__
      return next(self.gen)
             ^^^^^^^^^^^^^^
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-yi588u2c\overlay\Lib\site-packages\mesonpy\__init__.py", line 777, in with_temp_working_dir
      yield cls(source_dir, tmpdir, build_dir)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-yi588u2c\overlay\Lib\site-packages\mesonpy\__init__.py", line 682, in __init__
      self._configure(reconfigure=bool(build_dir) and not native_file_mismatch)
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-yi588u2c\overlay\Lib\site-packages\mesonpy\__init__.py", line 713, in _configure
      self._meson(
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-yi588u2c\overlay\Lib\site-packages\mesonpy\__init__.py", line 696, in _meson
      return self._proc('meson', *args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-yi588u2c\overlay\Lib\site-packages\mesonpy\__init__.py", line 691, in _proc
      subprocess.check_call(list(args))
    File "C:\hostedtoolcache\windows\Python\3.11.4\x64\Lib\subprocess.py", line 413, in check_call
      raise CalledProcessError(retcode, cmd)
  subprocess.CalledProcessError: Command '['meson', 'setup', '--native-file=C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pip-install-7kz0xhvi\\scipy_05fcc886ac8941b6b1ae68838123a8f0\\.mesonpy-native-file.ini', '-Ddebug=false', '-Doptimization=2', '--prefix=C:\\hostedtoolcache\\windows\\Python\\3.11.4\\x64', 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pip-install-7kz0xhvi\\scipy_05fcc886ac8941b6b1ae68838123a8f0', 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pip-install-7kz0xhvi\\scipy_05fcc886ac8941b6b1ae68838123a8f0\\.mesonpy-9h96qy_r\\build']' returned non-zero exit status 1.
  [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

Getting requirements to build wheel did not run successfully.
exit code: 1

See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
Error: Process completed with exit code 1.
```
</details>


<details> <summary> Click to view CI log for Ubuntu + Python 3.11 </summary>

```
Collecting scipy (from -r requirements-dev.txt (line 13))
  Obtaining dependency information for scipy from https://files.pythonhosted.org/packages/0e/a0/8606a7eef659f3d5f79d9efb92eed3ed1243178f4ae962614e1b202935a6/scipy-1.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata
  Using cached scipy-1.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (59 kB)
  Obtaining dependency information for scipy from https://files.pythonhosted.org/packages/b8/46/1d255bb55e63de02f7b2f3a2f71b59b840db21d61ff7cd41edbfc2da448a/scipy-1.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata
  Downloading scipy-1.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux[201](https://github.com/cleanlab/cleanlab/actions/runs/5964711880/job/16180553548?pr=829#step:6:202)4_x86_64.whl.metadata (59 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 59.1/59.1 kB 14.5 MB/s eta 0:00:00
  Downloading scipy-1.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (34.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 34.1/34.1 MB 50.4 MB/s eta 0:00:00
  Downloading scipy-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (34.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 34.1/34.1 MB 53.5 MB/s eta 0:00:00
  Downloading scipy-1.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (33.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 33.4/33.4 MB 55.2 MB/s eta 0:00:00
  Downloading scipy-1.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (33.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 33.4/33.4 MB 33.4 MB/s eta 0:00:00
  Downloading scipy-1.9.1.tar.gz (42.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 42.0/42.0 MB 44.9 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [66 lines of output]
      The Meson build system
      Version: 0.62.2
      Source dir: /tmp/pip-install-abs_d1r6/scipy_5b3db1a1[212](https://github.com/cleanlab/cleanlab/actions/runs/5964711880/job/16180553548?pr=829#step:6:213)54c378d49054d551e3afd
      Build dir: /tmp/pip-install-abs_d1r6/scipy_5b3db1a121[254](https://github.com/cleanlab/cleanlab/actions/runs/5964711880/job/16180553548?pr=829#step:6:255)c378d49054d551e3afd/.mesonpy-w5d1_qiz/build
      Build type: native build
      Project name: SciPy
      Project version: 1.9.1
      C compiler for the host machine: cc (gcc 11.4.0 "cc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0")
      C linker for the host machine: cc ld.bfd 2.38
      C++ compiler for the host machine: c++ (gcc 11.4.0 "c++ (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0")
      C++ linker for the host machine: c++ ld.bfd 2.38
      Host machine cpu family: x86_64
      Host machine cpu: x86_64
      Compiler for C supports arguments -Wno-unused-but-set-variable: YES
      Library m found: YES
      Fortran compiler for the host machine: gfortran (gcc 11.4.0 "GNU Fortran (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0")
      Fortran linker for the host machine: gfortran ld.bfd 2.38
      Program cython found: YES (/tmp/pip-build-env-doe9utwe/overlay/bin/cython)
      Program pythran found: YES (/tmp/pip-build-env-doe9utwe/overlay/bin/pythran)
      Program cp found: YES (/usr/bin/cp)
      Program python found: YES (/opt/hostedtoolcache/Python/3.11.4/x64/bin/python)
      Found pkg-config: /usr/bin/pkg-config (0.29.2)
      Library npymath found: YES
      Library npyrandom found: YES
      Found CMake: /usr/local/bin/cmake (3.27.3)
      Run-time dependency openblas found: NO (tried pkgconfig and cmake)
      Run-time dependency openblas found: NO (tried pkgconfig and cmake)
      
      ../../scipy/meson.build:130:0: ERROR: Dependency "OpenBLAS" not found, tried pkgconfig and cmake
      
      A full log can be found at /tmp/pip-install-abs_d1r6/scipy_5b3db1a121254c378d49054d551e3afd/.mesonpy-w5d1_qiz/build/meson-logs/meson-log.txt
      + meson setup --native-file=/tmp/pip-install-abs_d1r6/scipy_5b3db1a121254c378d49054d551e3afd/.mesonpy-native-file.ini -Ddebug=false -Doptimization=2 --prefix=/opt/hostedtoolcache/Python/3.11.4/x64 /tmp/pip-install-abs_d1r6/scipy_5b3db1a121254c378d49054d551e3afd /tmp/pip-install-abs_d1r6/scipy_5b3db1a121254c378d49054d551e3afd/.mesonpy-w5d1_qiz/build
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-doe9utwe/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 969, in get_requires_for_build_wheel
          with _project(config_settings) as project:
        File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/contextlib.py", line 137, in __enter__
          return next(self.gen)
                 ^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-doe9utwe/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 948, in _project
          with Project.with_temp_working_dir(
        File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/contextlib.py", line 137, in __enter__
          return next(self.gen)
                 ^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-doe9utwe/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 777, in with_temp_working_dir
          yield cls(source_dir, tmpdir, build_dir)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-doe9utwe/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 682, in __init__
          self._configure(reconfigure=bool(build_dir) and not native_file_mismatch)
        File "/tmp/pip-build-env-doe9utwe/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 713, in _configure
          self._meson(
        File "/tmp/pip-build-env-doe9utwe/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 696, in _meson
          return self._proc('meson', *args)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-doe9utwe/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 691, in _proc
          subprocess.check_call(list(args))
        File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/subprocess.py", line 413, in check_call
          raise CalledProcessError(retcode, cmd)
      subprocess.CalledProcessError: Command '['meson', 'setup', '--native-file=/tmp/pip-install-abs_d1r6/scipy_5b3db1a121254c378d49054d551e3afd/.mesonpy-native-file.ini', '-Ddebug=false', '-Doptimization=2', '--prefix=/opt/hostedtoolcache/Python/3.11.4/x64', '/tmp/pip-install-abs_d1r6/scipy_5b3db1a121254c378d49054d551e3afd', '/tmp/pip-install-abs_d1r6/scipy_5b3db1a121254c378d49054d551e3afd/.mesonpy-w5d1_qiz/build']' returned non-zero exit status 1.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

Notice:  A new release of pip is available: 23.1.2 -> 23.2.1
Notice:  To update, run: pip install --upgrade pip
Error: Process completed with exit code 1.
```

</details>

In light of these challenges, we've decided to hold off on adding Python 3.11 to our testing matrix. We recommend monitoring the developments around Scipy's compatibility with Python 3.11, and once the issues are resolved, consider reintroducing Python 3.11 tests to our CI.

---


Closes #824 