### PR TITLE
FAQ: Methods that can be sped up with low_memory=True

### DIFF
--- a/docs/source/tutorials/faq.ipynb
+++ b/docs/source/tutorials/faq.ipynb
@@ -276,16 +276,11 @@
    "id": "13228a99-5d3f-47c0-87e5-2290d16461c4",
    "metadata": {},
    "source": [
-    "For methods that use `filter.find_label_issues`,  `label_issues_batched` is used internally if `low_memory=True` is passed as a parameter. The example below shows how to use this flag for determining label issues inin a classification dataset "
+    "Methods that call `filter.find_label_issues` use `label_issues_batched` internally if `low_memory=True` is passed as a parameter. The following methods provide this option - \n",
+    "* [classification.CleanLearning](https://docs.cleanlab.ai/stable/cleanlab/classification.html?highlight=cleanlearning#cleanlab.classification.CleanLearning)\n",
+    "* [multilabel_classification.filter.find_label_issues](https://docs.cleanlab.ai/stable/cleanlab/multilabel_classification/filter.html#cleanlab.multilabel_classification.filter.find_label_issues)\n",
+    "* [token_classification.filter.find_label_issues](https://docs.cleanlab.ai/stable/cleanlab/token_classification/filter.html?highlight=token#cleanlab.token_classification.filter.find_label_issues)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f9b17abb-197c-4812-8748-eb61bea9577b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/docs/source/tutorials/faq.ipynb
+++ b/docs/source/tutorials/faq.ipynb
@@ -277,9 +277,10 @@
    "metadata": {},
    "source": [
     "Methods that call `filter.find_label_issues` use `label_issues_batched` internally if `low_memory=True` is passed as a parameter. The following methods provide this option - \n",
-    "* [classification.CleanLearning](https://docs.cleanlab.ai/stable/cleanlab/classification.html?highlight=cleanlearning#cleanlab.classification.CleanLearning)\n",
-    "* [multilabel_classification.filter.find_label_issues](https://docs.cleanlab.ai/stable/cleanlab/multilabel_classification/filter.html#cleanlab.multilabel_classification.filter.find_label_issues)\n",
-    "* [token_classification.filter.find_label_issues](https://docs.cleanlab.ai/stable/cleanlab/token_classification/filter.html?highlight=token#cleanlab.token_classification.filter.find_label_issues)"
+    "\n",
+    "1. [classification.CleanLearning](https://docs.cleanlab.ai/stable/cleanlab/classification.html?highlight=cleanlearning#cleanlab.classification.CleanLearning)\n",
+    "2. [multilabel_classification.filter.find_label_issues](https://docs.cleanlab.ai/stable/cleanlab/multilabel_classification/filter.html#cleanlab.multilabel_classification.filter.find_label_issues)\n",
+    "3. [token_classification.filter.find_label_issues](https://docs.cleanlab.ai/stable/cleanlab/token_classification/filter.html?highlight=token#cleanlab.token_classification.filter.find_label_issues)"
    ]
   },
   {

--- a/docs/source/tutorials/faq.ipynb
+++ b/docs/source/tutorials/faq.ipynb
@@ -272,6 +272,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "13228a99-5d3f-47c0-87e5-2290d16461c4",
+   "metadata": {},
+   "source": [
+    "For methods that use `filter.find_label_issues`,  `label_issues_batched` is used internally if `low_memory=True` is passed as a parameter. The example below shows how to use this flag for determining label issues inin a classification dataset "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9b17abb-197c-4812-8748-eb61bea9577b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "20476c70",

--- a/docs/source/tutorials/faq.ipynb
+++ b/docs/source/tutorials/faq.ipynb
@@ -276,11 +276,11 @@
    "id": "13228a99-5d3f-47c0-87e5-2290d16461c4",
    "metadata": {},
    "source": [
-    "Methods that call `filter.find_label_issues` use `label_issues_batched` internally if `low_memory=True` is passed as a parameter. The following methods provide this option - \n",
+    "Methods that internally call `filter.find_label_issues()` can be sped up by specifying the argument `low_memory=True`, which will instead use `find_label_issues_batched()` internally. The following methods provide this option: \n",
     "\n",
-    "1. [classification.CleanLearning](https://docs.cleanlab.ai/stable/cleanlab/classification.html?highlight=cleanlearning#cleanlab.classification.CleanLearning)\n",
-    "2. [multilabel_classification.filter.find_label_issues](https://docs.cleanlab.ai/stable/cleanlab/multilabel_classification/filter.html#cleanlab.multilabel_classification.filter.find_label_issues)\n",
-    "3. [token_classification.filter.find_label_issues](https://docs.cleanlab.ai/stable/cleanlab/token_classification/filter.html?highlight=token#cleanlab.token_classification.filter.find_label_issues)"
+    "1. [classification.CleanLearning](../cleanlab/classification.html#cleanlab.classification.CleanLearning)\n",
+    "2. [multilabel_classification.filter.find_label_issues](../cleanlab/multilabel_classification/filter.html#cleanlab.multilabel_classification.filter.find_label_issues)\n",
+    "3. [token_classification.filter.find_label_issues](../cleanlab/token_classification/filter.html?highlight=token#cleanlab.token_classification.filter.find_label_issues)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
In the FAQ, include methods that support speed up using the `low_memory=True` option. 


## Impact
Improve documentation for users to leverage memory efficient computation for classification tasks. 

## Testing
Documentation Screenshot: 
![image](https://github.com/cleanlab/cleanlab/assets/23188723/e69069cd-9d03-42ed-8c7e-082efe9b6f4b)

## Ticket(s) or Conversations
Fixes https://github.com/cleanlab/cleanlab/issues/855

## References
N/A
