### PR TITLE
List comprehension to numpy ops for efficiency

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -148,14 +148,11 @@ def num_label_issues(
         )
 
         label_issues_mask = np.zeros(len(labels), dtype=bool)
-        for idx in cl_error_indices:
-            label_issues_mask[idx] = True
+        label_issues_mask[cl_error_indices] = True
 
         # Remove label issues if given label == model prediction
         pred = pred_probs.argmax(axis=1)
-        for i, pred_label in enumerate(pred):
-            if pred_label == labels[i]:
-                label_issues_mask[i] = False
+        label_issues_mask[pred == labels] = False
         num_issues = np.sum(label_issues_mask)
     elif estimation_method == "off_diagonal_calibrated":
         calculated_confident_joint = compute_confident_joint(

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -438,8 +438,7 @@ def find_label_issues(
 
     if filter_by in ["confident_learning", "low_normalized_margin", "low_self_confidence"]:
         label_issues_mask = np.zeros(len(labels), dtype=bool)
-        for idx in cl_error_indices:
-            label_issues_mask[idx] = True
+        label_issues_mask[cl_error_indices] = True
 
     if filter_by == "predicted_neq_given":
         label_issues_mask = find_predicted_neq_given(labels, pred_probs, multi_label=multi_label)
@@ -447,9 +446,7 @@ def find_label_issues(
     if filter_by not in ["low_self_confidence", "low_normalized_margin"]:
         # Remove label issues if given label == model prediction if issues haven't been removed yet
         pred = pred_probs.argmax(axis=1)
-        for i, pred_label in enumerate(pred):
-            if pred_label == labels[i]:
-                label_issues_mask[i] = False
+        label_issues_mask[pred == labels] = False
 
     if verbose:
         print("Number of label issues found: {}".format(sum(label_issues_mask)))
@@ -505,8 +502,7 @@ def _find_label_issues_multilabel(
 
         cl_error_indices = np.argsort(label_quality_scores)[:num_errors]
         label_issues_mask = np.zeros(len(labels), dtype=bool)
-        for idx in cl_error_indices:
-            label_issues_mask[idx] = True
+        label_issues_mask[cl_error_indices] = True
 
         if return_indices_ranked_by is not None:
             label_quality_scores_issues = ml_scorer.get_label_quality_scores(

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -505,7 +505,7 @@ def get_self_confidence_for_each_label(
     """
 
     # To make this work for multi-label (but it will slow down runtime), return:
-    # np.mean(pred_probs[np.arange(labels.shape[0]), labels], axis=1)
+    # np.array([np.mean(pred_probs[i, l]) for i, l in enumerate(labels)])
     return pred_probs[np.arange(labels.shape[0]), labels]
 
 

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -504,9 +504,9 @@ def get_self_confidence_for_each_label(
       Lower scores indicate more likely mislabeled examples.
     """
 
-    # To make this work for multi-label (but it will slow down runtime), replace:
-    # pred_probs[i, l] -> np.mean(pred_probs[i, l])
-    return np.array([pred_probs[i, l] for i, l in enumerate(labels)])
+    # To make this work for multi-label (but it will slow down runtime), return:
+    # np.mean(pred_probs[np.arange(labels.shape[0]), labels], axis=1)
+    return pred_probs[np.arange(labels.shape[0]), labels]
 
 
 def get_normalized_margin_for_each_label(
@@ -544,8 +544,10 @@ def get_normalized_margin_for_each_label(
     """
 
     self_confidence = get_self_confidence_for_each_label(labels, pred_probs)
-    max_prob_not_label = np.array(
-        [max(np.delete(pred_probs[i], l, -1)) for i, l in enumerate(labels)]
+    N, D = pred_probs.shape
+    del_indices = np.arange(N) * D + labels
+    max_prob_not_label = np.max(
+        np.delete(pred_probs, del_indices, axis=None).reshape(N, D - 1), axis=-1
     )
     label_quality_scores = (self_confidence - max_prob_not_label + 1) / 2
     return label_quality_scores

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -544,10 +544,10 @@ def get_normalized_margin_for_each_label(
     """
 
     self_confidence = get_self_confidence_for_each_label(labels, pred_probs)
-    N, D = pred_probs.shape
-    del_indices = np.arange(N) * D + labels
+    N, K = pred_probs.shape
+    del_indices = np.arange(N) * K + labels
     max_prob_not_label = np.max(
-        np.delete(pred_probs, del_indices, axis=None).reshape(N, D - 1), axis=-1
+        np.delete(pred_probs, del_indices, axis=None).reshape(N, K - 1), axis=-1
     )
     label_quality_scores = (self_confidence - max_prob_not_label + 1) / 2
     return label_quality_scores


### PR DESCRIPTION
Port list comprehensions to numpy operations. 
Note - The `np.delete` change was derived from [this](https://stackoverflow.com/a/36502927/8505509) SO answer. 

<details><summary>Benchmarks</summary>

Thanks to @elisno for the benchmarking script!

### `np.delete` change.

<img src="https://github.com/cleanlab/cleanlab/assets/23188723/736e81c4-ad19-4894-ad96-d50e36ca74e6" alt="drawing" width="600"/>


### `get_self_confidence_for_each_label` change.
<img src="https://github.com/cleanlab/cleanlab/assets/23188723/6c957b93-6cd8-44f3-a602-53fae28a8b2a" alt="drawing" width="600"/>

</details>

