### PR TITLE
702 - Shorten Refs of classes and functions

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -381,7 +381,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           pruned from the data before training the final `clf` model.
 
           Caution: If you provide `label_issues` without having previously called
-          :py:meth:`self.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`,
+          `~cleanlab.classification.CleanLearning.find_label_issues`
           e.g. as a ``np.ndarray``, then some functionality like training with sample weights may be disabled.
 
         sample_weight : array_like, optional
@@ -432,7 +432,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
 
           * *self.label_issues_df*: a ``pd.DataFrame`` accessible via
           `~cleanlab.classification.CleanLearning.get_label_issues`
-          of similar format as the one returned by: :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`.
+          of similar format as the one returned by: `~cleanlab.classification.CleanLearning.find_label_issues`.
           See documentation of :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`
           for column descriptions.
 
@@ -973,7 +973,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         This ``pd.DataFrame`` describes the label issues identified for each example
         (each row corresponds to an example).
         For column definitions, see the documentation of
-        :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`.
+        `~cleanlab.classification.CleanLearning.find_label_issues`.
 
         Returns
         -------

--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -18,7 +18,7 @@
 cleanlab can be used for learning with noisy labels for any dataset and model.
 
 For regular (multi-class) classification tasks,
-the :py:class:`CleanLearning <cleanlab.classification.CleanLearning>` class wraps an instance of an
+the `~cleanlab.classification.CleanLearning` class wraps an instance of an
 sklearn classifier. The wrapped classifier must adhere to the `sklearn estimator API
 <https://scikit-learn.org/stable/developers/develop.html#rolling-your-own-estimator>`_,
 meaning it must define four functions:
@@ -369,8 +369,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           If ``pd.DataFrame``, must be formatted as the one returned by:
           :py:meth:`CleanLearning.find_label_issues
           <cleanlab.classification.CleanLearning.find_label_issues>` or
-          :py:meth:`CleanLearning.get_label_issues
-          <cleanlab.classification.CleanLearning.get_label_issues>`.
+          `~cleanlab.classification.CleanLearning.get_label_issues`.
           If ``np.ndarray``, must contain either boolean `label_issues_mask` as output by:
           default :py:func:`filter.find_label_issues <cleanlab.filter.find_label_issues>`,
           or integer indices as output by
@@ -432,8 +431,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           After calling ``self.fit()``, this estimator also stores extra attributes such as:
 
           * *self.label_issues_df*: a ``pd.DataFrame`` accessible via
-          :py:meth:`get_label_issues
-          <cleanlab.classification.CleanLearning.get_label_issues>`
+          `~cleanlab.classification.CleanLearning.get_label_issues`
           of similar format as the one returned by: :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`.
           See documentation of :py:meth:`CleanLearning.find_label_issues<cleanlab.classification.CleanLearning.find_label_issues>`
           for column descriptions.
@@ -724,18 +722,14 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         this method only requires a classifier and it can do the cross-validation for you.
         Both methods return the same boolean mask that identifies which examples have label issues.
         This is the preferred method to use if you plan to subsequently invoke:
-        :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`.
+        `~cleanlab.classification.CleanLearning.fit`.
 
         Note: this method computes the label issues from scratch. To access
-        previously-computed label issues from this :py:class:`CleanLearning
-        <cleanlab.classification.CleanLearning>` instance, use the
-        :py:meth:`get_label_issues
-        <cleanlab.classification.CleanLearning.get_label_issues>` method.
+        previously-computed label issues from this `~cleanlab.classification.CleanLearning` instance, use the
+        `~cleanlab.classification.CleanLearning.get_label_issues` method.
 
         This is the method called to find label issues inside
-        :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`
+        `~cleanlab.classification.CleanLearning.fit`
         and they share mostly the same parameters.
 
         Parameters
@@ -745,8 +739,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           This means some other methods like `self.get_label_issues()` will no longer work.
 
 
-        For info about the **other parameters**, see the docstring of :py:meth:`CleanLearning.fit()
-        <cleanlab.classification.CleanLearning.fit>`.
+        For info about the **other parameters**, see the docstring of `~cleanlab.classification.CleanLearning.fit`.
 
         Returns
         -------
@@ -754,7 +747,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           DataFrame with info about label issues for each example.
           Unless `save_space` argument is specified, same DataFrame is also stored as
           `self.label_issues_df` attribute accessible via
-          :py:meth:`get_label_issues<cleanlab.classification.CleanLearning.get_label_issues>`.
+          `~cleanlab.classification.CleanLearning.get_label_issues`.
           Each row represents an example from our dataset and
           the DataFrame may contain the following columns:
 
@@ -762,7 +755,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
           * *label_quality*: Numeric score that measures the quality of each label (how likely it is to be correct, with lower scores indicating potentially erroneous labels).
           * *given_label*: Integer indices corresponding to the class label originally given for this example (same as `labels` input). Included here for ease of comparison against `clf` predictions, only present if "predicted_label" column is present.
           * *predicted_label*: Integer indices corresponding to the class predicted by trained `clf` model. Only present if ``pred_probs`` were provided as input or computed during label-issue-finding.
-          * *sample_weight*: Numeric values used to weight examples during the final training of `clf` in :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. This column may not be present after `self.find_label_issues()` but may be added after call to :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`. For more precise definition of sample weights, see documentation of :py:meth:`CleanLearning.fit()<cleanlab.classification.CleanLearning.fit>`
+          * *sample_weight*: Numeric values used to weight examples during the final training of `clf` in `~cleanlab.classification.CleanLearning.fit`. This column may not be present after `self.find_label_issues()` but may be added after call to `~cleanlab.classification.CleanLearning.fit`. For more precise definition of sample weights, see documentation of `~cleanlab.classification.CleanLearning.fit`
         """
 
         # Check inputs

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -87,7 +87,7 @@ def num_label_issues(
     confident_joint :
       Array of estimated class label error statisics used for identifying label issues,
       in same format expected by :py:func:`filter.find_label_issues <cleanlab.filter.find_label_issues>` function.
-      The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
+      The `confident_joint` can be computed using `~cleanlab.count.compute_confident_joint`.
       It is internally computed from the given (noisy) `labels` and `pred_probs`.
 
     estimation_method :
@@ -114,7 +114,7 @@ def num_label_issues(
     multi_label : bool, optional
       Set ``False`` if your dataset is for regular (multi-class) classification, where each example belongs to exactly one class.
       Set ``True`` if your dataset is for multi-label classification, where each example can belong to multiple classes.
-      See documentation of :py:func:`compute_confident_joint <cleanlab.count.compute_confident_joint>` for details.
+      See documentation of `~cleanlab.count.compute_confident_joint` for details.
 
     Returns
     -------
@@ -204,7 +204,7 @@ def _num_label_issues_multilabel(
        Refer to documentation for this argument in ``count.calibrate_confident_joint()`` with `multi_label=True` for details.
 
     pred_probs : np.ndarray
-       Predicted-probabilities in the same format expected by the :py:func:`get_confident_thresholds <cleanlab.count.get_confident_thresholds>` function.
+       Predicted-probabilities in the same format expected by the `~cleanlab.count.get_confident_thresholds` function.
 
     Returns
     -------
@@ -246,7 +246,7 @@ def calibrate_confident_joint(
       An array of shape ``(K, K)`` representing the confident joint, the matrix used for identifying label issues, which
       estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.
       Entry ``(j, k)`` in the matrix is the number of examples confidently counted into the pair of ``(noisy label=j, true label=k)`` classes.
-      The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
+      The `confident_joint` can be computed using `~cleanlab.count.compute_confident_joint`.
       If not provided, it is computed from the given (noisy) `labels` and `pred_probs`.
       If `multi_label` is True, then the `confident_joint` should be a one-vs-rest array of shape ``(K, 2, 2)``, and an array of the same shape will be returned.
 
@@ -257,7 +257,7 @@ def calibrate_confident_joint(
     multi_label : bool, optional
       If ``False``, dataset is for regular (multi-class) classification, where each example belongs to exactly one class.
       If ``True``, dataset is for multi-label classification, where each example can belong to multiple classes.
-      See documentation of :py:func:`compute_confident_joint <cleanlab.count.compute_confident_joint>` for details.
+      See documentation of `~cleanlab.count.compute_confident_joint` for details.
       In multi-label classification, the confident/calibrated joint arrays have shape ``(K, 2, 2)``
       formatted in a one-vs-rest fashion such that they contain a 2x2 matrix for each class
       that counts examples which are correctly/incorrectly labeled as belonging to that class.
@@ -361,13 +361,13 @@ def estimate_joint(
     confident_joint : np.ndarray, optional
       Array of estimated class label error statisics used for identifying label issues,
       in same format expected by :py:func:`filter.find_label_issues <cleanlab.filter.find_label_issues>` function.
-      The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
+      The `confident_joint` can be computed using `~cleanlab.count.compute_confident_joint`.
       If not provided, it is internally computed from the given (noisy) `labels` and `pred_probs`.
 
     multi_label : bool, optional
       If ``False``, dataset is for regular (multi-class) classification, where each example belongs to exactly one class.
       If ``True``, dataset is for multi-label classification, where each example can belong to multiple classes.
-      See documentation of :py:func:`compute_confident_joint <cleanlab.count.compute_confident_joint>` for details.
+      See documentation of `~cleanlab.count.compute_confident_joint` for details.
 
     Returns
     -------
@@ -721,7 +721,7 @@ def estimate_latent(
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Computes the latent prior ``p(y)``, the noise matrix ``P(labels|y)`` and the
     inverse noise matrix ``P(y|labels)`` from the `confident_joint` ``count(labels, y)``. The
-    `confident_joint` can be estimated by `compute_confident_joint <cleanlab.count.compute_confident_joint>`
+    `confident_joint` can be estimated by `~cleanlab.count.compute_confident_joint`
     which counts confident examples.
 
     Parameters
@@ -730,7 +730,7 @@ def estimate_latent(
       An array of shape ``(K, K)`` representing the confident joint, the matrix used for identifying label issues, which
       estimates a confident subset of the joint distribution of the noisy and true labels, ``P_{noisy label, true label}``.
       Entry ``(j, k)`` in the matrix is the number of examples confidently counted into the pair of ``(noisy label=j, true label=k)`` classes.
-      The `confident_joint` can be computed using :py:func:`count.compute_confident_joint <cleanlab.count.compute_confident_joint>`.
+      The `confident_joint` can be computed using `~cleanlab.count.compute_confident_joint`.
       If not provided, it is computed from the given (noisy) `labels` and `pred_probs`.
 
     labels : np.ndarray
@@ -1428,7 +1428,7 @@ def get_confident_thresholds(
     multi_label : bool, default = False
       Set ``False`` if your dataset is for regular (multi-class) classification, where each example belongs to exactly one class.
       Set ``True`` if your dataset is for multi-label classification, where each example can belong to multiple classes.
-      See documentation of :py:func:`compute_confident_joint <cleanlab.count.compute_confident_joint>` for details.
+      See documentation of `~cleanlab.count.compute_confident_joint` for details.
 
     Returns
     -------
@@ -1473,7 +1473,7 @@ def _get_confident_thresholds_multilabel(
        Refer to documentation for this argument in ``count.calibrate_confident_joint()`` with ``multi_label=True`` for details.
 
     pred_probs : np.ndarray
-       Predicted class probabilities in the same format expected by the :py:func:`get_confident_thresholds <cleanlab.count.get_confident_thresholds>` function.
+       Predicted class probabilities in the same format expected by the `~cleanlab.count.get_confident_thresholds` function.
 
     Returns
     -------

--- a/cleanlab/datalab/internal/data_issues.py
+++ b/cleanlab/datalab/internal/data_issues.py
@@ -23,7 +23,7 @@ instances and keeps track of each issue, a summary for each type of issue,
 related information and statistics about the issues.
 
 The collected information can be accessed using the
-:py:meth:`get_info <cleanlab.datalab.internal.data_issues.DataIssues.get_info>` method.
+`~cleanlab.datalab.internal.data_issues.DataIssues.get_info` method.
 We recommend using that method instead of this module, which is just intended for internal use.
 """
 from __future__ import annotations

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -406,7 +406,7 @@ def health_summary(
         A dictionary containing keys (see the corresponding functions' documentation to understand the values):
 
         - ``"overall_label_health_score"``, corresponding to `~cleanlab.dataset.overall_label_health_score`
-        - ``"joint"``, corresponding to :py:func:`estimate_joint <cleanlab.count.estimate_joint>`
+        - ``"joint"``, corresponding to :py:func:`count.estimate_joint <cleanlab.count.estimate_joint>`
         - ``"classes_by_label_quality"``, corresponding to `~cleanlab.dataset.rank_classes_by_label_quality`
         - ``"overlapping_classes"``, corresponding to `~cleanlab.dataset.find_overlapping_classes`
     """

--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -17,8 +17,8 @@
 """
 Provides dataset-level and class-level overviews of issues in your classification dataset.
 If your task allows you to modify the classes in your dataset, this module can help you determine
-which classes to remove (see :py:func:`rank_classes_by_label_quality <cleanlab.dataset.rank_classes_by_label_quality>`)
-and which classes to merge (see :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`).
+which classes to remove (see `~cleanlab.dataset.rank_classes_by_label_quality`)
+and which classes to merge (see `~cleanlab.dataset.find_overlapping_classes`).
 """
 
 from typing import Optional, cast
@@ -63,7 +63,7 @@ def rank_classes_by_label_quality(
     >>> pred_probs = cross_val_predict(yourFavoriteModel, data, labels, cv=3, method="predict_proba")
     >>> df = rank_classes_by_label_quality(labels=labels, pred_probs=pred_probs)
 
-    **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
+    **Parameters**: For parameter info, see the docstring of `~cleanlab.dataset.find_overlapping_classes`.
 
     Returns
     -------
@@ -327,7 +327,7 @@ def overall_label_health_score(
     >>> pred_probs = cross_val_predict(yourFavoriteModel, data, labels, cv=3, method="predict_proba")
     >>> score = overall_label_health_score(labels=labels, pred_probs=pred_probs)  # doctest: +SKIP
 
-    **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
+    **Parameters**: For parameter info, see the docstring of `~cleanlab.dataset.find_overlapping_classes`.
 
 
     Returns
@@ -398,17 +398,17 @@ def health_summary(
     >>> pred_probs = cross_val_predict(yourFavoriteModel, data, labels, cv=3, method="predict_proba")
     >>> summary = health_summary(labels=labels, pred_probs=pred_probs)  # doctest: +SKIP
 
-    **Parameters**: For parameter info, see the docstring of :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`.
+    **Parameters**: For parameter info, see the docstring of `~cleanlab.dataset.find_overlapping_classes`.
 
     Returns
     -------
     summary : dict
         A dictionary containing keys (see the corresponding functions' documentation to understand the values):
 
-        - ``"overall_label_health_score"``, corresponding to :py:func:`overall_label_health_score <cleanlab.dataset.overall_label_health_score>`
+        - ``"overall_label_health_score"``, corresponding to `~cleanlab.dataset.overall_label_health_score`
         - ``"joint"``, corresponding to :py:func:`estimate_joint <cleanlab.count.estimate_joint>`
-        - ``"classes_by_label_quality"``, corresponding to :py:func:`rank_classes_by_label_quality <cleanlab.dataset.rank_classes_by_label_quality>`
-        - ``"overlapping_classes"``, corresponding to :py:func:`find_overlapping_classes <cleanlab.dataset.find_overlapping_classes>`
+        - ``"classes_by_label_quality"``, corresponding to `~cleanlab.dataset.rank_classes_by_label_quality`
+        - ``"overlapping_classes"``, corresponding to `~cleanlab.dataset.find_overlapping_classes`
     """
     from cleanlab.internal.util import smart_display_dataframe
 

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -661,13 +661,13 @@ def find_predicted_neq_given(
     Parameters
     ----------
     labels : np.ndarray or list
-      Labels in the same format expected by the :py:func:`find_label_issues <cleanlab.filter.find_label_issues>` function.
+      Labels in the same format expected by the `~cleanlab.filter.find_label_issues` function.
 
     pred_probs : np.ndarray
-      Predicted-probabilities in the same format expected by the :py:func:`find_label_issues <cleanlab.filter.find_label_issues>` function.
+      Predicted-probabilities in the same format expected by the `~cleanlab.filter.find_label_issues` function.
 
     multi_label : bool, optional
-      Whether each example may have multiple labels or not (see documentation for the :py:func:`find_label_issues <cleanlab.filter.find_label_issues>` function).
+      Whether each example may have multiple labels or not (see documentation for the `~cleanlab.filter.find_label_issues` function).
 
     Returns
     -------
@@ -697,7 +697,7 @@ def _find_predicted_neq_given_multilabel(labels: list, pred_probs: np.ndarray) -
        (e.g. ``labels = [[1,2],[1],[0],[],...]`` indicates the first example in dataset belongs to both class 1 and class 2).
 
      pred_probs : np.ndarray
-       Predicted-probabilities in the same format expected by the :py:func:`find_label_issues <cleanlab.filter.find_label_issues>` function.
+       Predicted-probabilities in the same format expected by the `~cleanlab.filter.find_label_issues` function.
 
      Returns
      -------
@@ -728,8 +728,7 @@ def find_label_issues_using_argmax_confusion_matrix(
     of ``argmax(pred_probs)`` and labels as the confident joint and then uses cleanlab
     (confident learning) to find the label issues using this matrix.
 
-    The only difference between this and :py:func:`find_label_issues
-    <cleanlab.filter.find_label_issues>` is that it uses the confusion matrix
+    The only difference between this and `~cleanlab.filter.find_label_issues` is that it uses the confusion matrix
     based on the argmax and given label instead of using the confident joint
     from :py:func:`count.compute_confident_joint
     <cleanlab.count.compute_confident_joint>`.
@@ -755,7 +754,7 @@ def find_label_issues_using_argmax_confusion_matrix(
         prior (given noisy labels) is correct based on the original labels.
 
     filter_by : str, default='prune_by_noise_rate'
-        See `filter_by` argument of :py:func:`find_label_issues <cleanlab.filter.find_label_issues>`.
+        See `filter_by` argument of `~cleanlab.filter.find_label_issues`.
 
     Returns
     -------

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -259,7 +259,7 @@ class Aggregator:
     method:
         The method to compute the label quality scores for each class.
         If passed as a callable, your function should take in a 1D array of K scores and return a single aggregated score.
-        See :py:func:`exponential_moving_average <cleanlab.internal.multilabel_scorer.exponential_moving_average>` for an example of such a function.
+        See `~cleanlab.internal.multilabel_scorer.exponential_moving_average` for an example of such a function.
         Alternatively, this can be a str value to specify a built-in function, possible values are the keys of the ``Aggregator``'s `possible_methods` attribute.
 
     kwargs:

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -18,7 +18,7 @@
 Methods for analysis of classification data labeled by multiple annotators.
 
 To analyze a fixed dataset labeled by multiple annotators, use the
-:py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>` function which estimates:
+`~cleanlab.multiannotator.get_label_quality_multiannotator` function which estimates:
 
 * A consensus label for each example that aggregates the individual annotations more accurately than alternative aggregation via majority-vote or other algorithms used in crowdsourcing like Dawid-Skene.
 * A quality score for each consensus label which measures our confidence that this label is correct.
@@ -28,7 +28,7 @@ To analyze a fixed dataset labeled by multiple annotators, use the
 The algorithms to compute these estimates are described in `the CROWDLAB paper <https://arxiv.org/abs/2210.06812>`_.
 
 If you have some labeled and unlabeled data (with multiple annotators for some labeled examples) and want to decide what data to collect additional labels for,
-use the :py:func:`get_active_learning_scores <cleanlab.multiannotator.get_active_learning_scores>` function, which is intended for active learning. 
+use the `~cleanlab.multiannotator.get_active_learning_scores` function, which is intended for active learning. 
 This function estimates an ActiveLab quality score for each example,
 which can be used to prioritize which examples are most informative to collect additional labels for.
 This function is effective for settings where some examples have been labeled by one or more annotators and other examples can have no labels at all so far,
@@ -83,7 +83,7 @@ def get_label_quality_multiannotator(
     It also computes similar quality scores for each annotator's individual labels, and the quality of each annotator.
     Scores are between 0 and 1 (estimated via methods like CROWDLAB); lower scores indicate labels/annotators less likely to be correct.
 
-    To decide what data to collect additional labels for, try the :py:func:`get_active_learning_scores <cleanlab.multiannotator.get_active_learning_scores>`
+    To decide what data to collect additional labels for, try the `~cleanlab.multiannotator.get_active_learning_scores`
     (ActiveLab) function, which is intended for active learning with multiple annotators.
 
     Parameters
@@ -378,28 +378,28 @@ def get_label_quality_multiannotator_ensemble(
 ) -> Dict[str, Any]:
     """Returns label quality scores for each example and for each annotator, based on predictions from an ensemble of models.
 
-    This function is similar to :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>` but for settings where
+    This function is similar to `~cleanlab.multiannotator.get_label_quality_multiannotator` but for settings where
     you have trained an ensemble of multiple classifier models rather than a single model.
 
     Parameters
     ----------
     labels_multiannotator : pd.DataFrame or np.ndarray
-        Multiannotator labels in the same format expected by :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        Multiannotator labels in the same format expected by `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     pred_probs : np.ndarray
         An array of shape ``(P, N, K)`` where P is the number of models, consisting of predicted class probabilities from the ensemble models.
         Each set of predicted probabilities with shape ``(N, K)`` is in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
     calibrate_probs : bool, default = False
-        Boolean value as expected by :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        Boolean value as expected by `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     return_detailed_quality: bool, default = True
-        Boolean value as expected by :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        Boolean value as expected by `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     return_annotator_stats : bool, default = True
-        Boolean value as expected by :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        Boolean value as expected by `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     return_weights : bool, default = False
-        Boolean value as expected by :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        Boolean value as expected by `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     verbose : bool, default = True
-        Boolean value as expected by :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        Boolean value as expected by `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     label_quality_score_kwargs : dict, optional
-        Keyword arguments in the same format expected by py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        Keyword arguments in the same format expected by `~cleanlab.multiannotator.get_label_quality_multiannotator`.
 
     Returns
     -------
@@ -407,13 +407,13 @@ def get_label_quality_multiannotator_ensemble(
         Dictionary containing up to 5 pandas DataFrame with keys as below:
 
         ``label_quality`` : pandas.DataFrame
-            Similar to output as :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+            Similar to output as `~cleanlab.multiannotator.get_label_quality_multiannotator`.
 
         ``detailed_label_quality`` : pandas.DataFrame
-            Similar to output as :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+            Similar to output as `~cleanlab.multiannotator.get_label_quality_multiannotator`.
 
         ``annotator_stats`` : pandas.DataFrame
-            Similar to output as :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+            Similar to output as `~cleanlab.multiannotator.get_label_quality_multiannotator`.
 
         ``model_weight`` : np.ndarray
             Only returned if `return_weights=True`.
@@ -423,7 +423,7 @@ def get_label_quality_multiannotator_ensemble(
 
         ``annotator_weight`` : np.ndarray
             Only returned if `return_weights=True`.
-            Similar to output as :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+            Similar to output as `~cleanlab.multiannotator.get_label_quality_multiannotator`.
 
     See Also
     --------
@@ -597,7 +597,7 @@ def get_active_learning_scores(
     as arguments), or for unlabeled examples (specify ``pred_probs_unlabeled``), or for both types of examples (specify all of the above arguments).
 
     To analyze a fixed dataset labeled by multiple annotators rather than collecting additional labels, try the
-    :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>` (CROWDLAB) function instead.
+    `~cleanlab.multiannotator.get_label_quality_multiannotator` (CROWDLAB) function instead.
 
     Parameters
     ----------
@@ -605,7 +605,7 @@ def get_active_learning_scores(
         2D pandas DataFrame or array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators. Note that this function also works with
         datasets where there is only one annotator (M=1).
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
         Note that examples that have no annotator labels should not be included in this DataFrame/array.
         This argument is optional if ``pred_probs`` is not provided (you might only provide ``pred_probs_unlabeled`` to only get active learning scores for the unlabeled examples).
     pred_probs : np.ndarray, optional
@@ -750,13 +750,13 @@ def get_active_learning_scores_ensemble(
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Returns an ActiveLab quality score for each example in the dataset, based on predictions from an ensemble of models.
 
-    This function is similar to :py:func:`get_active_learning_scores <cleanlab.multiannotator.get_active_learning_scores>` but allows for an
+    This function is similar to `~cleanlab.multiannotator.get_active_learning_scores` but allows for an
     ensemble of multiple classifier models to be trained and will aggregate predictions from the models to compute the ActiveLab quality score.
 
     Parameters
     ----------
     labels_multiannotator : pd.DataFrame or np.ndarray
-        Multiannotator labels in the same format expected by :py:func:`get_active_learning_scores <cleanlab.multiannotator.get_active_learning_scores>`.
+        Multiannotator labels in the same format expected by `~cleanlab.multiannotator.get_active_learning_scores`.
         This argument is optional if ``pred_probs`` is not provided (in cases where you only provide ``pred_probs_unlabeled`` to get active learning scores for unlabeled examples).
     pred_probs : np.ndarray
         An array of shape ``(P, N, K)`` where P is the number of models, consisting of predicted class probabilities from the ensemble models.
@@ -923,10 +923,10 @@ def get_majority_vote_label(
     labels_multiannotator : pd.DataFrame or np.ndarray
         2D pandas DataFrame or array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     pred_probs : np.ndarray, optional
         An array of shape ``(N, K)`` of model-predicted probabilities, ``P(label=k|x)``.
-        For details, predicted probabilities in the same format expected by :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For details, predicted probabilities in the same format expected by `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     verbose : bool, optional
         Important warnings and other printed statements may be suppressed if ``verbose`` is set to ``False``.
     Returns
@@ -1076,7 +1076,7 @@ def convert_long_to_wide_dataset(
     labels_multiannotator_long: pd.DataFrame,
 ) -> pd.DataFrame:
     """Converts a long format dataset to wide format which is suitable for passing into
-    :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+    `~cleanlab.multiannotator.get_label_quality_multiannotator`.
 
     Dataframe must contain three columns named:
 
@@ -1119,17 +1119,17 @@ def _get_consensus_stats(
     labels_multiannotator : np.ndarray
         2D numpy array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     pred_probs : np.ndarray
         An array of shape ``(N, K)`` of model-predicted probabilities, ``P(label=k|x)``.
-        For details, predicted probabilities in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For details, predicted probabilities in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     num_annotations : np.ndarray
         An array of shape ``(N,)`` with the number of annotators that have labeled each example.
     consensus_label : np.ndarray
         An array of shape ``(N,)`` with the consensus labels aggregated from all annotators.
     quality_method : str, default = "crowdlab" (Options: ["crowdlab", "agreement"])
         Specifies the method used to calculate the quality of the consensus label.
-        For valid quality methods, view :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`
+        For valid quality methods, view `~cleanlab.multiannotator.get_label_quality_multiannotator`
     label_quality_score_kwargs : dict, optional
         Keyword arguments to pass into ``get_label_quality_scores()``.
     verbose : bool, default = True
@@ -1210,10 +1210,10 @@ def _get_annotator_stats(
     labels_multiannotator : np.ndarray
         2D numpy array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     pred_probs : np.ndarray
         An array of shape ``(N, K)`` of model-predicted probabilities, ``P(label=k|x)``.
-        For details, predicted probabilities in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For details, predicted probabilities in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     consensus_label : np.ndarray
         An array of shape ``(N,)`` with the consensus labels aggregated from all annotators.
     num_annotations : np.ndarray
@@ -1232,13 +1232,13 @@ def _get_annotator_stats(
         pandas DataFrame containing the detailed label quality scores for all examples and annotators
     quality_method : str, default = "crowdlab" (Options: ["crowdlab", "agreement"])
         Specifies the method used to calculate the quality of the consensus label.
-        For valid quality methods, view :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`
+        For valid quality methods, view `~cleanlab.multiannotator.get_label_quality_multiannotator`
 
     Returns
     -------
     annotator_stats : pd.DataFrame
         Overall statistics about each annotator.
-        For details, see the documentation of :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For details, see the documentation of `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     """
 
     annotator_quality = _get_annotator_quality(
@@ -1297,7 +1297,7 @@ def _get_annotator_agreement_with_consensus(
     labels_multiannotator : np.ndarray
         2D numpy array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     consensus_label : np.ndarray
         An array of shape ``(N,)`` with the consensus labels aggregated from all annotators.
 
@@ -1325,7 +1325,7 @@ def _get_annotator_agreement_with_annotators(
     labels_multiannotator : np.ndarray
         2D numpy array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     consensus_label : np.ndarray
         An array of shape ``(N,)`` with the consensus labels aggregated from all annotators.
     verbose : bool, default = True
@@ -1421,20 +1421,20 @@ def _get_post_pred_probs_and_weights(
     labels_multiannotator : np.ndarray
         2D numpy array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     consensus_label : np.ndarray
         An array of shape ``(N,)`` with the consensus labels aggregated from all annotators.
     prior_pred_probs : np.ndarray
         An array of shape ``(N, K)`` of prior predicted probabilities, ``P(label=k|x)``, usually the out-of-sample predicted probability computed by a model.
-        For details, predicted probabilities in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For details, predicted probabilities in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     num_annotations : np.ndarray
         An array of shape ``(N,)`` with the number of annotators that have labeled each example.
     annotator_agreement : np.ndarray
         An array of shape ``(N,)`` with the fraction of annotators that agree with each consensus label.
     quality_method : default = "crowdlab" (Options: ["crowdlab", "agreement"])
         Specifies the method used to calculate the quality of the consensus label.
-        For valid quality methods, view :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`
-    verbose : default = True
+        For valid quality methods, view `~cleanlab.multiannotator.get_label_quality_multiannotator`
+    verbose : bool, default = True
         Certain warnings and notes will be printed if ``verbose`` is set to ``True``.
 
     Returns
@@ -1557,20 +1557,20 @@ def _get_post_pred_probs_and_weights_ensemble(
     labels_multiannotator : np.ndarray
         2D numpy array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     consensus_label : np.ndarray
         An array of shape ``(P, N, K)`` where P is the number of models, consisting of predicted class probabilities from the ensemble models.
         Each set of predicted probabilities with shape ``(N, K)`` is in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
     prior_pred_probs : np.ndarray
         An array of shape ``(N, K)`` of prior predicted probabilities, ``P(label=k|x)``, usually the out-of-sample predicted probability computed by a model.
-        For details, predicted probabilities in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For details, predicted probabilities in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     num_annotations : np.ndarray
         An array of shape ``(N,)`` with the number of annotators that have labeled each example.
     annotator_agreement : np.ndarray
         An array of shape ``(N,)`` with the fraction of annotators that agree with each consensus label.
     quality_method : str, default = "crowdlab" (Options: ["crowdlab", "agreement"])
         Specifies the method used to calculate the quality of the consensus label.
-        For valid quality methods, view :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`
+        For valid quality methods, view `~cleanlab.multiannotator.get_label_quality_multiannotator`
     verbose : bool, default = True
         Certain warnings and notes will be printed if ``verbose`` is set to ``True``.
 
@@ -1668,19 +1668,19 @@ def _get_consensus_quality_score(
     labels_multiannotator : np.ndarray
         2D numpy array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     consensus_label : np.ndarray
         An array of shape ``(N,)`` with the consensus labels aggregated from all annotators.
     pred_probs : np.ndarray
         An array of shape ``(N, K)`` of posterior predicted probabilities, ``P(label=k|x)``.
-        For details, predicted probabilities in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For details, predicted probabilities in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     num_annotations : np.ndarray
         An array of shape ``(N,)`` with the number of annotators that have labeled each example.
     annotator_agreement : np.ndarray
         An array of shape ``(N,)`` with the fraction of annotators that agree with each consensus label.
     quality_method : str, default = "crowdlab" (Options: ["crowdlab", "agreement"])
         Specifies the method used to calculate the quality of the consensus label.
-        For valid quality methods, view :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`
+        For valid quality methods, view `~cleanlab.multiannotator.get_label_quality_multiannotator`
 
     Returns
     -------
@@ -1719,7 +1719,7 @@ def _get_annotator_label_quality_score(
 ) -> np.ndarray:
     """Returns quality scores for each datapoint.
     Very similar functionality as ``_get_consensus_quality_score`` with additional support for annotator labels that contain NaN values.
-    For more info about parameters and returns, see the docstring of :py:func:`_get_consensus_quality_score <cleanlab.multiannotator._get_consensus_quality_score>`.
+    For more info about parameters and returns, see the docstring of `~cleanlab.multiannotator._get_consensus_quality_score`.
     """
     mask = ~np.isnan(annotator_label)
 
@@ -1752,10 +1752,10 @@ def _get_annotator_quality(
     labels_multiannotator : np.ndarray
         2D numpy array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     pred_probs : np.ndarray
         An array of shape ``(N, K)`` of model-predicted probabilities, ``P(label=k|x)``.
-        For details, predicted probabilities in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For details, predicted probabilities in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     consensus_label : np.ndarray
         An array of shape ``(N,)`` with the consensus labels aggregated from all annotators.
     num_annotations : np.ndarray
@@ -1772,7 +1772,7 @@ def _get_annotator_quality(
         pandas DataFrame containing the detailed label quality scores for all examples and annotators
     quality_method : str, default = "crowdlab" (Options: ["crowdlab", "agreement"])
         Specifies the method used to calculate the quality of the annotators.
-        For valid quality methods, view :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`
+        For valid quality methods, view `~cleanlab.multiannotator.get_label_quality_multiannotator`
 
     Returns
     -------
@@ -1863,7 +1863,7 @@ def _get_annotator_worst_class(
     labels_multiannotator : np.ndarray
         2D pandas DataFrame of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     consensus_label : np.ndarray
         An array of shape ``(N,)`` with the consensus labels aggregated from all annotators.
     consensus_quality_score : np.ndarray

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -28,11 +28,11 @@ To analyze a fixed dataset labeled by multiple annotators, use the
 The algorithms to compute these estimates are described in `the CROWDLAB paper <https://arxiv.org/abs/2210.06812>`_.
 
 If you have some labeled and unlabeled data (with multiple annotators for some labeled examples) and want to decide what data to collect additional labels for,
-use the `~cleanlab.multiannotator.get_active_learning_scores` function, which is intended for active learning. 
+use the `~cleanlab.multiannotator.get_active_learning_scores` function, which is intended for active learning.
 This function estimates an ActiveLab quality score for each example,
 which can be used to prioritize which examples are most informative to collect additional labels for.
 This function is effective for settings where some examples have been labeled by one or more annotators and other examples can have no labels at all so far,
-as well as settings where new labels are collected either in batches of examples or one at a time. 
+as well as settings where new labels are collected either in batches of examples or one at a time.
 Here is an `example notebook <https://github.com/cleanlab/examples/blob/master/active_learning_multiannotator/active_learning.ipynb>`_ showcasing the use of this ActiveLab method for active learning with data re-labeling.
 
 The algorithms to compute these active learning scores are described in `the ActiveLab paper <https://arxiv.org/abs/2301.11856>`_.
@@ -1373,7 +1373,7 @@ def _get_single_annotator_agreement(
     labels_multiannotator : np.ndarray
         2D numpy array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators.
-        For more details, labels in the same format expected by the :py:func:`get_label_quality_multiannotator <cleanlab.multiannotator.get_label_quality_multiannotator>`.
+        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
     num_annotations : np.ndarray
         An array of shape ``(N,)`` with the number of annotators that have labeled each example.
     annotator_idx : int

--- a/cleanlab/multilabel_classification/dataset.py
+++ b/cleanlab/multilabel_classification/dataset.py
@@ -132,7 +132,7 @@ def rank_classes_by_multilabel_quality(
     **Parameters**:
 
     For information about the arguments to this method, see the documentation of
-    :py:func:`common_multilabel_issues <cleanlab.multilabel_classification.dataset.common_multilabel_issues>`.
+    `~cleanlab.multilabel_classification.dataset.common_multilabel_issues`.
 
     Returns
     -------
@@ -208,7 +208,7 @@ def _get_num_examples_multilabel(labels=None, confident_joint: Optional[np.ndarr
 
     Parameters
     ----------
-    For parameter info, see the docstring of :py:func:`common_multilabel_issues <cleanlab.multilabel_classification.dataset.common_multilabel_issues>`.
+    For parameter info, see the docstring of `~cleanlab.multilabel_classification.dataset.common_multilabel_issues`.
 
     Returns
     -------
@@ -244,7 +244,7 @@ def overall_multilabel_health_score(
     score implies a higher quality dataset.
 
     **Parameters**: For information about the arguments to this method, see the documentation of
-    :py:func:`common_multilabel_issues <cleanlab.multilabel_classification.dataset.common_multilabel_issues>`.
+    `~cleanlab.multilabel_classification.dataset.common_multilabel_issues`.
 
     Returns
     -------
@@ -276,15 +276,15 @@ def multilabel_health_summary(
     * Overall label quality scores, summarizing how accurate the labels appear across the entire dataset.
 
     **Parameters**: For information about the arguments to this method, see the documentation of
-    :py:func:`common_multilabel_issues <cleanlab.multilabel_classification.dataset.common_multilabel_issues>`.
+    `~cleanlab.multilabel_classification.dataset.common_multilabel_issues`.
 
     Returns
     -------
     summary : dict
         A dictionary containing keys (see the corresponding functions' documentation to understand the values):
-            - ``"overall_label_health_score"``, corresponding to output of :py:func:`overall_multilabel_health_score <cleanlab.multilabel_classification.dataset.overall_multilabel_health_score>`
-            - ``"classes_by_multilabel_quality"``, corresponding to output of :py:func:`rank_classes_by_multilabel_quality <cleanlab.multilabel_classification.dataset.rank_classes_by_multilabel_quality>`
-            - ``"common_multilabel_issues"``, corresponding to output of :py:func:`common_multilabel_issues <cleanlab.multilabel_classification.dataset.common_multilabel_issues>`
+            - ``"overall_label_health_score"``, corresponding to output of `~cleanlab.multilabel_classification.dataset.overall_multilabel_health_score`
+            - ``"classes_by_multilabel_quality"``, corresponding to output of `~cleanlab.multilabel_classification.dataset.rank_classes_by_multilabel_quality`
+            - ``"common_multilabel_issues"``, corresponding to output of `~cleanlab.multilabel_classification.dataset.common_multilabel_issues`
     """
     from cleanlab.internal.util import smart_display_dataframe
 

--- a/cleanlab/multilabel_classification/filter.py
+++ b/cleanlab/multilabel_classification/filter.py
@@ -185,7 +185,7 @@ def find_multilabel_issues_per_class(
 ) -> Union[np.ndarray, Tuple[List[np.ndarray], List[Any], List[np.ndarray]]]:
     """
     Identifies potentially bad labels for each example and each class in a multi-label classification dataset.
-    Whereas :py:func:`find_label_issues <cleanlab.multilabel_classification.filter.find_label_issues>`
+    Whereas `~cleanlab.multilabel_classification.filter.find_label_issues`
     estimates which examples have an erroneous annotation for *any* class, this method estimates which specific classes are incorrectly annotated as well.
     This method returns a list of size K, the number of classes in the dataset.
 
@@ -193,12 +193,12 @@ def find_multilabel_issues_per_class(
     ----------
     labels : List[List[int]]
       List of noisy labels for multi-label classification where each example can belong to multiple classes.
-      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.multilabel_classification.filter.find_label_issues>` for further details.
+      Refer to documentation for this argument in `~cleanlab.multilabel_classification.filter.find_label_issues` for further details.
       This method will identify whether ``labels[i][k]`` appears correct, for every example ``i`` and class ``k``.
 
     pred_probs : np.ndarray
       An array of shape ``(N, K)`` of model-predicted class probabilities.
-      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.multilabel_classification.filter.find_label_issues>` for further details.
+      Refer to documentation for this argument in `~cleanlab.multilabel_classification.filter.find_label_issues` for further details.
 
     return_indices_ranked_by : {None, 'self_confidence', 'normalized_margin', 'confidence_weighted_entropy'}, default = None
       This function can return a boolean mask (if this argument is ``None``) or a sorted array of indices based on the specified ranking method (if not ``None``).
@@ -227,7 +227,7 @@ def find_multilabel_issues_per_class(
 
     confident_joint : np.ndarray, optional
       An array of shape ``(K, 2, 2)`` representing a one-vs-rest formatted confident joint.
-      Refer to documentation for this argument in :py:func:`cleanlab.multilabel_classification.filter.find_label_issues <cleanlab.multilabel_classification.filter.find_label_issues>` for details.
+      Refer to documentation for this argument in `~cleanlab.multilabel_classification.filter.find_label_issues` for details.
 
     n_jobs : optional
       Number of processing threads used by multiprocessing.
@@ -243,7 +243,7 @@ def find_multilabel_issues_per_class(
       ``per_class_label_issues[k]`` is a Boolean mask of the same length as the dataset,
       where ``True`` values indicate examples where class ``k`` appears incorrectly annotated.
 
-      For more details, refer to :py:func:`cleanlab.multilabel_classification.filter.find_label_issues <cleanlab.multilabel_classification.filter.find_label_issues>`.
+      For more details, refer to `~cleanlab.multilabel_classification.filter.find_label_issues`.
 
       Otherwise if `return_indices_ranked_by` is not ``None``, then this method returns 3 objects (each of length K, the number of classes): `label_issues_list`, `labels_list`, `pred_probs_list`.
         - *label_issues_list*: an ordered list of indices of examples where class k appears incorrectly annotated, sorted by the likelihood that class k is correctly annotated.

--- a/cleanlab/multilabel_classification/rank.py
+++ b/cleanlab/multilabel_classification/rank.py
@@ -145,10 +145,10 @@ def get_label_quality_scores_per_class(
 ) -> np.ndarray:
     """
     Computes a quality score quantifying how likely each individual class annotation is correct in a multi-label classification dataset.
-    This is similar to :py:func:`get_label_quality_scores <cleanlab.multilabel_classification.rank.get_label_quality_scores>`
+    This is similar to `~cleanlab.multilabel_classification.rank.get_label_quality_scores`
     but instead returns the per-class results without aggregation.
     For a dataset with K classes, each example receives K scores from this method.
-    Refer to documentation in :py:func:`get_label_quality_scores <cleanlab.multilabel_classification.rank.get_label_quality_scores>` for details.
+    Refer to documentation in `~cleanlab.multilabel_classification.rank.get_label_quality_scores` for details.
 
     Parameters
     ----------
@@ -162,7 +162,7 @@ def get_label_quality_scores_per_class(
 
     method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default = "self_confidence"
       Method to calculate separate per-class annotation scores (that quantify how likely a particular class annotation is correct for a particular example).
-      Refer to documentation for this argument in :py:func:`get_label_quality_scores <cleanlab.multilabel_classification.rank.get_label_quality_scores>` for further details.
+      Refer to documentation for this argument in `~cleanlab.multilabel_classification.rank.get_label_quality_scores` for further details.
 
     adjust_pred_probs : bool, default = False
       Account for class imbalance in the label-quality scoring by adjusting predicted probabilities.

--- a/cleanlab/multilabel_classification/rank.py
+++ b/cleanlab/multilabel_classification/rank.py
@@ -109,7 +109,7 @@ def get_label_quality_scores(
       Options for ``"method"`` include: ``"exponential_moving_average"`` or ``"softmin"`` or your own callable function.
       See :py:class:`internal.multilabel_scorer.Aggregator <cleanlab.internal.multilabel_scorer.Aggregator>` for details about each option and other possible hyperparameters.
 
-    To get a score for each class annotation for each example, use the :py:func:`multilabel_classification.classification.rank.get_label_quality_scores_per_class <cleanlab.multilabel_classification.rank.get_label_quality_scores_per_class>` method instead.
+    To get a score for each class annotation for each example, use the `~cleanlab.multilabel_classification.rank.get_label_quality_scores_per_class` method instead.
 
     Returns
     -------

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -434,8 +434,7 @@ def order_label_issues(
 
     rank_by : str, optional
       Score by which to order label error indices (in increasing order). See
-      the `method` argument of :py:func:`get_label_quality_scores
-      <cleanlab.rank.get_label_quality_scores>`.
+      the `method` argument of `~cleanlab.rank.get_label_quality_scores`.
 
     rank_by_kwargs : dict, optional
       Optional keyword arguments to pass into `~cleanlab.rank.get_label_quality_scores` function.

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -17,7 +17,7 @@
 
 """
 Methods to rank examples in standard (multi-class) classification datasets by cleanlab's `label quality score`.
-Except for :py:func:`order_label_issues <cleanlab.rank.order_label_issues>`, which operates only on the subset of the data identified
+Except for `~cleanlab.rank.order_label_issues`, which operates only on the subset of the data identified
 as potential label issues/errors, the methods in this module can be used on whichever subset
 of the dataset you choose (including the entire dataset) and provide a `label quality score` for
 every example. You can then do something like: ``np.argsort(label_quality_score)`` to obtain ranked

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -196,19 +196,19 @@ def get_label_quality_ensemble_scores(
     Parameters
     ----------
     labels : np.ndarray
-      Labels in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      Labels in the same format expected by the `~cleanlab.rank.get_label_quality_scores` function.
 
     pred_probs_list : List[np.ndarray]
       Each element in this list should be an array of pred_probs in the same format
-      expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      expected by the `~cleanlab.rank.get_label_quality_scores` function.
       Each element of `pred_probs_list` corresponds to the predictions from one model for all examples.
 
     method : {"self_confidence", "normalized_margin", "confidence_weighted_entropy"}, default="self_confidence"
-      Label quality scoring method. See :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`
+      Label quality scoring method. See `~cleanlab.rank.get_label_quality_scores`
       for scenarios on when to use each method.
 
     adjust_pred_probs : bool, optional
-      `adjust_pred_probs` in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      `adjust_pred_probs` in the same format expected by the `~cleanlab.rank.get_label_quality_scores` function.
 
     weight_ensemble_members_by : {"uniform", "accuracy", "log_loss_search", "custom"}, default="accuracy"
       Weighting scheme used to aggregate scores from each model:
@@ -427,10 +427,10 @@ def order_label_issues(
       high confidence.
 
     labels : np.ndarray
-      Labels in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      Labels in the same format expected by the `~cleanlab.rank.get_label_quality_scores` function.
 
     pred_probs : np.ndarray (shape (N, K))
-      Predicted-probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      Predicted-probabilities in the same format expected by the `~cleanlab.rank.get_label_quality_scores` function.
 
     rank_by : str, optional
       Score by which to order label error indices (in increasing order). See
@@ -438,7 +438,7 @@ def order_label_issues(
       <cleanlab.rank.get_label_quality_scores>`.
 
     rank_by_kwargs : dict, optional
-      Optional keyword arguments to pass into :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      Optional keyword arguments to pass into `~cleanlab.rank.get_label_quality_scores` function.
       Accepted args include `adjust_pred_probs`.
 
     Returns
@@ -492,10 +492,10 @@ def get_self_confidence_for_each_label(
     Parameters
     ----------
     labels : np.ndarray
-      Labels in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      Labels in the same format expected by the `~cleanlab.rank.get_label_quality_scores` function.
 
     pred_probs : np.ndarray
-      Predicted-probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      Predicted-probabilities in the same format expected by the `~cleanlab.rank.get_label_quality_scores` function.
 
     Returns
     -------
@@ -531,10 +531,10 @@ def get_normalized_margin_for_each_label(
     Parameters
     ----------
     labels : np.ndarray
-      Labels in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      Labels in the same format expected by the `~cleanlab.rank.get_label_quality_scores` function.
 
     pred_probs : np.ndarray
-      Predicted-probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      Predicted-probabilities in the same format expected by the `~cleanlab.rank.get_label_quality_scores` function.
 
     Returns
     -------
@@ -564,10 +564,10 @@ def get_confidence_weighted_entropy_for_each_label(
     Parameters
     ----------
     labels : np.ndarray
-      Labels in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      Labels in the same format expected by the `~cleanlab.rank.get_label_quality_scores` function.
 
     pred_probs : np.ndarray
-      Predicted-probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>` function.
+      Predicted-probabilities in the same format expected by the `~cleanlab.rank.get_label_quality_scores` function.
 
     Returns
     -------

--- a/cleanlab/regression/rank.py
+++ b/cleanlab/regression/rank.py
@@ -151,10 +151,10 @@ def _get_outre_score_for_each_label(
     Parameters
     ----------
     labels: np.ndarray
-        Labels in the same format as expected by the :py:func:`get_label_quality_scores <cleanlab.regression.rank.get_label_quality_scores>` function.
+        Labels in the same format as expected by the `~cleanlab.regression.rank.get_label_quality_scores` function.
 
     predictions: np.ndarray
-        Predicted labels in the same format as expected by the :py:func:`get_label_quality_scores <cleanlab.regression.rank.get_label_quality_scores>` function.
+        Predicted labels in the same format as expected by the `~cleanlab.regression.rank.get_label_quality_scores` function.
 
     residual_scale: float, default = 5
         Multiplicative factor to adjust scale (standard deviation) of the residuals relative to the labels.

--- a/cleanlab/regression/rank.py
+++ b/cleanlab/regression/rank.py
@@ -118,10 +118,10 @@ def _get_residual_score_for_each_label(
     Parameters
     ----------
     labels: np.ndarray
-        Labels in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.regression.rank.get_label_quality_scores>` function.
+        Labels in the same format expected by the `~cleanlab.regression.rank.get_label_quality_scores` function.
 
     predictions: np.ndarray
-        Predicted labels in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.regression.rank.get_label_quality_scores>` function.
+        Predicted labels in the same format expected by the `~cleanlab.regression.rank.get_label_quality_scores` function.
 
     Returns
     -------

--- a/cleanlab/segmentation/rank.py
+++ b/cleanlab/segmentation/rank.py
@@ -146,7 +146,7 @@ def issues_from_scores(
     image_scores: np.ndarray, pixel_scores: Optional[np.ndarray] = None, threshold: float = 0.1
 ) -> Union[list, np.ndarray]:
     """
-    Converts scores output by :py:func:`segmentation.rank.get_label_quality_scores <cleanlab.segmentation.rank.get_label_quality_scores>`
+    Converts scores output by `~cleanlab.segmentation.rank.get_label_quality_scores`
     to a list of issues of similar format as output by :py:func:`segmentation.filter.find_label_issues <cleanlab.segmentation.filter.find_label_issues>`.
 
     Only considers as issues those tokens with label quality score lower than `threshold`,
@@ -161,11 +161,11 @@ def issues_from_scores(
     ----------
     image_scores:
       Array of shape `(N, )` of overall image scores, where `N` is the number of images in the dataset.
-      Same format as the `image_scores` returned by :py:func:`segmentation.rank.get_label_quality_scores <cleanlab.segmentation.rank.get_label_quality_scores>`.
+      Same format as the `image_scores` returned by `~cleanlab.segmentation.rank.get_label_quality_scores`.
 
     pixel_scores:
       Optional array of shape ``(N,H,W)`` of scores between 0 and 1, one per pixel in the dataset.
-      Same format as the `pixel_scores` returned by :py:func:`segmentation.rank.get_label_quality_scores <cleanlab.segmentation.rank.get_label_quality_scores>`.
+      Same format as the `pixel_scores` returned by `~cleanlab.segmentation.rank.get_label_quality_scores`.
 
     threshold:
         Optional quality scores threshold that determines which pixels are included in result. Pixels with with quality scores above the `threshold` are not

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -169,12 +169,12 @@ def issues_from_scores(
     sentence_scores:
         Array of shape `(N, )` of overall sentence scores, where `N` is the number of sentences in the dataset.
 
-        Same format as the `sentence_scores` returned by :py:func:`token_classification.rank.get_label_quality_scores <cleanlab.token_classification.rank.get_label_quality_scores>`.
+        Same format as the `sentence_scores` returned by `~cleanlab.token_classification.rank.get_label_quality_scores`.
 
     token_scores:
         Optional list such that `token_scores[i]` contains the individual token scores for the `i`-th sentence.
 
-        Same format as the `token_scores` returned by :py:func:`token_classification.rank.get_label_quality_scores <cleanlab.token_classification.rank.get_label_quality_scores>`.
+        Same format as the `token_scores` returned by `~cleanlab.token_classification.rank.get_label_quality_scores`.
 
     threshold:
         Tokens (or sentences, if `token_scores` is not provided) with quality scores above the `threshold` are not

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -79,7 +79,7 @@ def get_label_quality_scores(
     sentence_score_kwargs:
         Optional keyword arguments for `sentence_score_method` function (for advanced users only).
 
-        See `cleanlab.token_classification.rank._softmin_sentence_score` for more info about keyword arguments supported for that scoring method.
+        See `~cleanlab.token_classification.rank._softmin_sentence_score` for more info about keyword arguments supported for that scoring method.
 
     Returns
     -------

--- a/cleanlab/token_classification/rank.py
+++ b/cleanlab/token_classification/rank.py
@@ -151,7 +151,7 @@ def issues_from_scores(
     sentence_scores: np.ndarray, *, token_scores: Optional[list] = None, threshold: float = 0.1
 ) -> Union[list, np.ndarray]:
     """
-    Converts scores output by :py:func:`token_classification.rank.get_label_quality_scores <cleanlab.token_classification.rank.get_label_quality_scores>`
+    Converts scores output by `~cleanlab.token_classification.rank.get_label_quality_scores`
     to a list of issues of similar format as output by :py:func:`token_classification.filter.find_label_issues <cleanlab.token_classification.filter.find_label_issues>`.
 
     Issues are sorted by label quality score, from most to least severe.

--- a/cleanlab/token_classification/summary.py
+++ b/cleanlab/token_classification/summary.py
@@ -178,13 +178,13 @@ def common_label_issues(
         Nested list such that `tokens[i]` is a list of tokens (strings/words) that comprise the `i`-th sentence.
 
     labels:
-        Optional nested list of given labels for all tokens in the same format as `labels` for :py:func:`token_classification.summary.display_issues <cleanlab.token_classification.summary.display_issues>`.
+        Optional nested list of given labels for all tokens in the same format as `labels` for `~cleanlab.token_classification.summary.display_issues`.
 
         If `labels` is provided, this function also displays given label of the token identified to commonly suffer from label issues.
 
     pred_probs:
         Optional list of model-predicted probabilities (np arrays) in the same format as `pred_probs` for
-        :py:func:`token_classification.summary.display_issues <cleanlab.token_classification.summary.display_issues>`.
+        `~cleanlab.token_classification.summary.display_issues`.
 
         If both `labels` and `pred_probs` are provided, also reports each type of given/predicted label swap for tokens identified to commonly suffer from label issues.
 
@@ -198,7 +198,7 @@ def common_label_issues(
 
     exclude:
         Optional list of given/predicted label swaps (tuples) to be ignored in the same format as `exclude` for
-        :py:func:`token_classification.summary.display_issues <cleanlab.token_classification.summary.display_issues>`.
+        `~cleanlab.token_classification.summary.display_issues`.
 
     verbose:
         Whether to also print out the token information in the returned DataFrame `df`.


### PR DESCRIPTION
Resolves #702 
Replaces #790 

- [x] classification.py
- [x] count.py
- [x] dataset.py
- [x] filter.py
- [x] multiannotator.py
- [x] rank.py
- [x] files in datalab/
- [x] files in internal/
- [x] files in multilabel_classification/
- [x] files in token_classification/

none found
- [x] files in benchmarking
- [x] files in experimental/
- [x] files in models


Apologies, that this took so long. As mentioned in the other ticket. I missed one of the requirements and didn't make the correct changes. I've closed the old ticket. I'm not super confident, but I did double and triple check the changes. Hoping I didn't miss anything.


Notes. Can squash and merge at the end. 