### PR TITLE
Non-IID: Tests for preference of feature knn-graph  over pred-probs knn-graph

### DIFF
--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -874,6 +874,13 @@ class TestDatalabFindNonIIDIssues:
         assert non_iid_summary["num_issues"].values[0] == 1
 
     def test_non_iid_issues_pred_probs_knn_graph_checks(self, lab, random_embeddings):
+        """
+        Note
+        ----
+        If the user did provides `features` or there was already a KNN graph
+        constructed in Datalab, the results should be returned as they currently
+        are, not using the `pred_probs` at all.
+        """
         pred_probs = pred_probs_from_features(random_embeddings)
         # knn graph is computed and stored
         lab.find_issues(


### PR DESCRIPTION
## Summary

🎯 **Purpose**: This PR adds tests to check behaviour of Non-IID issue manager when `pred_probs` are passed and `features` are not passed to `find_issues`. Specifically, the tests verify that- 

* `knn_graph` generated using `pred_probs` is not stored in the `info` attribute of `Datalab`. 
* Cached `knn_graph` is preferred over construction of a new `knn_graph` with `pred_probs`. 
* `find_issues` with cached `knn_graph`  yields the same non-iid issues as passing the cached `knn_graph`  explicitly to `find_issues`. 

## Impact

🌐 Areas Affected: Class `TestDatalabFindNonIIDIssues` in `test_datalab.py`. 

## Testing

 🔍 Testing Done: Verified that unit-tests pass.

## Links to Relevant Issues or Conversations

Resolves https://github.com/cleanlab/cleanlab/issues/888
