### PR TITLE
Refactor Non-IID tests to reuse common code

### DIFF
--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -774,6 +774,16 @@ def test_near_duplicates_reuses_knn_graph():
 
 
 def pred_probs_from_features(features):
+    """
+    Converts an array of features into an array of predicted probabilities
+    by normalizing each row to sum to 1.
+
+    Note
+    ----
+    This function is only used for testing purposes
+    and may not align with conventional methodologies
+    used in real-world applications.
+    """
     return features / features.sum(axis=1, keepdims=True)
 
 


### PR DESCRIPTION
## Summary

The Non-IID test class for the datalab interface has been refactored to reuse code that is common across different test methods. This includes using a pytest fixture for the datalab instance and using a function for computing prediction probabilities using features. 

## Impact

Areas Affected: Class `TestDatalabFindNonIIDIssues` in `test_datalab.py`. 


## Testing

Testing Done: Verified that the tests run successfully after the refactor. 



