### PR TITLE
Extends non-iid issue check to run if only pred_probs are provided

### DIFF
--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -199,7 +199,7 @@ class IssueFinder:
             "label": {"pred_probs": pred_probs, "features": features},
             "outlier": {"pred_probs": pred_probs, "features": features, "knn_graph": knn_graph},
             "near_duplicate": {"features": features, "knn_graph": knn_graph},
-            "non_iid": {"pred_probs":pred_probs, "features": features, "knn_graph": knn_graph},
+            "non_iid": {"pred_probs": pred_probs, "features": features, "knn_graph": knn_graph},
         }
 
         args_dict = {

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -199,7 +199,7 @@ class IssueFinder:
             "label": {"pred_probs": pred_probs, "features": features},
             "outlier": {"pred_probs": pred_probs, "features": features, "knn_graph": knn_graph},
             "near_duplicate": {"features": features, "knn_graph": knn_graph},
-            "non_iid": {"features": features, "knn_graph": knn_graph},
+            "non_iid": {"features": features, "pred_probs": pred_probs, "knn_graph": knn_graph},
         }
 
         args_dict = {

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -199,7 +199,7 @@ class IssueFinder:
             "label": {"pred_probs": pred_probs, "features": features},
             "outlier": {"pred_probs": pred_probs, "features": features, "knn_graph": knn_graph},
             "near_duplicate": {"features": features, "knn_graph": knn_graph},
-            "non_iid": {"features": features, "knn_graph": knn_graph},
+            "non_iid": {"pred_probs":pred_probs, "features": features, "knn_graph": knn_graph},
         }
 
         args_dict = {

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -199,7 +199,7 @@ class IssueFinder:
             "label": {"pred_probs": pred_probs, "features": features},
             "outlier": {"pred_probs": pred_probs, "features": features, "knn_graph": knn_graph},
             "near_duplicate": {"features": features, "knn_graph": knn_graph},
-            "non_iid": {"features": features, "pred_probs": pred_probs, "knn_graph": knn_graph},
+            "non_iid": {"features": features, "knn_graph": knn_graph},
         }
 
         args_dict = {

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -132,15 +132,24 @@ class NonIIDIssueManager(IssueManager):
         """
         Determines the feature array to be used for the non-IID check. Prioritizing the original features array over pred_probs.
 
-        Parameters:
-        - features: Original feature array or None.
-        - pred_probs: Predicted probabilities array or None.
+        Parameters
+        ----------
+        features : 
+            Original feature array or None.
+        
+        pred_probs :
+            Predicted probabilities array or None.
 
-        Returns:
-        - Selected feature array.
+        Returns
+        -------
+        features_to_use :
+            Either the original feature array or the predicted probabilities array,
+            intended to be used for the non-IID check.
 
-        Raises:
-        - ValueError: If both `features` and `pred_probs` are None.
+        Raises
+        ------
+        ValueError :
+            If both `features` and `pred_probs` are None.
         """
         if features is not None:
             return features

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -168,7 +168,6 @@ class NonIIDIssueManager(IssueManager):
 
         if self.metric is None:
             self.metric = "cosine" if features_to_use.shape[1] > 3 else "euclidean"
-            metric_changes = True
 
         if knn_graph is not None and not metric_changes:
             return None, features_to_use

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -123,11 +123,11 @@ class NonIIDIssueManager(IssueManager):
         self.background_distribution = None
         self.seed = seed
         self.significance_threshold = significance_threshold
-        
-        # TODO: Temporary flag introduced to decide on storing knn graphs based on pred_probs. 
+
+        # TODO: Temporary flag introduced to decide on storing knn graphs based on pred_probs.
         # Revisit and finalize the implementation.
         self._skip_storing_knn_graph_for_pred_probs: bool = False
-        
+
     @staticmethod
     def _determine_features(
         features: Optional[npt.NDArray],
@@ -138,9 +138,9 @@ class NonIIDIssueManager(IssueManager):
 
         Parameters
         ----------
-        features : 
+        features :
             Original feature array or None.
-        
+
         pred_probs :
             Predicted probabilities array or None.
 

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -156,7 +156,7 @@ class NonIIDIssueManager(IssueManager):
         self,
         features: Optional[npt.NDArray],
         pred_probs: Optional[np.ndarray],
-        knn_graph,
+        knn_graph:Any,
         metric_changes: Any,
     ) -> Tuple[Optional[NearestNeighbors], npt.NDArray]:
         """

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -198,7 +198,7 @@ class NonIIDIssueManager(IssueManager):
     ) -> None:
         knn_graph = self._process_knn_graph_from_inputs(kwargs)
         old_knn_metric = self.datalab.get_info("statistics").get("knn_metric")
-        metric_changes = self.metric and self.metric != old_knn_metric
+        metric_changes = True if (self.metric and self.metric != old_knn_metric) else False
 
         # This block of code has been extracted to a helper method for readability and making the code more modular.
         knn, features_used = self._select_features_and_setup_knn(

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -207,8 +207,6 @@ class NonIIDIssueManager(IssueManager):
         knn_graph = self._process_knn_graph_from_inputs(kwargs)
         old_knn_metric = self.datalab.get_info("statistics").get("knn_metric")
         metric_changes = self.metric and self.metric != old_knn_metric
-
-        # This block of code has been extracted to a helper method for readability and making the code more modular.
         knn, features_used = self._select_features_and_setup_knn(
             features, pred_probs, knn_graph, metric_changes
         )

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -165,8 +165,8 @@ class NonIIDIssueManager(IssueManager):
         self,
         features: Optional[npt.NDArray],
         pred_probs: Optional[np.ndarray],
-        knn_graph: Any,
-        metric_changes: Any,
+        knn_graph: Optional[csr_matrix],
+        metric_changes: bool,
     ) -> Tuple[Optional[NearestNeighbors], npt.NDArray]:
         """
         Selects features (or pred_probs if features are None) and sets up a NearestNeighbors object if needed.

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -408,7 +408,7 @@ class NonIIDIssueManager(IssueManager):
         shifted_neighbors[:, 1:] = sorted_neighbors[:, :-1]
         diffs = sorted_neighbors - shifted_neighbors  # the distances between the sorted indices
 
-        area_beginning = (double_distances ** 2) / (N - 1)
+        area_beginning = (double_distances**2) / (N - 1)
         length = N - 2 * double_distances - 1
         a = 2 * double_distances / (N - 1)
         area_middle = 0.5 * (a + 1) * length
@@ -416,7 +416,7 @@ class NonIIDIssueManager(IssueManager):
         # compute the area under the CDF for each of the indices in sorted_neighbors
         background_area = np.zeros(diffs.shape)
         background_diffs = np.zeros(diffs.shape)
-        background_area[set_beginning] = ((sorted_neighbors ** 2) / (N - 1))[set_beginning]
+        background_area[set_beginning] = ((sorted_neighbors**2) / (N - 1))[set_beginning]
         background_area[set_middle] = (
             area_beginning
             + 0.5

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -124,7 +124,8 @@ class NonIIDIssueManager(IssueManager):
         self.seed = seed
         self.significance_threshold = significance_threshold
 
-    def find_issues(self, features: Optional[npt.NDArray] = None, **kwargs) -> None:
+    def find_issues(self, features: Optional[npt.NDArray] = None,
+                    pred_probs: Optional[np.ndarray] = None, **kwargs) -> None:
         knn_graph = self._process_knn_graph_from_inputs(kwargs)
         old_knn_metric = self.datalab.get_info("statistics").get("knn_metric")
         metric_changes = self.metric and self.metric != old_knn_metric
@@ -133,9 +134,14 @@ class NonIIDIssueManager(IssueManager):
 
         if knn_graph is None or metric_changes:
             if features is None:
-                raise ValueError(
-                    "If a knn_graph is not provided, features must be provided to fit a new knn."
-                )
+                if pred_probs is None:
+                    raise ValueError(
+                        "If a knn_graph is not provided and features is not provided, pred_probs must be provided "
+                        "to fit a new knn."
+                    )
+                else:
+                    # using pred_probs as features if features are not provided
+                    features = pred_probs
 
             if self.metric is None:
                 self.metric = "cosine" if features.shape[1] > 3 else "euclidean"

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -197,7 +197,7 @@ class NonIIDIssueManager(IssueManager):
     ) -> None:
         knn_graph = self._process_knn_graph_from_inputs(kwargs)
         old_knn_metric = self.datalab.get_info("statistics").get("knn_metric")
-        metric_changes = True if (self.metric and self.metric != old_knn_metric) else False
+        metric_changes = self.metric and self.metric != old_knn_metric
 
         # This block of code has been extracted to a helper method for readability and making the code more modular.
         knn, features_used = self._select_features_and_setup_knn(

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -157,7 +157,7 @@ class NonIIDIssueManager(IssueManager):
         features: Optional[npt.NDArray],
         pred_probs: Optional[np.ndarray],
         knn_graph,
-        metric_changes: bool,
+        metric_changes: Any,
     ) -> Tuple[Optional[NearestNeighbors], npt.NDArray]:
         """
         Selects features (or pred_probs if features are None) and sets up a NearestNeighbors object if needed.

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -124,8 +124,12 @@ class NonIIDIssueManager(IssueManager):
         self.seed = seed
         self.significance_threshold = significance_threshold
 
-    def find_issues(self, features: Optional[npt.NDArray] = None,
-                    pred_probs: Optional[np.ndarray] = None, **kwargs) -> None:
+    def find_issues(
+        self,
+        features: Optional[npt.NDArray] = None,
+        pred_probs: Optional[np.ndarray] = None,
+        **kwargs,
+    ) -> None:
         knn_graph = self._process_knn_graph_from_inputs(kwargs)
         old_knn_metric = self.datalab.get_info("statistics").get("knn_metric")
         metric_changes = self.metric and self.metric != old_knn_metric

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -156,7 +156,7 @@ class NonIIDIssueManager(IssueManager):
         self,
         features: Optional[npt.NDArray],
         pred_probs: Optional[np.ndarray],
-        knn_graph:Any,
+        knn_graph: Any,
         metric_changes: Any,
     ) -> Tuple[Optional[NearestNeighbors], npt.NDArray]:
         """

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -61,6 +61,12 @@ class TestNonIIDIssueManager:
         return embeddings_array
 
     @pytest.fixture
+    def pred_probs(self, lab):
+        pred_probs_array = (np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1)) / len(
+            np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1))
+        return pred_probs_array
+
+    @pytest.fixture
     def issue_manager(self, lab):
         return NonIIDIssueManager(
             datalab=lab,
@@ -121,6 +127,46 @@ class TestNonIIDIssueManager:
         assert info_perm.get("p-value", None) is not None, "Should have p-value"
         assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
 
+    def test_find_issues_with_pred_probs(self, issue_manager, pred_probs):
+        # checking the non-iid with pred_probs
+        pred_probs = pred_probs
+        issue_manager.find_issues(pred_probs=pred_probs)
+        issues_sort, summary_sort, info_sort = (
+            issue_manager.issues,
+            issue_manager.summary,
+            issue_manager.info,
+        )
+        expected_sorted_issue_mask = np.array([False] * 46 + [True] + [False] * 3)
+        assert np.all(
+            issues_sort["is_non_iid_issue"] == expected_sorted_issue_mask
+        ), "Issue mask should be correct"
+        assert summary_sort["issue_type"][0] == "non_iid"
+        assert summary_sort["score"][0] == pytest.approx(expected=0.0, abs=1e-7)
+        assert info_sort.get("p-value", None) is not None, "Should have p-value"
+        assert summary_sort["score"][0] == pytest.approx(expected=info_sort["p-value"], abs=1e-7)
+
+        permutation = np.random.permutation(len(pred_probs))
+        new_issue_manager = NonIIDIssueManager(
+            datalab=issue_manager.datalab,
+            metric="euclidean",
+            k=10,
+        )
+        new_issue_manager.find_issues(features=pred_probs[permutation])
+        issues_perm, summary_perm, info_perm = (
+            new_issue_manager.issues,
+            new_issue_manager.summary,
+            new_issue_manager.info,
+        )
+        expected_permuted_issue_mask = np.array([False] * len(pred_probs))
+        assert np.all(
+            issues_perm["is_non_iid_issue"] == expected_permuted_issue_mask
+        ), "Issue mask should be correct"
+        assert summary_perm["issue_type"][0] == "non_iid"
+        # ensure score is large, cannot easily ensure precise value because random seed has different effects on different OS:
+        assert summary_perm["score"][0] > 0.05
+        assert info_perm.get("p-value", None) is not None, "Should have p-value"
+        assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
+
     def test_report(self, issue_manager, embeddings):
         np.random.seed(SEED)
         issue_manager.find_issues(features=embeddings)
@@ -132,9 +178,32 @@ class TestNonIIDIssueManager:
 
         assert isinstance(report, str)
         assert (
-            "---------------------- non_iid issues ----------------------\n\n"
-            "Number of examples with this issue:"
-        ) in report
+                   "---------------------- non_iid issues ----------------------\n\n"
+                   "Number of examples with this issue:"
+               ) in report
+
+        report = issue_manager.report(
+            issues=issue_manager.issues,
+            summary=issue_manager.summary,
+            info=issue_manager.info,
+            verbosity=3,
+        )
+        assert "Additional Information: " in report
+
+    def test_report_using_pred_probs(self, issue_manager, pred_probs):
+        # using pred_probs instead of features
+        issue_manager.find_issues(pred_probs=pred_probs)
+        report = issue_manager.report(
+            issues=issue_manager.issues,
+            summary=issue_manager.summary,
+            info=issue_manager.info,
+        )
+
+        assert isinstance(report, str)
+        assert (
+                   "---------------------- non_iid issues ----------------------\n\n"
+                   "Number of examples with this issue:"
+               ) in report
 
         report = issue_manager.report(
             issues=issue_manager.issues,
@@ -151,6 +220,19 @@ class TestNonIIDIssueManager:
         """
 
         issue_manager.find_issues(features=embeddings)
+        info = issue_manager.info
+
+        assert info["p-value"] == 0
+        assert info["metric"] == "euclidean"
+        assert info["k"] == 10
+
+    def test_collect_info_using_pred_probs(self, issue_manager, pred_probs):
+        """Test some values in the info dict.
+
+        Mainly focused on the nearest neighbor info.
+        """
+        # using pred_probs instead of features
+        issue_manager.find_issues(pred_probs=pred_probs)
         info = issue_manager.info
 
         assert info["p-value"] == 0
@@ -214,6 +296,35 @@ class TestNonIIDIssueManager:
 
         # Run again with the same seed
         issue_manager.find_issues(features=embeddings)
+        p_value2 = issue_manager.info["p-value"]
+
+        assert p_value > 0.0
+        if seed is not None or seed == "default":
+            assert p_value == p_value2
+        else:
+            assert p_value != p_value2
+
+        # using pred_probs
+        # normalizing pred_probs (0 to 1)
+        pred_probs = embeddings/(np.max(embeddings)-np.min(embeddings))
+        if seed == "default":
+            issue_manager = NonIIDIssueManager(
+                datalab=lab,
+                metric="euclidean",
+                k=10,
+            )
+        else:
+            issue_manager = NonIIDIssueManager(
+                datalab=lab,
+                metric="euclidean",
+                k=10,
+                seed=seed,
+            )
+        issue_manager.find_issues(pred_probs=pred_probs)
+        p_value = issue_manager.info["p-value"]
+
+        # Run again with the same seed
+        issue_manager.find_issues(pred_probs=pred_probs)
         p_value2 = issue_manager.info["p-value"]
 
         assert p_value > 0.0

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -62,8 +62,9 @@ class TestNonIIDIssueManager:
 
     @pytest.fixture
     def pred_probs(self, lab):
-        pred_probs_array = (np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1)) / len(
-            np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1))
+        pred_probs_array = (
+            np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1)
+        ) / len(np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1))
         return pred_probs_array
 
     @pytest.fixture
@@ -178,9 +179,9 @@ class TestNonIIDIssueManager:
 
         assert isinstance(report, str)
         assert (
-                   "---------------------- non_iid issues ----------------------\n\n"
-                   "Number of examples with this issue:"
-               ) in report
+            "---------------------- non_iid issues ----------------------\n\n"
+            "Number of examples with this issue:"
+        ) in report
 
         report = issue_manager.report(
             issues=issue_manager.issues,
@@ -201,9 +202,9 @@ class TestNonIIDIssueManager:
 
         assert isinstance(report, str)
         assert (
-                   "---------------------- non_iid issues ----------------------\n\n"
-                   "Number of examples with this issue:"
-               ) in report
+            "---------------------- non_iid issues ----------------------\n\n"
+            "Number of examples with this issue:"
+        ) in report
 
         report = issue_manager.report(
             issues=issue_manager.issues,
@@ -306,7 +307,7 @@ class TestNonIIDIssueManager:
 
         # using pred_probs
         # normalizing pred_probs (0 to 1)
-        pred_probs = embeddings/(np.max(embeddings)-np.min(embeddings))
+        pred_probs = embeddings / (np.max(embeddings) - np.min(embeddings))
         if seed == "default":
             issue_manager = NonIIDIssueManager(
                 datalab=lab,

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -66,8 +66,8 @@ class TestNonIIDIssueManager:
     @pytest.fixture
     def pred_probs(self, lab):
         pred_probs_array = (
-                               np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1)
-                           ) / len(np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1))
+            np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1)
+        ) / len(np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1))
         return pred_probs_array
 
     @pytest.fixture
@@ -92,11 +92,20 @@ class TestNonIIDIssueManager:
 
         assert issue_manager.num_permutations == 15
 
-    @pytest.mark.parametrize("datalab_flag, features_flag",
-                             [(True, True), (False, False), (False, True), (True, False)])
-    def test_find_issues(self, issue_manager, embeddings, pred_probs, lab, datalab_flag, features_flag, dataset,
-                         label_name):
-
+    @pytest.mark.parametrize(
+        "datalab_flag, features_flag", [(True, True), (False, False), (False, True), (True, False)]
+    )
+    def test_find_issues(
+        self,
+        issue_manager,
+        embeddings,
+        pred_probs,
+        lab,
+        datalab_flag,
+        features_flag,
+        dataset,
+        label_name,
+    ):
         np.random.seed(SEED)
         if datalab_flag:
             if features_flag:
@@ -165,8 +174,9 @@ class TestNonIIDIssueManager:
         assert info_perm.get("p-value", None) is not None, "Should have p-value"
         assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
 
-    @pytest.mark.parametrize("datalab_flag, features_flag",
-                             [(True, True), (False, False), (False, True), (True, False)])
+    @pytest.mark.parametrize(
+        "datalab_flag, features_flag", [(True, True), (False, False), (False, True), (True, False)]
+    )
     def test_report(self, issue_manager, embeddings, lab, pred_probs, datalab_flag, features_flag):
         np.random.seed(SEED)
         if datalab_flag:
@@ -175,13 +185,16 @@ class TestNonIIDIssueManager:
             else:
                 lab.find_issues(pred_probs=pred_probs)
             lab.data_issues.issue_summary = lab.data_issues.issue_summary[
-                lab.data_issues.issue_summary["issue_type"] == "non_iid"]
+                lab.data_issues.issue_summary["issue_type"] == "non_iid"
+            ]
             reporter = report_factory(lab._imagelab)(
                 data_issues=lab.data_issues,
                 verbosity=0,
                 imagelab=lab._imagelab,
             )
-            report = reporter.get_report(num_examples=len(embeddings) if features_flag else len(pred_probs))
+            report = reporter.get_report(
+                num_examples=len(embeddings) if features_flag else len(pred_probs)
+            )
         else:
             if features_flag:
                 issue_manager.find_issues(features=embeddings)
@@ -195,15 +208,17 @@ class TestNonIIDIssueManager:
 
         assert isinstance(report, str)
         if datalab_flag:
-            assert ('Here is a summary of the different kinds of issues found in the data:\n'
-                    '\n'
-                    'issue_type  num_issues\n'
-                    '   non_iid') in report
+            assert (
+                "Here is a summary of the different kinds of issues found in the data:\n"
+                "\n"
+                "issue_type  num_issues\n"
+                "   non_iid"
+            ) in report
         else:
             assert (
-                       "---------------------- non_iid issues ----------------------\n\n"
-                       "Number of examples with this issue:"
-                   ) in report
+                "---------------------- non_iid issues ----------------------\n\n"
+                "Number of examples with this issue:"
+            ) in report
 
         if datalab_flag:
             if features_flag:
@@ -211,13 +226,16 @@ class TestNonIIDIssueManager:
             else:
                 lab.find_issues(pred_probs=pred_probs)
             lab.data_issues.issue_summary = lab.data_issues.issue_summary[
-                lab.data_issues.issue_summary["issue_type"] == "non_iid"]
+                lab.data_issues.issue_summary["issue_type"] == "non_iid"
+            ]
             reporter = report_factory(lab._imagelab)(
                 data_issues=lab.data_issues,
                 verbosity=3,
                 imagelab=lab._imagelab,
             )
-            report = reporter.get_report(num_examples=len(embeddings) if features_flag else len(pred_probs))
+            report = reporter.get_report(
+                num_examples=len(embeddings) if features_flag else len(pred_probs)
+            )
         else:
             if features_flag:
                 issue_manager.find_issues(features=embeddings)
@@ -232,9 +250,12 @@ class TestNonIIDIssueManager:
 
         assert "Additional Information: " in report
 
-    @pytest.mark.parametrize("datalab_flag, features_flag",
-                             [(True, True), (False, False), (False, True), (True, False)])
-    def test_collect_info(self, issue_manager, embeddings, pred_probs, lab, datalab_flag, features_flag):
+    @pytest.mark.parametrize(
+        "datalab_flag, features_flag", [(True, True), (False, False), (False, True), (True, False)]
+    )
+    def test_collect_info(
+        self, issue_manager, embeddings, pred_probs, lab, datalab_flag, features_flag
+    ):
         """Test some values in the info dict.
 
         Mainly focused on the nearest neighbor info.

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -89,15 +89,7 @@ class TestNonIIDIssueManager:
 
         assert issue_manager.num_permutations == 15
 
-    def test_find_issues(
-        self,
-        issue_manager,
-        embeddings,
-        pred_probs,
-        lab,
-        dataset,
-        label_name,
-    ):
+    def test_find_issues(self, issue_manager, embeddings):
         np.random.seed(SEED)
         issue_manager.find_issues(features=embeddings)
         issues_sort, summary_sort, info_sort = (
@@ -137,15 +129,7 @@ class TestNonIIDIssueManager:
         assert info_perm.get("p-value", None) is not None, "Should have p-value"
         assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
 
-    def test_find_issues_using_pred_probs(
-        self,
-        issue_manager,
-        embeddings,
-        pred_probs,
-        lab,
-        dataset,
-        label_name,
-    ):
+    def test_find_issues_using_pred_probs(self, issue_manager, pred_probs):
         np.random.seed(SEED)
         issue_manager.find_issues(pred_probs=pred_probs)
         issues_sort, summary_sort, info_sort = (
@@ -162,7 +146,7 @@ class TestNonIIDIssueManager:
         assert info_sort.get("p-value", None) is not None, "Should have p-value"
         assert summary_sort["score"][0] == pytest.approx(expected=info_sort["p-value"], abs=1e-7)
 
-        permutation = np.random.permutation(len(embeddings))
+        permutation = np.random.permutation(len(pred_probs))
         new_issue_manager = NonIIDIssueManager(
             datalab=issue_manager.datalab,
             metric="euclidean",
@@ -175,7 +159,7 @@ class TestNonIIDIssueManager:
             new_issue_manager.summary,
             new_issue_manager.info,
         )
-        expected_permuted_issue_mask = np.array([False] * len(embeddings))
+        expected_permuted_issue_mask = np.array([False] * len(pred_probs))
         assert np.all(
             issues_perm["is_non_iid_issue"] == expected_permuted_issue_mask
         ), "Issue mask should be correct"
@@ -186,7 +170,7 @@ class TestNonIIDIssueManager:
         assert info_perm.get("p-value", None) is not None, "Should have p-value"
         assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
 
-    def test_report(self, issue_manager, embeddings, lab, pred_probs):
+    def test_report(self, issue_manager, embeddings):
         np.random.seed(SEED)
         issue_manager.find_issues(features=embeddings)
         report = issue_manager.report(
@@ -211,7 +195,7 @@ class TestNonIIDIssueManager:
 
         assert "Additional Information: " in report
 
-    def test_report_using_pred_probs(self, issue_manager, embeddings, lab, pred_probs):
+    def test_report_using_pred_probs(self, issue_manager, pred_probs):
         np.random.seed(SEED)
         issue_manager.find_issues(pred_probs=pred_probs)
         report = issue_manager.report(
@@ -235,7 +219,7 @@ class TestNonIIDIssueManager:
 
         assert "Additional Information: " in report
 
-    def test_collect_info(self, issue_manager, embeddings, pred_probs, lab):
+    def test_collect_info(self, issue_manager, embeddings):
         """Test some values in the info dict.
 
         Mainly focused on the nearest neighbor info.
@@ -248,7 +232,7 @@ class TestNonIIDIssueManager:
         assert info["metric"] == "euclidean"
         assert info["k"] == 10
 
-    def test_collect_info_using_pred_probs(self, issue_manager, embeddings, pred_probs, lab):
+    def test_collect_info_using_pred_probs(self, issue_manager, pred_probs):
         """Test some values in the info dict.
 
         Mainly focused on the nearest neighbor info.

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -6,6 +6,9 @@ from cleanlab.datalab.internal.issue_manager.noniid import (
     simplified_kolmogorov_smirnov_test,
 )
 
+from cleanlab.datalab.internal.helper_factory import report_factory
+from cleanlab.datalab.datalab import Datalab
+
 SEED = 42
 
 
@@ -63,8 +66,8 @@ class TestNonIIDIssueManager:
     @pytest.fixture
     def pred_probs(self, lab):
         pred_probs_array = (
-            np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1)
-        ) / len(np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1))
+                               np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1)
+                           ) / len(np.arange(lab.get_info("statistics")["num_examples"] * 10).reshape(-1, 1))
         return pred_probs_array
 
     @pytest.fixture
@@ -89,14 +92,33 @@ class TestNonIIDIssueManager:
 
         assert issue_manager.num_permutations == 15
 
-    def test_find_issues(self, issue_manager, embeddings):
+    @pytest.mark.parametrize("datalab_flag, features_flag",
+                             [(True, True), (False, False), (False, True), (True, False)])
+    def test_find_issues(self, issue_manager, embeddings, pred_probs, lab, datalab_flag, features_flag, dataset,
+                         label_name):
+
         np.random.seed(SEED)
-        issue_manager.find_issues(features=embeddings)
-        issues_sort, summary_sort, info_sort = (
-            issue_manager.issues,
-            issue_manager.summary,
-            issue_manager.info,
-        )
+        if datalab_flag:
+            if features_flag:
+                lab.find_issues(features=embeddings)
+            else:
+                lab.find_issues(pred_probs=pred_probs)
+
+            issues_sort, summary_sort, info_sort = (
+                lab.get_issues("non_iid"),
+                lab.get_issue_summary("non_iid"),
+                lab.get_info("non_iid"),
+            )
+        else:
+            if features_flag:
+                issue_manager.find_issues(features=embeddings)
+            else:
+                issue_manager.find_issues(pred_probs=pred_probs)
+            issues_sort, summary_sort, info_sort = (
+                issue_manager.issues,
+                issue_manager.summary,
+                issue_manager.info,
+            )
         expected_sorted_issue_mask = np.array([False] * 46 + [True] + [False] * 3)
         assert np.all(
             issues_sort["is_non_iid_issue"] == expected_sorted_issue_mask
@@ -112,12 +134,27 @@ class TestNonIIDIssueManager:
             metric="euclidean",
             k=10,
         )
-        new_issue_manager.find_issues(features=embeddings[permutation])
-        issues_perm, summary_perm, info_perm = (
-            new_issue_manager.issues,
-            new_issue_manager.summary,
-            new_issue_manager.info,
-        )
+        new_lab = Datalab(data=dataset, label_name=label_name)
+        if datalab_flag:
+            if features_flag:
+                new_lab.find_issues(features=embeddings[permutation])
+            else:
+                new_lab.find_issues(pred_probs=pred_probs[permutation])
+            issues_perm, summary_perm, info_perm = (
+                new_lab.get_issues("non_iid"),
+                new_lab.get_issue_summary("non_iid"),
+                new_lab.get_info("non_iid"),
+            )
+        else:
+            if features_flag:
+                new_issue_manager.find_issues(features=embeddings[permutation])
+            else:
+                new_issue_manager.find_issues(pred_probs=pred_probs[permutation])
+            issues_perm, summary_perm, info_perm = (
+                new_issue_manager.issues,
+                new_issue_manager.summary,
+                new_issue_manager.info,
+            )
         expected_permuted_issue_mask = np.array([False] * len(embeddings))
         assert np.all(
             issues_perm["is_non_iid_issue"] == expected_permuted_issue_mask
@@ -128,113 +165,94 @@ class TestNonIIDIssueManager:
         assert info_perm.get("p-value", None) is not None, "Should have p-value"
         assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
 
-    def test_find_issues_with_pred_probs(self, issue_manager, pred_probs):
-        # checking the non-iid with pred_probs
-        pred_probs = pred_probs
-        issue_manager.find_issues(pred_probs=pred_probs)
-        issues_sort, summary_sort, info_sort = (
-            issue_manager.issues,
-            issue_manager.summary,
-            issue_manager.info,
-        )
-        expected_sorted_issue_mask = np.array([False] * 46 + [True] + [False] * 3)
-        assert np.all(
-            issues_sort["is_non_iid_issue"] == expected_sorted_issue_mask
-        ), "Issue mask should be correct"
-        assert summary_sort["issue_type"][0] == "non_iid"
-        assert summary_sort["score"][0] == pytest.approx(expected=0.0, abs=1e-7)
-        assert info_sort.get("p-value", None) is not None, "Should have p-value"
-        assert summary_sort["score"][0] == pytest.approx(expected=info_sort["p-value"], abs=1e-7)
-
-        permutation = np.random.permutation(len(pred_probs))
-        new_issue_manager = NonIIDIssueManager(
-            datalab=issue_manager.datalab,
-            metric="euclidean",
-            k=10,
-        )
-        new_issue_manager.find_issues(features=pred_probs[permutation])
-        issues_perm, summary_perm, info_perm = (
-            new_issue_manager.issues,
-            new_issue_manager.summary,
-            new_issue_manager.info,
-        )
-        expected_permuted_issue_mask = np.array([False] * len(pred_probs))
-        assert np.all(
-            issues_perm["is_non_iid_issue"] == expected_permuted_issue_mask
-        ), "Issue mask should be correct"
-        assert summary_perm["issue_type"][0] == "non_iid"
-        # ensure score is large, cannot easily ensure precise value because random seed has different effects on different OS:
-        assert summary_perm["score"][0] > 0.05
-        assert info_perm.get("p-value", None) is not None, "Should have p-value"
-        assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
-
-    def test_report(self, issue_manager, embeddings):
+    @pytest.mark.parametrize("datalab_flag, features_flag",
+                             [(True, True), (False, False), (False, True), (True, False)])
+    def test_report(self, issue_manager, embeddings, lab, pred_probs, datalab_flag, features_flag):
         np.random.seed(SEED)
-        issue_manager.find_issues(features=embeddings)
-        report = issue_manager.report(
-            issues=issue_manager.issues,
-            summary=issue_manager.summary,
-            info=issue_manager.info,
-        )
+        if datalab_flag:
+            if features_flag:
+                lab.find_issues(features=embeddings)
+            else:
+                lab.find_issues(pred_probs=pred_probs)
+            lab.data_issues.issue_summary = lab.data_issues.issue_summary[
+                lab.data_issues.issue_summary["issue_type"] == "non_iid"]
+            reporter = report_factory(lab._imagelab)(
+                data_issues=lab.data_issues,
+                verbosity=0,
+                imagelab=lab._imagelab,
+            )
+            report = reporter.get_report(num_examples=len(embeddings) if features_flag else len(pred_probs))
+        else:
+            if features_flag:
+                issue_manager.find_issues(features=embeddings)
+            else:
+                issue_manager.find_issues(pred_probs=pred_probs)
+            report = issue_manager.report(
+                issues=issue_manager.issues,
+                summary=issue_manager.summary,
+                info=issue_manager.info,
+            )
 
         assert isinstance(report, str)
-        assert (
-            "---------------------- non_iid issues ----------------------\n\n"
-            "Number of examples with this issue:"
-        ) in report
+        if datalab_flag:
+            assert ('Here is a summary of the different kinds of issues found in the data:\n'
+                    '\n'
+                    'issue_type  num_issues\n'
+                    '   non_iid') in report
+        else:
+            assert (
+                       "---------------------- non_iid issues ----------------------\n\n"
+                       "Number of examples with this issue:"
+                   ) in report
 
-        report = issue_manager.report(
-            issues=issue_manager.issues,
-            summary=issue_manager.summary,
-            info=issue_manager.info,
-            verbosity=3,
-        )
+        if datalab_flag:
+            if features_flag:
+                lab.find_issues(features=embeddings)
+            else:
+                lab.find_issues(pred_probs=pred_probs)
+            lab.data_issues.issue_summary = lab.data_issues.issue_summary[
+                lab.data_issues.issue_summary["issue_type"] == "non_iid"]
+            reporter = report_factory(lab._imagelab)(
+                data_issues=lab.data_issues,
+                verbosity=3,
+                imagelab=lab._imagelab,
+            )
+            report = reporter.get_report(num_examples=len(embeddings) if features_flag else len(pred_probs))
+        else:
+            if features_flag:
+                issue_manager.find_issues(features=embeddings)
+            else:
+                issue_manager.find_issues(pred_probs=pred_probs)
+            report = issue_manager.report(
+                issues=issue_manager.issues,
+                summary=issue_manager.summary,
+                info=issue_manager.info,
+                verbosity=3,
+            )
+
         assert "Additional Information: " in report
 
-    def test_report_using_pred_probs(self, issue_manager, pred_probs):
-        # using pred_probs instead of features
-        issue_manager.find_issues(pred_probs=pred_probs)
-        report = issue_manager.report(
-            issues=issue_manager.issues,
-            summary=issue_manager.summary,
-            info=issue_manager.info,
-        )
-
-        assert isinstance(report, str)
-        assert (
-            "---------------------- non_iid issues ----------------------\n\n"
-            "Number of examples with this issue:"
-        ) in report
-
-        report = issue_manager.report(
-            issues=issue_manager.issues,
-            summary=issue_manager.summary,
-            info=issue_manager.info,
-            verbosity=3,
-        )
-        assert "Additional Information: " in report
-
-    def test_collect_info(self, issue_manager, embeddings):
+    @pytest.mark.parametrize("datalab_flag, features_flag",
+                             [(True, True), (False, False), (False, True), (True, False)])
+    def test_collect_info(self, issue_manager, embeddings, pred_probs, lab, datalab_flag, features_flag):
         """Test some values in the info dict.
 
         Mainly focused on the nearest neighbor info.
         """
 
-        issue_manager.find_issues(features=embeddings)
-        info = issue_manager.info
+        if datalab_flag:
+            if features_flag:
+                lab.find_issues(features=embeddings)
+            else:
+                lab.find_issues(pred_probs=pred_probs)
 
-        assert info["p-value"] == 0
-        assert info["metric"] == "euclidean"
-        assert info["k"] == 10
-
-    def test_collect_info_using_pred_probs(self, issue_manager, pred_probs):
-        """Test some values in the info dict.
-
-        Mainly focused on the nearest neighbor info.
-        """
-        # using pred_probs instead of features
-        issue_manager.find_issues(pred_probs=pred_probs)
-        info = issue_manager.info
+            info = lab.get_info("non_iid")
+        else:
+            if features_flag:
+                issue_manager.find_issues(features=embeddings)
+            else:
+                issue_manager.find_issues(pred_probs=pred_probs)
+            info = issue_manager.info
 
         assert info["p-value"] == 0
         assert info["metric"] == "euclidean"

--- a/tests/datalab/issue_manager/test_noniid.py
+++ b/tests/datalab/issue_manager/test_noniid.py
@@ -6,9 +6,6 @@ from cleanlab.datalab.internal.issue_manager.noniid import (
     simplified_kolmogorov_smirnov_test,
 )
 
-from cleanlab.datalab.internal.helper_factory import report_factory
-from cleanlab.datalab.datalab import Datalab
-
 SEED = 42
 
 
@@ -92,42 +89,22 @@ class TestNonIIDIssueManager:
 
         assert issue_manager.num_permutations == 15
 
-    @pytest.mark.parametrize(
-        "datalab_flag, features_flag", [(True, True), (False, False), (False, True), (True, False)]
-    )
     def test_find_issues(
         self,
         issue_manager,
         embeddings,
         pred_probs,
         lab,
-        datalab_flag,
-        features_flag,
         dataset,
         label_name,
     ):
         np.random.seed(SEED)
-        if datalab_flag:
-            if features_flag:
-                lab.find_issues(features=embeddings)
-            else:
-                lab.find_issues(pred_probs=pred_probs)
-
-            issues_sort, summary_sort, info_sort = (
-                lab.get_issues("non_iid"),
-                lab.get_issue_summary("non_iid"),
-                lab.get_info("non_iid"),
-            )
-        else:
-            if features_flag:
-                issue_manager.find_issues(features=embeddings)
-            else:
-                issue_manager.find_issues(pred_probs=pred_probs)
-            issues_sort, summary_sort, info_sort = (
-                issue_manager.issues,
-                issue_manager.summary,
-                issue_manager.info,
-            )
+        issue_manager.find_issues(features=embeddings)
+        issues_sort, summary_sort, info_sort = (
+            issue_manager.issues,
+            issue_manager.summary,
+            issue_manager.info,
+        )
         expected_sorted_issue_mask = np.array([False] * 46 + [True] + [False] * 3)
         assert np.all(
             issues_sort["is_non_iid_issue"] == expected_sorted_issue_mask
@@ -143,137 +120,141 @@ class TestNonIIDIssueManager:
             metric="euclidean",
             k=10,
         )
-        new_lab = Datalab(data=dataset, label_name=label_name)
-        if datalab_flag:
-            if features_flag:
-                new_lab.find_issues(features=embeddings[permutation])
-            else:
-                new_lab.find_issues(pred_probs=pred_probs[permutation])
-            issues_perm, summary_perm, info_perm = (
-                new_lab.get_issues("non_iid"),
-                new_lab.get_issue_summary("non_iid"),
-                new_lab.get_info("non_iid"),
-            )
-        else:
-            if features_flag:
-                new_issue_manager.find_issues(features=embeddings[permutation])
-            else:
-                new_issue_manager.find_issues(pred_probs=pred_probs[permutation])
-            issues_perm, summary_perm, info_perm = (
-                new_issue_manager.issues,
-                new_issue_manager.summary,
-                new_issue_manager.info,
-            )
+        new_issue_manager.find_issues(features=embeddings[permutation])
+        issues_perm, summary_perm, info_perm = (
+            new_issue_manager.issues,
+            new_issue_manager.summary,
+            new_issue_manager.info,
+        )
         expected_permuted_issue_mask = np.array([False] * len(embeddings))
         assert np.all(
             issues_perm["is_non_iid_issue"] == expected_permuted_issue_mask
         ), "Issue mask should be correct"
         assert summary_perm["issue_type"][0] == "non_iid"
-        # ensure score is large, cannot easily ensure precise value because random seed has different effects on different OS:
+        # ensure score is large, cannot easily ensure precise value because random seed has different effects on
+        # different OS:
         assert summary_perm["score"][0] > 0.05
         assert info_perm.get("p-value", None) is not None, "Should have p-value"
         assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
 
-    @pytest.mark.parametrize(
-        "datalab_flag, features_flag", [(True, True), (False, False), (False, True), (True, False)]
-    )
-    def test_report(self, issue_manager, embeddings, lab, pred_probs, datalab_flag, features_flag):
+    def test_find_issues_using_pred_probs(
+        self,
+        issue_manager,
+        embeddings,
+        pred_probs,
+        lab,
+        dataset,
+        label_name,
+    ):
         np.random.seed(SEED)
-        if datalab_flag:
-            if features_flag:
-                lab.find_issues(features=embeddings)
-            else:
-                lab.find_issues(pred_probs=pred_probs)
-            lab.data_issues.issue_summary = lab.data_issues.issue_summary[
-                lab.data_issues.issue_summary["issue_type"] == "non_iid"
-            ]
-            reporter = report_factory(lab._imagelab)(
-                data_issues=lab.data_issues,
-                verbosity=0,
-                imagelab=lab._imagelab,
-            )
-            report = reporter.get_report(
-                num_examples=len(embeddings) if features_flag else len(pred_probs)
-            )
-        else:
-            if features_flag:
-                issue_manager.find_issues(features=embeddings)
-            else:
-                issue_manager.find_issues(pred_probs=pred_probs)
-            report = issue_manager.report(
-                issues=issue_manager.issues,
-                summary=issue_manager.summary,
-                info=issue_manager.info,
-            )
+        issue_manager.find_issues(pred_probs=pred_probs)
+        issues_sort, summary_sort, info_sort = (
+            issue_manager.issues,
+            issue_manager.summary,
+            issue_manager.info,
+        )
+        expected_sorted_issue_mask = np.array([False] * 46 + [True] + [False] * 3)
+        assert np.all(
+            issues_sort["is_non_iid_issue"] == expected_sorted_issue_mask
+        ), "Issue mask should be correct"
+        assert summary_sort["issue_type"][0] == "non_iid"
+        assert summary_sort["score"][0] == pytest.approx(expected=0.0, abs=1e-7)
+        assert info_sort.get("p-value", None) is not None, "Should have p-value"
+        assert summary_sort["score"][0] == pytest.approx(expected=info_sort["p-value"], abs=1e-7)
+
+        permutation = np.random.permutation(len(embeddings))
+        new_issue_manager = NonIIDIssueManager(
+            datalab=issue_manager.datalab,
+            metric="euclidean",
+            k=10,
+        )
+
+        new_issue_manager.find_issues(pred_probs=pred_probs[permutation])
+        issues_perm, summary_perm, info_perm = (
+            new_issue_manager.issues,
+            new_issue_manager.summary,
+            new_issue_manager.info,
+        )
+        expected_permuted_issue_mask = np.array([False] * len(embeddings))
+        assert np.all(
+            issues_perm["is_non_iid_issue"] == expected_permuted_issue_mask
+        ), "Issue mask should be correct"
+        assert summary_perm["issue_type"][0] == "non_iid"
+        # ensure score is large, cannot easily ensure precise value because random seed has different effects on
+        # different OS:
+        assert summary_perm["score"][0] > 0.05
+        assert info_perm.get("p-value", None) is not None, "Should have p-value"
+        assert summary_perm["score"][0] == pytest.approx(expected=info_perm["p-value"], abs=1e-7)
+
+    def test_report(self, issue_manager, embeddings, lab, pred_probs):
+        np.random.seed(SEED)
+        issue_manager.find_issues(features=embeddings)
+        report = issue_manager.report(
+            issues=issue_manager.issues,
+            summary=issue_manager.summary,
+            info=issue_manager.info,
+        )
 
         assert isinstance(report, str)
-        if datalab_flag:
-            assert (
-                "Here is a summary of the different kinds of issues found in the data:\n"
-                "\n"
-                "issue_type  num_issues\n"
-                "   non_iid"
-            ) in report
-        else:
-            assert (
-                "---------------------- non_iid issues ----------------------\n\n"
-                "Number of examples with this issue:"
-            ) in report
+        assert (
+            "---------------------- non_iid issues ----------------------\n\n"
+            "Number of examples with this issue:"
+        ) in report
 
-        if datalab_flag:
-            if features_flag:
-                lab.find_issues(features=embeddings)
-            else:
-                lab.find_issues(pred_probs=pred_probs)
-            lab.data_issues.issue_summary = lab.data_issues.issue_summary[
-                lab.data_issues.issue_summary["issue_type"] == "non_iid"
-            ]
-            reporter = report_factory(lab._imagelab)(
-                data_issues=lab.data_issues,
-                verbosity=3,
-                imagelab=lab._imagelab,
-            )
-            report = reporter.get_report(
-                num_examples=len(embeddings) if features_flag else len(pred_probs)
-            )
-        else:
-            if features_flag:
-                issue_manager.find_issues(features=embeddings)
-            else:
-                issue_manager.find_issues(pred_probs=pred_probs)
-            report = issue_manager.report(
-                issues=issue_manager.issues,
-                summary=issue_manager.summary,
-                info=issue_manager.info,
-                verbosity=3,
-            )
+        issue_manager.find_issues(features=embeddings)
+        report = issue_manager.report(
+            issues=issue_manager.issues,
+            summary=issue_manager.summary,
+            info=issue_manager.info,
+            verbosity=3,
+        )
 
         assert "Additional Information: " in report
 
-    @pytest.mark.parametrize(
-        "datalab_flag, features_flag", [(True, True), (False, False), (False, True), (True, False)]
-    )
-    def test_collect_info(
-        self, issue_manager, embeddings, pred_probs, lab, datalab_flag, features_flag
-    ):
+    def test_report_using_pred_probs(self, issue_manager, embeddings, lab, pred_probs):
+        np.random.seed(SEED)
+        issue_manager.find_issues(pred_probs=pred_probs)
+        report = issue_manager.report(
+            issues=issue_manager.issues,
+            summary=issue_manager.summary,
+            info=issue_manager.info,
+        )
+
+        assert (
+            "---------------------- non_iid issues ----------------------\n\n"
+            "Number of examples with this issue:"
+        ) in report
+
+        issue_manager.find_issues(pred_probs=pred_probs)
+        report = issue_manager.report(
+            issues=issue_manager.issues,
+            summary=issue_manager.summary,
+            info=issue_manager.info,
+            verbosity=3,
+        )
+
+        assert "Additional Information: " in report
+
+    def test_collect_info(self, issue_manager, embeddings, pred_probs, lab):
         """Test some values in the info dict.
 
         Mainly focused on the nearest neighbor info.
         """
 
-        if datalab_flag:
-            if features_flag:
-                lab.find_issues(features=embeddings)
-            else:
-                lab.find_issues(pred_probs=pred_probs)
+        issue_manager.find_issues(features=embeddings)
+        info = issue_manager.info
 
-            info = lab.get_info("non_iid")
-        else:
-            if features_flag:
-                issue_manager.find_issues(features=embeddings)
-            else:
-                issue_manager.find_issues(pred_probs=pred_probs)
-            info = issue_manager.info
+        assert info["p-value"] == 0
+        assert info["metric"] == "euclidean"
+        assert info["k"] == 10
+
+    def test_collect_info_using_pred_probs(self, issue_manager, embeddings, pred_probs, lab):
+        """Test some values in the info dict.
+
+        Mainly focused on the nearest neighbor info.
+        """
+        issue_manager.find_issues(pred_probs=pred_probs)
+        info = issue_manager.info
 
         assert info["p-value"] == 0
         assert info["metric"] == "euclidean"

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1077,7 +1077,7 @@ class TestDatalabWithoutLabels:
     def test_find_issues(self, lab, features, pred_probs):
         lab = Datalab(data={"X": features})
         lab.find_issues(pred_probs=pred_probs)
-        assert lab.issues.empty
+        assert set(lab.issues.columns) == {"is_non_iid_issue", "non_iid_score"}
 
         lab = Datalab(data={"X": features})
         lab.find_issues(features=features)

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -779,9 +779,8 @@ class TestDatalabFindNonIIDIssues:
     def test_find_non_iid_issues_using_pred_probs(self, random_embeddings):
         data = {"labels": [0, 1, 0]}
         lab = Datalab(data=data, label_name="labels")
-        lab.find_issues(
-            pred_probs=random_embeddings, issue_types={"non_iid": {"pred_probs": random_embeddings}}
-        )
+        pred_probs = random_embeddings / random_embeddings.sum(axis=1, keepdims=True)
+        lab.find_issues(pred_probs=pred_probs, issue_types={"non_iid": {}})
         summary = lab.get_issue_summary()
         assert ["non_iid"] == summary["issue_type"].values
         assert summary["score"].values[0] > 0.05
@@ -799,9 +798,8 @@ class TestDatalabFindNonIIDIssues:
     def test_find_non_iid_issues_sorted_using_pred_probs(self, sorted_embeddings):
         data = {"labels": [0, 1, 0]}
         lab = Datalab(data=data, label_name="labels")
-        lab.find_issues(
-            pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs": sorted_embeddings}}
-        )
+        pred_probs = sorted_embeddings / sorted_embeddings.sum(axis=1, keepdims=True)
+        lab.find_issues(pred_probs=pred_probs, issue_types={"non_iid": {}})
         summary = lab.get_issue_summary()
         assert ["non_iid"] == summary["issue_type"].values
         assert summary["score"].values[0] == 0
@@ -824,14 +822,11 @@ class TestDatalabFindNonIIDIssues:
     def test_incremental_search_using_pred_probs(self, sorted_embeddings):
         data = {"labels": [0, 1, 0]}
         lab = Datalab(data=data, label_name="labels")
-        lab.find_issues(
-            pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs": sorted_embeddings}}
-        )
+        pred_probs = sorted_embeddings / sorted_embeddings.sum(axis=1, keepdims=True)
+        lab.find_issues(pred_probs=pred_probs, issue_types={"non_iid": {}})
         summary = lab.get_issue_summary()
         assert len(summary) == 1
-        lab.find_issues(
-            pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs": sorted_embeddings}}
-        )
+        lab.find_issues(pred_probs=pred_probs, issue_types={"non_iid": {}})
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "non_iid" in summary["issue_type"].values

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -776,10 +776,28 @@ class TestDatalabFindNonIIDIssues:
         assert summary["score"].values[0] > 0.05
         assert lab.get_issues()["is_non_iid_issue"].sum() == 0
 
+    def test_find_non_iid_issues_using_pred_probs(self, random_embeddings):
+        data = {"labels": [0, 1, 0]}
+        lab = Datalab(data=data, label_name="labels")
+        lab.find_issues(pred_probs=random_embeddings, issue_types={"non_iid": {"pred_probs": random_embeddings}})
+        summary = lab.get_issue_summary()
+        assert ["non_iid"] == summary["issue_type"].values
+        assert summary["score"].values[0] > 0.05
+        assert lab.get_issues()["is_non_iid_issue"].sum() == 0
+
     def test_find_non_iid_issues_sorted(self, sorted_embeddings):
         data = {"labels": [0, 1, 0]}
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(features=sorted_embeddings, issue_types={"non_iid": {}})
+        summary = lab.get_issue_summary()
+        assert ["non_iid"] == summary["issue_type"].values
+        assert summary["score"].values[0] == 0
+        assert lab.get_issues()["is_non_iid_issue"].sum() == 1
+
+    def test_find_non_iid_issues_sorted_using_pred_probs(self, sorted_embeddings):
+        data = {"labels": [0, 1, 0]}
+        lab = Datalab(data=data, label_name="labels")
+        lab.find_issues(pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs": sorted_embeddings}})
         summary = lab.get_issue_summary()
         assert ["non_iid"] == summary["issue_type"].values
         assert summary["score"].values[0] == 0
@@ -794,6 +812,20 @@ class TestDatalabFindNonIIDIssues:
         lab.find_issues(features=sorted_embeddings, issue_types={"non_iid": {}})
         summary = lab.get_issue_summary()
         assert len(summary) == 3
+        assert "non_iid" in summary["issue_type"].values
+        non_iid_summary = lab.get_issue_summary("non_iid")
+        assert non_iid_summary["score"].values[0] == 0
+        assert non_iid_summary["num_issues"].values[0] == 1
+
+    def test_incremental_search_using_pred_probs(self, sorted_embeddings):
+        data = {"labels": [0, 1, 0]}
+        lab = Datalab(data=data, label_name="labels")
+        lab.find_issues(pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs":sorted_embeddings}})
+        summary = lab.get_issue_summary()
+        assert len(summary) == 1
+        lab.find_issues(pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs":sorted_embeddings}})
+        summary = lab.get_issue_summary()
+        assert len(summary) == 1
         assert "non_iid" in summary["issue_type"].values
         non_iid_summary = lab.get_issue_summary("non_iid")
         assert non_iid_summary["score"].values[0] == 0

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -779,7 +779,9 @@ class TestDatalabFindNonIIDIssues:
     def test_find_non_iid_issues_using_pred_probs(self, random_embeddings):
         data = {"labels": [0, 1, 0]}
         lab = Datalab(data=data, label_name="labels")
-        lab.find_issues(pred_probs=random_embeddings, issue_types={"non_iid": {"pred_probs": random_embeddings}})
+        lab.find_issues(
+            pred_probs=random_embeddings, issue_types={"non_iid": {"pred_probs": random_embeddings}}
+        )
         summary = lab.get_issue_summary()
         assert ["non_iid"] == summary["issue_type"].values
         assert summary["score"].values[0] > 0.05
@@ -797,7 +799,9 @@ class TestDatalabFindNonIIDIssues:
     def test_find_non_iid_issues_sorted_using_pred_probs(self, sorted_embeddings):
         data = {"labels": [0, 1, 0]}
         lab = Datalab(data=data, label_name="labels")
-        lab.find_issues(pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs": sorted_embeddings}})
+        lab.find_issues(
+            pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs": sorted_embeddings}}
+        )
         summary = lab.get_issue_summary()
         assert ["non_iid"] == summary["issue_type"].values
         assert summary["score"].values[0] == 0
@@ -820,10 +824,14 @@ class TestDatalabFindNonIIDIssues:
     def test_incremental_search_using_pred_probs(self, sorted_embeddings):
         data = {"labels": [0, 1, 0]}
         lab = Datalab(data=data, label_name="labels")
-        lab.find_issues(pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs":sorted_embeddings}})
+        lab.find_issues(
+            pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs": sorted_embeddings}}
+        )
         summary = lab.get_issue_summary()
         assert len(summary) == 1
-        lab.find_issues(pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs":sorted_embeddings}})
+        lab.find_issues(
+            pred_probs=sorted_embeddings, issue_types={"non_iid": {"pred_probs": sorted_embeddings}}
+        )
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "non_iid" in summary["issue_type"].values


### PR DESCRIPTION
Closes #808
Added an additional param for pred_probs in find_issues function and an additional check in non_iid.py file.