### PR TITLE
Use existing Datalab to audit additional new data

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -120,9 +120,8 @@ class Datalab:
             warnings.warn(
                 "An existing Datalab instacne has been passed, the new datalab will use the existing statistics."
             )
-            self.data_issues._update_issue_info(
-                "statistics", trained_datalab.get_info("statistics")
-            )
+            for k in trained_datalab.get_info().keys():
+                self.data_issues._update_issue_info(k, trained_datalab.get_info(k))
             self._trained_statistics = True
         else:
             self._trained_statistics = False

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -84,6 +84,10 @@ class Datalab:
         If specified, additional image-specific issue types can be detected in the dataset.
         See the CleanVision package `documentation <https://cleanvision.readthedocs.io/en/latest/>`_ for descriptions of these image-specific issue types.
 
+    trained_datalab : Datalab, optional
+        A Trained Datalab instance that contains statistics information from similar data distribution. This means that the `trained_datalab` should already call `find_issues` and collect statistic information.
+        If provided, the new datalab will use the existing statistics.
+
     verbosity : int, optional
         The higher the verbosity level, the more information
         Datalab prints when auditing a dataset.

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -102,6 +102,7 @@ class Datalab:
         data: "DatasetLike",
         label_name: Optional[str] = None,
         image_key: Optional[str] = None,
+        trained_datalab: Optional[Datalab] = None,
         verbosity: int = 1,
     ) -> None:
         self._data = Data(data, label_name)
@@ -114,6 +115,16 @@ class Datalab:
         self.verbosity = verbosity
         self._imagelab = create_imagelab(dataset=self.data, image_key=image_key)
         self.data_issues = data_issues_factory(self._imagelab)(self._data)
+        if trained_datalab is not None:
+            warnings.warn(
+                "An existing Datalab instacne has been passed, the new datalab will use the existing statistics."
+            )
+            self.data_issues._update_issue_info(
+                "statistics", trained_datalab.get_info("statistics")
+            )
+            self.trained_statistics = True
+        else:
+            self.trained_statistics = False
 
     # todo: check displayer methods
     def __repr__(self) -> str:
@@ -139,6 +150,11 @@ class Datalab:
         If the dataset has no labels, returns an empty list.
         """
         return self._labels.class_names
+
+    @property
+    def has_trained_statistics(self) -> bool:
+        """Whether the dataset has trained statistics."""
+        return self.trained_statistics
 
     def find_issues(
         self,

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -115,8 +115,11 @@ class Datalab:
         self.verbosity = verbosity
         self._imagelab = create_imagelab(dataset=self.data, image_key=image_key)
         self.data_issues = data_issues_factory(self._imagelab)(self._data)
-        if trained_datalab is not None:
-            """The internal field _trained_statistics is used to indicate whether the datalab already has statistics information from an existing datalab trained with similar data distribution."""
+        if trained_datalab is not None and self._label_map == trained_datalab._label_map:
+            """
+            The "test" datalab will use some statistics informations from the "train" datalab passed by user when the test data has the same label distribution as the train data.
+            The internal field _trained_statistics is used to indicate whether the datalab already has statistics information from an existing datalab trained with similar data distribution.
+            """
             warnings.warn(
                 "An existing Datalab instacne has been passed, the new datalab will use the existing statistics."
             )

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -116,15 +116,16 @@ class Datalab:
         self._imagelab = create_imagelab(dataset=self.data, image_key=image_key)
         self.data_issues = data_issues_factory(self._imagelab)(self._data)
         if trained_datalab is not None:
+            """The internal field _trained_statistics is used to indicate whether the datalab already has statistics information from an existing datalab trained with similar data distribution."""
             warnings.warn(
                 "An existing Datalab instacne has been passed, the new datalab will use the existing statistics."
             )
             self.data_issues._update_issue_info(
                 "statistics", trained_datalab.get_info("statistics")
             )
-            self.trained_statistics = True
+            self._trained_statistics = True
         else:
-            self.trained_statistics = False
+            self._trained_statistics = False
 
     # todo: check displayer methods
     def __repr__(self) -> str:
@@ -153,8 +154,8 @@ class Datalab:
 
     @property
     def has_trained_statistics(self) -> bool:
-        """Whether the dataset has trained statistics."""
-        return self.trained_statistics
+        """Whether the dataset already has statistics information from an existing datalab trained with similar data distribution."""
+        return self._trained_statistics
 
     def find_issues(
         self,

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -221,14 +221,8 @@ class IssueFinder:
 
     def _resolve_trained_statistics_args(self, issue_types: Dict[str, Any], **kwargs):
         """For label error only now"""
-        confident_joint = kwargs.get("confident_joint", None)
-        py = kwargs.get("py", None)
-        noise_matrix = kwargs.get("noise_matrix", None)
-        inverse_noise_matrix = kwargs.get("inverse_noise_matrix", None)
-        issue_types["label"]["confident_joint"] = confident_joint
-        issue_types["label"]["py"] = py
-        issue_types["label"]["noise_matrix"] = noise_matrix
-        issue_types["label"]["inverse_noise_matrix"] = inverse_noise_matrix
+        keys = ["confident_joint", "py", "noise_matrix", "inverse_noise_matrix"]
+        issue_types["label"].update({key: kwargs.get(key, None) for key in keys})
         return issue_types
 
     def _set_issue_types(

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -219,6 +219,18 @@ class IssueFinder:
 
         return args_dict
 
+    def _resolve_trained_statistics_args(self, issue_types: Dict[str, Any], **kwargs):
+        """For label error only now"""
+        confident_joint = kwargs.get("confident_joint", None)
+        py = kwargs.get("py", None)
+        noise_matrix = kwargs.get("noise_matrix", None)
+        inverse_noise_matrix = kwargs.get("inverse_noise_matrix", None)
+        issue_types["label"]["confident_joint"] = confident_joint
+        issue_types["label"]["py"] = py
+        issue_types["label"]["noise_matrix"] = noise_matrix
+        issue_types["label"]["inverse_noise_matrix"] = inverse_noise_matrix
+        return issue_types
+
     def _set_issue_types(
         self,
         issue_types: Optional[Dict[str, Any]],
@@ -342,6 +354,17 @@ class IssueFinder:
         if drop_label_check:
             warnings.warn("No labels were provided. " "The 'label' issue type will not be run.")
             issue_types_copy.pop("label")
+
+        label_use_trained_statistics = (
+            "label" in issue_types_copy
+            and self.datalab.has_trained_statistics
+            and not drop_label_check
+        )
+        if label_use_trained_statistics:
+            warnings.warn("Using precomputed statistics from a previously trained datalab. ")
+            issue_types_copy = self._resolve_trained_statistics_args(
+                issue_types_copy, kwargs=kwargs
+            )
 
         outlier_check_needs_features = "outlier" in issue_types_copy and not self.datalab.has_labels
         if outlier_check_needs_features:

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -221,8 +221,21 @@ class IssueFinder:
 
     def _resolve_trained_statistics_args(self, issue_types: Dict[str, Any]):
         """For label error only now"""
-        for issue in issue_types:
-            issue_types[issue].update({k: v for k, v in self.datalab.get_info(issue).items()})
+        # get 'confident_joint' if it not passed by user. Note: the 'noise_matrix' and 'inversed_noise_matrix' will always be recomputed by the `CleanLearning` instance.
+        supported_issue_types = ["label"]
+        issue_keys = {"label": ["confident_joint"]}
+        for issue in supported_issue_types:
+            issue_types[issue].update(
+                {
+                    "clean_learning_kwargs": {
+                        "find_label_issues_kwargs": {
+                            k: v
+                            for k, v in self.datalab.get_info(issue).items()
+                            if (k in issue_keys[issue] and issue_types[issue].get(k) is None)
+                        }
+                    }
+                }
+            )
         return issue_types
 
     def _set_issue_types(

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -219,10 +219,10 @@ class IssueFinder:
 
         return args_dict
 
-    def _resolve_trained_statistics_args(self, issue_types: Dict[str, Any], **kwargs):
+    def _resolve_trained_statistics_args(self, issue_types: Dict[str, Any]):
         """For label error only now"""
-        keys = ["confident_joint", "py", "noise_matrix", "inverse_noise_matrix"]
-        issue_types["label"].update({key: kwargs.get(key, None) for key in keys})
+        for issue in issue_types:
+            issue_types[issue].update({k: v for k, v in self.datalab.get_info(issue).items()})
         return issue_types
 
     def _set_issue_types(
@@ -356,9 +356,7 @@ class IssueFinder:
         )
         if label_use_trained_statistics:
             warnings.warn("Using precomputed statistics from a previously trained datalab. ")
-            issue_types_copy = self._resolve_trained_statistics_args(
-                issue_types_copy, kwargs=kwargs
-            )
+            issue_types_copy = self._resolve_trained_statistics_args(issue_types_copy)
 
         outlier_check_needs_features = "outlier" in issue_types_copy and not self.datalab.has_labels
         if outlier_check_needs_features:

--- a/tests/datalab/test_issue_finder.py
+++ b/tests/datalab/test_issue_finder.py
@@ -59,6 +59,21 @@ class TestIssueFinder:
                 issue_finder._validate_issue_types_dict(issue_types, defaults_dict)
             assert all([string in str(e.value) for string in ["issue_type_1", "arg_1", "arg_2"]])
 
+    def test_resolve_trained_statistics_args(self, issue_finder, lab, monkeypatch):
+        """Test that the required args for statistics info reusing is set correctly."""
+        N = len(lab.data)
+        K = lab.get_info("statistics")["num_classes"]
+        X = np.random.rand(N, 2)
+        pred_probs = np.random.rand(N, K)
+        pred_probs = pred_probs / pred_probs.sum(axis=1, keepdims=True)
+        lab.find_issues(pred_probs=pred_probs, issue_types={"label": {}})
+        # construct a datalab with statistics info and `has_trained_statistics` set to True
+        new_lab = Datalab(trained_datalab=lab, data=lab.data, label_name="y")
+        issue_finder.datalab = new_lab
+        issue_types = issue_finder.get_available_issue_types(issue_types={"label": {}})
+        for k in lab.get_info("label").keys():
+            assert k in issue_types["label"]
+
     @pytest.mark.parametrize(
         "defaults_dict",
         [


### PR DESCRIPTION
For issue #820 
Datalab now can accept an existing Datalab instance and use its statistics information for finding issues for new data.
This only support label issue and `pred_probs` only.
As mentioned in the issue, I made a simple tutorial [here](https://github.com/coding-famer/cleanlab/blob/datalab-reuse-tutorial/docs/source/tutorials/datalab/datalab_reuse_trained.ipynb).