### PR TITLE
Bump lower bounds of datasets library for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ tensorflow==2.9.1
 tensorflow-io==0.26.0
 sentence-transformers==2.2.2
 speechbrain==0.5.13
-huggingface_hub=>0.14.1
+huggingface_hub>=0.14.1
 torch==1.13.1
 torchvision==0.14.1
 torchaudio==0.13.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ tensorflow==2.9.1
 tensorflow-io==0.26.0
 sentence-transformers==2.2.2
 speechbrain==0.5.13
-huggingface_hub==0.11.1
+huggingface_hub=>0.14.1
 torch==1.13.1
 torchvision==0.14.1
 torchaudio==0.13.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -23,4 +23,4 @@ torch==1.13.1
 torchvision==0.14.1
 torchaudio==0.13.1
 timm==0.6.12
-datasets>=2.9.0
+datasets>=2.14.6


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Attempt to fix error in the `deploy` job in CI by updating CI dependencies.

The latest release of the `datasets` library has a fix for an issue which I think is causing a failure in our docs deploying.
This PR makes this release the minimum required version.

## Impact

> 🌐 Areas Affected: `docs/requirements.txt` and `docs/source/tutorial/image.ipynb`.
>
> 👥 Who’s Affected: Developers attempting to build the docs.



**Unaddressed Cases**

> ⚠️ Mention any aspects of testing that have *not* been covered, and why.

- [ ] Revisit the version bounds of the datasets library in CI. 


## References


<details><summary>Click to see example error from CI</summary>
<p>

```bash
Notebook error:
CellExecutionError in tutorials/image.ipynb:
------------------
dataset = load_dataset("fashion_mnist", split="train")
dataset
------------------

----- stdout -----
Downloading and preparing dataset fashion_mnist/fashion_mnist to file:///home/runner/.cache/huggingface/datasets/fashion_mnist/fashion_mnist/1.0.0/0a671f063342996f19779d38c0ab4abef9c64f757b35af8134b331c294d7ba48...
----- stdout -----
Dataset fashion_mnist downloaded and prepared to file:///home/runner/.cache/huggingface/datasets/fashion_mnist/fashion_mnist/1.0.0/0a671f063342996f19779d38c0ab4abef9c64f757b35af8134b331c294d7ba48. Subsequent calls will reuse this data.
------------------

---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
Input In [3], in <module>
----> 1 dataset = load_dataset("fashion_mnist",split="train")
      2 dataset

File /opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/datasets/load.py:1822, in load_dataset(path, name, data_dir, data_files, split, cache_dir, features, download_config, download_mode, verification_mode, ignore_verifications, keep_in_memory, save_infos, revision, use_auth_token, task, streaming, num_proc, storage_options, **config_kwargs)
   1818 # Build dataset for splits
   1819 keep_in_memory = (
   1820     keep_in_memory if keep_in_memory is not None else is_small_dataset(builder_instance.info.dataset_size)
   1821 )
-> 1822 ds = builder_instance.as_dataset(split=split,verification_mode=verification_mode,in_memory=keep_in_memory)
   1823 # Rename and cast features to match task schema
   1824 if task is not None:

File /opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/datasets/builder.py:1128, in DatasetBuilder.as_dataset(self, split, run_post_process, verification_mode, ignore_verifications, in_memory)
   1126 is_local = not is_remote_filesystem(self._fs)
   1127 if not is_local:
-> 1128     raise NotImplementedError(f"Loading a dataset cached in a {type(self._fs).__name__} is not supported.")
   1129 if not os.path.exists(self._output_dir):
   1130     raise FileNotFoundError(
   1131         f"Dataset {self.name}: could not find data in {self._output_dir}. Please make sure to call "
   1132         "builder.download_and_prepare(), or use "
   1133         "datasets.load_dataset() before trying to access the Dataset object."
   1134     )

NotImplementedError: Loading a dataset cached in a LocalFileSystem is not supported.

```

</p>
</details> 

## Reviewer Notes
> 💡 Include any specific points for the reviewer to consider during their review.

If we consider this to be a temporary fix, then we should turn the task item above into an issue as a reminder to undo this temporary workaround.
