### PR TITLE
Add image, title, and description for SEO link previews for the docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,6 +12,7 @@ sphinx-copybutton==0.5.0
 sphinxcontrib-katex==0.8.6
 sphinxcontrib-gtagjs==0.2.1
 sphinx-autodoc-typehints==1.19.2
+sphinxext-opengraph==0.9.0
 matplotlib==3.6.3
 requests==2.28.2
 tensorflow==2.9.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,11 @@ import pathlib
 
 sys.path.insert(0, pathlib.Path(__file__).parents[2].resolve().as_posix())
 
+# Open Graph extension
+ogp_site_url = "https://docs.cleanlab.ai"
+ogp_image = "https://raw.githubusercontent.com/cleanlab/assets/master/cleanlab/clos-preview-card.png"
+
+
 # -- Project information -----------------------------------------------------
 
 project = "cleanlab"
@@ -49,6 +54,7 @@ extensions = [
     "sphinxcontrib.gtagjs",
     "sphinx_autodoc_typehints",
     "sphinx.ext.doctest",
+    "sphinxext.opengraph",
 ]
 
 numpy_show_class_members = True

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,6 @@
+:og:title: Cleanlab Open-Source Documentation
+:og:description: Get started, learn about capabilities, and follow tutorials to improve your own Data and Models.
+
 cleanlab open-source documentation
 ==================================
 


### PR DESCRIPTION
**Screenshots**

Here's how preview links to the docs would look like (ignore the firebaseapp url, it was just used for testing locally):

<img width="520" alt="image" src="https://github.com/cleanlab/cleanlab/assets/18127060/5b1281df-00c3-46f3-bc20-c1f95fdd7567">

**Unaddressed Cases**

The image persists across all pages, but the title and description don't.
Is that something that should be done?


## References

- Sphinx extension, [sphinxext-opengraph](https://github.com/wpilibsuite/sphinxext-opengraph), is added in this PR.

