### PR TITLE
Test properties of near duplicate sets

### DIFF
--- a/tests/datalab/issue_manager/conftest.py
+++ b/tests/datalab/issue_manager/conftest.py
@@ -14,22 +14,39 @@ def knn_graph_strategy(draw, num_samples, k_neighbors):
 
     # Generate a symmetric distance matrix
     upper_triangle = [
-        draw(st.lists(st.floats(min_value=0, max_value=100, allow_nan=False, allow_infinity=False), 
-                     min_size=i, max_size=i, unique=True))
-        for i in range(1, num_samples+1)
+        draw(
+            st.lists(
+                st.floats(min_value=0, max_value=100, allow_nan=False, allow_infinity=False),
+                min_size=i,
+                max_size=i,
+                unique=True,
+            )
+        )
+        for i in range(1, num_samples + 1)
     ]
 
     distance_matrix = np.zeros((num_samples, num_samples))
     for i, row in enumerate(upper_triangle):
-        distance_matrix[i, :i+1] = row
-        distance_matrix[:i+1, i] = row
+        distance_matrix[i, : i + 1] = row
+        distance_matrix[: i + 1, i] = row
 
-    np.fill_diagonal(distance_matrix, np.inf)  # To ensure we don't select a point as its own neighbor
+    np.fill_diagonal(
+        distance_matrix, np.inf
+    )  # To ensure we don't select a point as its own neighbor
 
     # Compute k-nearest neighbors based on the distance matrix
     sorted_indices = np.argsort(distance_matrix, axis=1)
     kneighbor_indices = sorted_indices[:, :k_neighbors]
-    kneighbor_distances = np.array([distance_matrix[i, kneighbor_indices[i]] for i in range(num_samples)])
+    kneighbor_distances = np.array(
+        [distance_matrix[i, kneighbor_indices[i]] for i in range(num_samples)]
+    )
 
-    knn_graph = csr_matrix((kneighbor_distances.flatten(), kneighbor_indices.flatten(), np.arange(0,( kneighbor_distances.shape[0] * k_neighbors + 1), k_neighbors)), shape=(num_samples, num_samples))
+    knn_graph = csr_matrix(
+        (
+            kneighbor_distances.flatten(),
+            kneighbor_indices.flatten(),
+            np.arange(0, (kneighbor_distances.shape[0] * k_neighbors + 1), k_neighbors),
+        ),
+        shape=(num_samples, num_samples),
+    )
     return knn_graph

--- a/tests/datalab/issue_manager/conftest.py
+++ b/tests/datalab/issue_manager/conftest.py
@@ -5,6 +5,37 @@ from scipy.sparse import csr_matrix
 
 @st.composite
 def knn_graph_strategy(draw, num_samples, k_neighbors):
+    """
+    Generate a K-nearest neighbors (KNN) graph based on the given parameters.
+
+    Parameters
+    ----------
+    draw: A function used to draw values from search strategies.
+    
+    num_samples (int or SearchStrategy): The number of samples in the graph.
+        If a SearchStrategy is provided, a value will be drawn from it.
+    
+    k_neighbors (int or SearchStrategy): The number of nearest neighbors to consider for each sample.
+        If a SearchStrategy is provided, a value will be drawn from it.
+
+    Returns
+    -------
+    knn_graph : csr_matrix
+        The KNN graph represented as a sparse matrix.
+
+    Notes
+    -----
+    - The KNN graph is generated based on a symmetric distance matrix.
+    - The distance matrix is computed using randomly generated upper triangle values.
+    - The diagonal of the distance matrix is set to infinity to avoid selecting a point as its own neighbor.
+    - The K-nearest neighbors are computed based on the distance matrix.
+    - The resulting KNN graph is returned as a sparse matrix in csr format.
+    - The number of samples must be greater than the number of neighbors.
+    - The KNN graph is not guaranteed to be connected (i.e. there may be isolated subgraphs).
+    - The KNN graph is a directed graph (i.e. the edges are not symmetric).
+    - The neighbors are sorted by distance in the CSR-formatted sparse matrix,
+        so the first neighbor is the closest neighbor.
+    """
     # If the argument is a strategy, draw a value from it.
     if isinstance(num_samples, st.SearchStrategy):
         num_samples = draw(num_samples)

--- a/tests/datalab/issue_manager/conftest.py
+++ b/tests/datalab/issue_manager/conftest.py
@@ -11,10 +11,10 @@ def knn_graph_strategy(draw, num_samples, k_neighbors):
     Parameters
     ----------
     draw: A function used to draw values from search strategies.
-    
+
     num_samples (int or SearchStrategy): The number of samples in the graph.
         If a SearchStrategy is provided, a value will be drawn from it.
-    
+
     k_neighbors (int or SearchStrategy): The number of nearest neighbors to consider for each sample.
         If a SearchStrategy is provided, a value will be drawn from it.
 

--- a/tests/datalab/issue_manager/conftest.py
+++ b/tests/datalab/issue_manager/conftest.py
@@ -1,0 +1,35 @@
+from hypothesis import strategies as st
+import numpy as np
+from scipy.sparse import csr_matrix
+
+
+@st.composite
+def knn_graph_strategy(draw, num_samples, k_neighbors):
+    # If the argument is a strategy, draw a value from it.
+    if isinstance(num_samples, st.SearchStrategy):
+        num_samples = draw(num_samples)
+
+    if isinstance(k_neighbors, st.SearchStrategy):
+        k_neighbors = draw(k_neighbors)
+
+    # Generate a symmetric distance matrix
+    upper_triangle = [
+        draw(st.lists(st.floats(min_value=0, max_value=100, allow_nan=False, allow_infinity=False), 
+                     min_size=i, max_size=i, unique=True))
+        for i in range(1, num_samples+1)
+    ]
+
+    distance_matrix = np.zeros((num_samples, num_samples))
+    for i, row in enumerate(upper_triangle):
+        distance_matrix[i, :i+1] = row
+        distance_matrix[:i+1, i] = row
+
+    np.fill_diagonal(distance_matrix, np.inf)  # To ensure we don't select a point as its own neighbor
+
+    # Compute k-nearest neighbors based on the distance matrix
+    sorted_indices = np.argsort(distance_matrix, axis=1)
+    kneighbor_indices = sorted_indices[:, :k_neighbors]
+    kneighbor_distances = np.array([distance_matrix[i, kneighbor_indices[i]] for i in range(num_samples)])
+
+    knn_graph = csr_matrix((kneighbor_distances.flatten(), kneighbor_indices.flatten(), np.arange(0,( kneighbor_distances.shape[0] * k_neighbors + 1), k_neighbors)), shape=(num_samples, num_samples))
+    return knn_graph

--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -143,47 +143,65 @@ class TestNearDuplicateIssueManager:
         ), "Issue examples should have near duplicate sets"
 
 
-def build_issue_manager(draw, num_samples_strategy, k_neighbors_strategy, with_issues=False, threshold=None):
+def build_issue_manager(
+    draw, num_samples_strategy, k_neighbors_strategy, with_issues=False, threshold=None
+):
     """Create a random knn_graph with the given number of samples and k neighbors.
     Run the NearDuplicateIssueManager on the knn_graph and return the issue manager.
     A threshold can be provided to control the number of issues for small graphs.
     A with_issues flag can be provided to control whether the issue manager should have issues.
     """
-    knn_graph = draw(knn_graph_strategy(num_samples=num_samples_strategy, k_neighbors=k_neighbors_strategy))
-    
+    knn_graph = draw(
+        knn_graph_strategy(num_samples=num_samples_strategy, k_neighbors=k_neighbors_strategy)
+    )
+
     lab = Datalab(data={})
     inputs = {"datalab": lab, "threshold": threshold}
-    inputs = {k:v for k,v in inputs.items() if v is not None}
+    inputs = {k: v for k, v in inputs.items() if v is not None}
     issue_manager = NearDuplicateIssueManager(**inputs)
     issue_manager.find_issues(knn_graph=knn_graph)
     issues = issue_manager.issues["is_near_duplicate_issue"]
-    
+
     if with_issues:
         assume(any(issues))
     else:
         assume(not any(issues))
     return issue_manager
 
+
 @st.composite
 def no_issue_issue_manager_strategy(draw):
     """Strategy for generating NearDuplicateIssueManagers with no issues."""
-    return build_issue_manager(draw, st.integers(min_value=10, max_value=50), st.integers(min_value=2, max_value=5), with_issues=False)
+    return build_issue_manager(
+        draw,
+        st.integers(min_value=10, max_value=50),
+        st.integers(min_value=2, max_value=5),
+        with_issues=False,
+    )
+
 
 @st.composite
 def issue_manager_with_issues_strategy(draw):
     """Strategy for generating NearDuplicateIssueManagers with issues."""
-    return build_issue_manager(draw, st.integers(min_value=10, max_value=20), st.integers(min_value=2, max_value=5), with_issues=True, threshold=0.9)
+    return build_issue_manager(
+        draw,
+        st.integers(min_value=10, max_value=20),
+        st.integers(min_value=2, max_value=5),
+        with_issues=True,
+        threshold=0.9,
+    )
 
 
 class TestNearDuplicateSets:
     """Property-based tests properties of near duplicate sets found in a knn graph."""
+
     @pytest.mark.slow
     @given(issue_manager=no_issue_issue_manager_strategy())
     @settings(deadline=800, suppress_health_check=[HealthCheck.too_slow])
     def test_near_duplicate_sets_empty_if_no_issue_next(self, issue_manager):
         near_duplicate_sets = issue_manager.info["near_duplicate_sets"]
         assert all(len(near_duplicate_set) == 0 for near_duplicate_set in near_duplicate_sets)
-        
+
     @given(issue_manager=issue_manager_with_issues_strategy())
     @settings(deadline=800, max_examples=1000, suppress_health_check=[HealthCheck.too_slow])
     def test_symmetric_and_flagged_consistency(self, issue_manager):
@@ -193,14 +211,20 @@ class TestNearDuplicateSets:
         # Test symmetry: If A is in near_duplicate_set of B, then B should be in near_duplicate_set of A.
         for i, near_duplicates in enumerate(near_duplicate_sets):
             for j in near_duplicates:
-                assert i in near_duplicate_sets[j], f"Example {j} is in near_duplicate_set of {i}, but not vice versa"
+                assert (
+                    i in near_duplicate_sets[j]
+                ), f"Example {j} is in near_duplicate_set of {i}, but not vice versa"
 
         # Test consistency of flags with near_duplicate_sets
         for i, near_duplicate_set in enumerate(near_duplicate_sets):
             if issues[i]:
                 # Near duplicate sets of flagged examples should not be empty
-                assert len(near_duplicate_set) > 0, f"Near duplicate set of flagged example {i} is empty"
+                assert (
+                    len(near_duplicate_set) > 0
+                ), f"Near duplicate set of flagged example {i} is empty"
 
                 # Check if all examples in the near_duplicate_set of a flagged example are also flagged
                 flagged_in_set = [issues[j] for j in near_duplicate_set]
-                assert all(flagged_in_set), f"Example {i} is flagged as near_duplicate but some examples in its near_duplicate_set are not flagged"
+                assert all(
+                    flagged_in_set
+                ), f"Example {i} is flagged as near_duplicate but some examples in its near_duplicate_set are not flagged"

--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -1,9 +1,8 @@
 import numpy as np
 import pytest
-from hypothesis import assume, given, settings, strategies as st
+from hypothesis import HealthCheck, assume, given, settings, strategies as st
 from hypothesis.strategies import composite
 from hypothesis.extra.numpy import arrays
-from scipy.sparse import csr_matrix
 
 
 from cleanlab import Datalab
@@ -178,14 +177,15 @@ def issue_manager_with_issues_strategy(draw):
 
 class TestNearDuplicateSets:
     """Property-based tests properties of near duplicate sets found in a knn graph."""
+    @pytest.mark.slow
     @given(issue_manager=no_issue_issue_manager_strategy())
-    @settings(deadline=800)
+    @settings(deadline=800, suppress_health_check=[HealthCheck.too_slow])
     def test_near_duplicate_sets_empty_if_no_issue_next(self, issue_manager):
         near_duplicate_sets = issue_manager.info["near_duplicate_sets"]
         assert all(len(near_duplicate_set) == 0 for near_duplicate_set in near_duplicate_sets)
         
     @given(issue_manager=issue_manager_with_issues_strategy())
-    @settings(deadline=800, max_examples=1000)
+    @settings(deadline=800, max_examples=1000, suppress_health_check=[HealthCheck.too_slow])
     def test_symmetric_and_flagged_consistency(self, issue_manager):
         near_duplicate_sets = issue_manager.info["near_duplicate_sets"]
         issues = issue_manager.issues["is_near_duplicate_issue"]

--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -145,6 +145,11 @@ class TestNearDuplicateIssueManager:
 
 
 def build_issue_manager(draw, num_samples_strategy, k_neighbors_strategy, with_issues=False, threshold=None):
+    """Create a random knn_graph with the given number of samples and k neighbors.
+    Run the NearDuplicateIssueManager on the knn_graph and return the issue manager.
+    A threshold can be provided to control the number of issues for small graphs.
+    A with_issues flag can be provided to control whether the issue manager should have issues.
+    """
     knn_graph = draw(knn_graph_strategy(num_samples=num_samples_strategy, k_neighbors=k_neighbors_strategy))
     
     lab = Datalab(data={})
@@ -162,15 +167,17 @@ def build_issue_manager(draw, num_samples_strategy, k_neighbors_strategy, with_i
 
 @st.composite
 def no_issue_issue_manager_strategy(draw):
+    """Strategy for generating NearDuplicateIssueManagers with no issues."""
     return build_issue_manager(draw, st.integers(min_value=10, max_value=50), st.integers(min_value=2, max_value=5), with_issues=False)
 
 @st.composite
 def issue_manager_with_issues_strategy(draw):
+    """Strategy for generating NearDuplicateIssueManagers with issues."""
     return build_issue_manager(draw, st.integers(min_value=10, max_value=20), st.integers(min_value=2, max_value=5), with_issues=True, threshold=0.9)
 
 
 class TestNearDuplicateSets:
-    
+    """Property-based tests properties of near duplicate sets found in a knn graph."""
     @given(issue_manager=no_issue_issue_manager_strategy())
     @settings(deadline=800)
     def test_near_duplicate_sets_empty_if_no_issue_next(self, issue_manager):

--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -9,7 +9,7 @@ from scipy.sparse import csr_matrix
 from cleanlab import Datalab
 from cleanlab.datalab.internal.issue_manager.duplicate import NearDuplicateIssueManager
 
-from tests.datalab.issue_manager.test_knn_graph import knn_graph_strategy
+from .conftest import knn_graph_strategy
 
 SEED = 42
 

--- a/tests/datalab/issue_manager/test_knn_graph.py
+++ b/tests/datalab/issue_manager/test_knn_graph.py
@@ -49,11 +49,11 @@ class TestKNNGraph:
     @pytest.mark.slow
     @given(
         knn_graph=knn_graph_strategy(
-            num_samples=st.integers(min_value=10, max_value=50),
+            num_samples=st.integers(min_value=6, max_value=10),
             k_neighbors=st.integers(min_value=2, max_value=5),
         )
     )
-    @settings(suppress_health_check=[HealthCheck.too_slow])
+    @settings(suppress_health_check=[HealthCheck.too_slow], max_examples=1000, deadline=None)
     def test_knn_graph(self, knn_graph):
         """Run through the property tests defined above."""
         N = knn_graph.shape[0]

--- a/tests/datalab/issue_manager/test_knn_graph.py
+++ b/tests/datalab/issue_manager/test_knn_graph.py
@@ -73,6 +73,7 @@ class TestKNNGraph:
 
     @given(knn_graph=knn_graph_strategy(num_samples=st.integers(min_value=10, max_value=50), k_neighbors=st.integers(min_value=2, max_value=5)))
     def test_knn_graph(self, knn_graph):
+        """Run through the property tests defined above."""
         N = knn_graph.shape[0]
         distances = knn_graph.data.reshape(N, -1)
         indices = knn_graph.indices.reshape(N, -1)

--- a/tests/datalab/issue_manager/test_knn_graph.py
+++ b/tests/datalab/issue_manager/test_knn_graph.py
@@ -1,5 +1,5 @@
 import math
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, strategies as st
 import numpy as np
 from scipy.sparse import csr_matrix
 
@@ -43,7 +43,7 @@ class TestKNNGraph:
 
     @staticmethod
     def assert_indices_unique(indices):
-        """Check that indices are unique across columns and don't have the row's index."""
+        """Check that neighbor indices are unique and don't have the row's index."""
         for row_idx, row in enumerate(indices):
             assert len(set(row)) == len(row)  # Check uniqueness
             assert row_idx not in row  # Check that row's index is not in the row

--- a/tests/datalab/issue_manager/test_knn_graph.py
+++ b/tests/datalab/issue_manager/test_knn_graph.py
@@ -4,12 +4,13 @@ import pytest
 
 from .conftest import knn_graph_strategy
 
+
 class TestKNNGraph:
     @staticmethod
     def assert_distances_sorted(distances):
         """Check distances are sorted in ascending order for each row."""
         for row in distances:
-            assert all(row[i] <= row[i+1] for i in range(len(row)-1))
+            assert all(row[i] <= row[i + 1] for i in range(len(row) - 1))
 
     @staticmethod
     def assert_indices_unique(indices):
@@ -26,7 +27,9 @@ class TestKNNGraph:
                 if i in indices[j]:
                     d_ij = distances[i][list(indices[i]).index(j)]
                     d_ji = distances[j][list(indices[j]).index(i)]
-                    assert math.isclose(d_ij, d_ji), f"Distances between {i} and {j} do not match: {d_ij} vs {d_ji}"
+                    assert math.isclose(
+                        d_ij, d_ji
+                    ), f"Distances between {i} and {j} do not match: {d_ij} vs {d_ji}"
 
     @staticmethod
     def assert_mutual_consistency_of_knn_distances(distances, indices):
@@ -39,10 +42,17 @@ class TestKNNGraph:
                 d_ij = distances[i][list(indices[i]).index(j)]
                 j_neighbors_distances = distances[j]
                 if d_ij < max(j_neighbors_distances):
-                    assert i in indices[j], f"Point {i} should be a neighbor of point {j}, it's closer than the farthest neighbor of {j}"
+                    assert (
+                        i in indices[j]
+                    ), f"Point {i} should be a neighbor of point {j}, it's closer than the farthest neighbor of {j}"
 
     @pytest.mark.slow
-    @given(knn_graph=knn_graph_strategy(num_samples=st.integers(min_value=10, max_value=50), k_neighbors=st.integers(min_value=2, max_value=5)))
+    @given(
+        knn_graph=knn_graph_strategy(
+            num_samples=st.integers(min_value=10, max_value=50),
+            k_neighbors=st.integers(min_value=2, max_value=5),
+        )
+    )
     @settings(suppress_health_check=[HealthCheck.too_slow])
     def test_knn_graph(self, knn_graph):
         """Run through the property tests defined above."""

--- a/tests/datalab/issue_manager/test_knn_graph.py
+++ b/tests/datalab/issue_manager/test_knn_graph.py
@@ -1,0 +1,83 @@
+import math
+from hypothesis import given, settings, strategies as st
+import numpy as np
+from scipy.sparse import csr_matrix
+
+@st.composite
+def knn_graph_strategy(draw, num_samples, k_neighbors):
+    # If the argument is a strategy, draw a value from it.
+    if isinstance(num_samples, st.SearchStrategy):
+        num_samples = draw(num_samples)
+
+    if isinstance(k_neighbors, st.SearchStrategy):
+        k_neighbors = draw(k_neighbors)
+
+    # Generate a symmetric distance matrix
+    upper_triangle = [
+        draw(st.lists(st.floats(min_value=0, max_value=100, allow_nan=False, allow_infinity=False), 
+                     min_size=i, max_size=i, unique=True))
+        for i in range(1, num_samples+1)
+    ]
+
+    distance_matrix = np.zeros((num_samples, num_samples))
+    for i, row in enumerate(upper_triangle):
+        distance_matrix[i, :i+1] = row
+        distance_matrix[:i+1, i] = row
+
+    np.fill_diagonal(distance_matrix, np.inf)  # To ensure we don't select a point as its own neighbor
+
+    # Compute k-nearest neighbors based on the distance matrix
+    sorted_indices = np.argsort(distance_matrix, axis=1)
+    kneighbor_indices = sorted_indices[:, :k_neighbors]
+    kneighbor_distances = np.array([distance_matrix[i, kneighbor_indices[i]] for i in range(num_samples)])
+
+    knn_graph = csr_matrix((kneighbor_distances.flatten(), kneighbor_indices.flatten(), np.arange(0,( kneighbor_distances.shape[0] * k_neighbors + 1), k_neighbors)), shape=(num_samples, num_samples))
+    return knn_graph
+
+class TestKNNGraph:
+    @staticmethod
+    def assert_distances_sorted(distances):
+        """Check distances are sorted in ascending order for each row."""
+        for row in distances:
+            assert all(row[i] <= row[i+1] for i in range(len(row)-1))
+
+    @staticmethod
+    def assert_indices_unique(indices):
+        """Check that indices are unique across columns and don't have the row's index."""
+        for row_idx, row in enumerate(indices):
+            assert len(set(row)) == len(row)  # Check uniqueness
+            assert row_idx not in row  # Check that row's index is not in the row
+
+    @staticmethod
+    def assert_mutual_neighbors_have_same_distances(distances, indices):
+        """Verify that mutual neighbors have the same distances."""
+        for i in range(distances.shape[0]):
+            for j in indices[i]:
+                if i in indices[j]:
+                    d_ij = distances[i][list(indices[i]).index(j)]
+                    d_ji = distances[j][list(indices[j]).index(i)]
+                    assert math.isclose(d_ij, d_ji), f"Distances between {i} and {j} do not match: {d_ij} vs {d_ji}"
+
+    @staticmethod
+    def assert_mutual_consistency_of_knn_distances(distances, indices):
+        """Verify the mutual consistency of k-NN distances:
+        For every point i and its neighbor j, ensure that the distance from i to j
+        cannot be smaller than the distance from any other neighbor k of j to j.
+        """
+        for i in range(distances.shape[0]):
+            for j in indices[i]:
+                d_ij = distances[i][list(indices[i]).index(j)]
+                j_neighbors_distances = distances[j]
+                if d_ij < max(j_neighbors_distances):
+                    assert i in indices[j], f"Point {i} should be a neighbor of point {j}, it's closer than the farthest neighbor of {j}"
+
+    @given(knn_graph=knn_graph_strategy(num_samples=st.integers(min_value=10, max_value=50), k_neighbors=st.integers(min_value=2, max_value=5)))
+    def test_knn_graph(self, knn_graph):
+        N = knn_graph.shape[0]
+        distances = knn_graph.data.reshape(N, -1)
+        indices = knn_graph.indices.reshape(N, -1)
+
+        self.assert_distances_sorted(distances)
+        self.assert_indices_unique(indices)
+        self.assert_mutual_neighbors_have_same_distances(distances, indices)
+        self.assert_mutual_consistency_of_knn_distances(distances, indices)

--- a/tests/datalab/issue_manager/test_knn_graph.py
+++ b/tests/datalab/issue_manager/test_knn_graph.py
@@ -1,38 +1,7 @@
 import math
 from hypothesis import given, strategies as st
-import numpy as np
-from scipy.sparse import csr_matrix
 
-@st.composite
-def knn_graph_strategy(draw, num_samples, k_neighbors):
-    # If the argument is a strategy, draw a value from it.
-    if isinstance(num_samples, st.SearchStrategy):
-        num_samples = draw(num_samples)
-
-    if isinstance(k_neighbors, st.SearchStrategy):
-        k_neighbors = draw(k_neighbors)
-
-    # Generate a symmetric distance matrix
-    upper_triangle = [
-        draw(st.lists(st.floats(min_value=0, max_value=100, allow_nan=False, allow_infinity=False), 
-                     min_size=i, max_size=i, unique=True))
-        for i in range(1, num_samples+1)
-    ]
-
-    distance_matrix = np.zeros((num_samples, num_samples))
-    for i, row in enumerate(upper_triangle):
-        distance_matrix[i, :i+1] = row
-        distance_matrix[:i+1, i] = row
-
-    np.fill_diagonal(distance_matrix, np.inf)  # To ensure we don't select a point as its own neighbor
-
-    # Compute k-nearest neighbors based on the distance matrix
-    sorted_indices = np.argsort(distance_matrix, axis=1)
-    kneighbor_indices = sorted_indices[:, :k_neighbors]
-    kneighbor_distances = np.array([distance_matrix[i, kneighbor_indices[i]] for i in range(num_samples)])
-
-    knn_graph = csr_matrix((kneighbor_distances.flatten(), kneighbor_indices.flatten(), np.arange(0,( kneighbor_distances.shape[0] * k_neighbors + 1), k_neighbors)), shape=(num_samples, num_samples))
-    return knn_graph
+from .conftest import knn_graph_strategy
 
 class TestKNNGraph:
     @staticmethod

--- a/tests/datalab/issue_manager/test_knn_graph.py
+++ b/tests/datalab/issue_manager/test_knn_graph.py
@@ -1,5 +1,6 @@
 import math
-from hypothesis import given, strategies as st
+from hypothesis import HealthCheck, given, settings, strategies as st
+import pytest
 
 from .conftest import knn_graph_strategy
 
@@ -40,7 +41,9 @@ class TestKNNGraph:
                 if d_ij < max(j_neighbors_distances):
                     assert i in indices[j], f"Point {i} should be a neighbor of point {j}, it's closer than the farthest neighbor of {j}"
 
+    @pytest.mark.slow
     @given(knn_graph=knn_graph_strategy(num_samples=st.integers(min_value=10, max_value=50), k_neighbors=st.integers(min_value=2, max_value=5)))
+    @settings(suppress_health_check=[HealthCheck.too_slow])
     def test_knn_graph(self, knn_graph):
         """Run through the property tests defined above."""
         N = knn_graph.shape[0]


### PR DESCRIPTION
## Summary

This PR aims to verify the correctness of near-duplicate sets found in knn-graphs by introducing property-based tests. It also modifies the `is_near_duplicate_issue` column to consider examples only within the sets.


## Impact

🌐 Areas Affected: 
- `cleanlab/datalab/internal/issue_manager/duplicate.py`
- Other changes add more tests.

👥 Who’s Affected:

Anyone constructing a `knn_graph: csr_matrix` with an ANN-search algorithm with low-recall is now guaranteed to find only examples in `near_duplicate_sets` that are flagged as `is_near_duplicate_issue == True`.

## Testing

> 🔍 Testing Done: A strategy for generating valid knn-graphs is added to `tests/datalab/issue_manager/test_knn_graph.py`. Its properties are tested in the same module. This strategy is used to generate test inputs to property-based tests for `near_duplicate_sets` found by the `NearDuplicateIssueManager`.
>
> 🔗 Test Case Link: [Main test class](https://github.com/cleanlab/cleanlab/compare/master...elisno:duplicate-sets-properties?expand=1#diff-5ecb578d192001a407b24144094a6c25631fa2cfe24bac88668574343a26170dR172-R199) verifies that the `near_duplicate_sets` satisfy the desired properties for any knn-graph. 

**Unaddressed Cases**

> - sklearn has [deprecated and removed the only known ann-search algorithm](https://scikit-learn.org/0.16/modules/generated/sklearn.neighbors.LSHForest.html) I am aware of.
> - To avoid adding extra test dependencies, the strategy generates only exact knn graphs.
> - These desired properties don't require a brute-force search algorithm and are valid for an approximate search algorithm that finds k_neighbors for every point.

## Reviewer Notes

When reviewing the changes in cleanlab/datalab/internal/issue_manager/duplicate.py, please note that 
```python
is_issue_column = nn_distances < self.threshold * np.median(nn_distances)
```
previously flagged examples whose 1-nearest-neighbor is within the given threshold. With the changes, the same right-hand side of the inequality is used to flag examples in a near-duplicate set. These sets were made symmetric in a [previous PR](https://github.com/cleanlab/cleanlab/pull/781).

