### PR TITLE
Address mypy issues following added support for pred_probs-based non-iid issue checks

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -175,7 +175,25 @@ class NonIIDIssueManager(IssueManager):
         """
         Selects features (or pred_probs if features are None) and sets up a NearestNeighbors object if needed.
 
-        # Add type-hints and document the arguments.
+        Parameters
+        ----------
+        features :
+            Original feature array or None.
+            
+        pred_probs :
+            Predicted probabilities array or None.
+            
+        knn_graph :
+            A precomputed KNN-graph stored in a csr_matrix or None. If None, a new NearestNeighbors object will be created.
+        
+        metric_changes :
+            Whether the metric used to compute the KNN-graph has changed.
+            This is a result of comparing the metric of a pre-existing KNN-graph and the metric specified by the user.
+    
+        Returns
+        -------
+        knn :
+            A NearestNeighbors object or None.
         """
         if features is None and pred_probs is not None:
             self._skip_storing_knn_graph_for_pred_probs = True

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -212,7 +212,7 @@ class NonIIDIssueManager(IssueManager):
     ) -> None:
         knn_graph = self._process_knn_graph_from_inputs(kwargs)
         old_knn_metric = self.datalab.get_info("statistics").get("knn_metric")
-        metric_changes = self.metric and self.metric != old_knn_metric
+        metric_changes = bool(self.metric and self.metric != old_knn_metric)
         knn, features_used = self._select_features_and_setup_knn(
             features, pred_probs, knn_graph, metric_changes
         )

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -179,17 +179,17 @@ class NonIIDIssueManager(IssueManager):
         ----------
         features :
             Original feature array or None.
-            
+
         pred_probs :
             Predicted probabilities array or None.
-            
+
         knn_graph :
             A precomputed KNN-graph stored in a csr_matrix or None. If None, a new NearestNeighbors object will be created.
-        
+
         metric_changes :
             Whether the metric used to compute the KNN-graph has changed.
             This is a result of comparing the metric of a pre-existing KNN-graph and the metric specified by the user.
-    
+
         Returns
         -------
         knn :
@@ -231,9 +231,7 @@ class NonIIDIssueManager(IssueManager):
         knn_graph = self._process_knn_graph_from_inputs(kwargs)
         old_knn_metric = self.datalab.get_info("statistics").get("knn_metric")
         metric_changes = bool(self.metric and self.metric != old_knn_metric)
-        knn = self._setup_knn(
-            features, pred_probs, knn_graph, metric_changes
-        )
+        knn = self._setup_knn(features, pred_probs, knn_graph, metric_changes)
 
         if knn_graph is None or metric_changes:
             self.neighbor_index_choices = self._get_neighbors(knn=knn)

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Union, cast, Tuple
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Union, cast
 import warnings
 import itertools
 


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Follow up with #857 which didn't pass a mypy check in CI

The high-level changes include:
- Wrap a conditional expression in a `bool` class to help mypy.
- Remove unused return value of an internal function.
- Complete an unfinished docstring.


## Links to Relevant Issues or Conversations

> 🔗 What Git or Slack items (Issues, threads, etc) that are specifically related to
> this work? Please link them here.

- Continuation from https://github.com/cleanlab/cleanlab/pull/857#issuecomment-1784396020

## Reviewer Notes
> 💡 Include any specific points for the reviewer to consider during their review.

The reason for dropping `features_to_use` is that it's part of the `knn: NearestNeighbors` object. Returning both is redundant for this issue manager.
