### PR TITLE
Predictions for regression in Datalab

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -589,9 +589,10 @@ class Datalab:
         print(load_message)
         return datalab
 
+
 def _ensure_single_prediction_input(pred_probs: Any, predictions: Any, task: str) -> None:
     """Helper function for resolving conflicting inputs.
-    
+
     For greater coverage, it checks if both pred_probs and predictions are provided, regardless of task.
     If that's not the case, it checks if the provided input is unsupported for the given task.
 

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -160,7 +160,6 @@ class Datalab:
         self,
         *,
         pred_probs: Optional[np.ndarray] = None,
-        predictions: Optional[np.ndarray] = None,
         features: Optional[npt.NDArray] = None,
         knn_graph: Optional[csr_matrix] = None,
         issue_types: Optional[Dict[str, Any]] = None,
@@ -189,13 +188,6 @@ class Datalab:
             To best detect label issues, provide this input obtained from the most accurate model you can produce.
 
             If provided, this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
-            Must not be provided if `predictions` is provided.
-
-        predictions :
-            Out-of-sample predicted output variables made by the model for every example in the dataset.
-            To best detect label issues, provide this input obtained from the most accurate model you can produce.
-
-            Must not be provided if `pred_probs` is provided.
 
         features : Optional[np.ndarray]
             Feature embeddings (vector representations) of every example in the dataset.
@@ -309,8 +301,6 @@ class Datalab:
                 >>> # lab.find_issues(pred_probs=pred_probs, issue_types=issue_types)
 
         """
-        # Check for conflicting inputs
-        _ensure_single_prediction_input(pred_probs, predictions, task=self.task)
 
         if issue_types is not None and not issue_types:
             warnings.warn(
@@ -322,7 +312,6 @@ class Datalab:
         )
         issue_finder.find_issues(
             pred_probs=pred_probs,
-            predictions=predictions,
             features=features,
             knn_graph=knn_graph,
             issue_types=issue_types,
@@ -588,34 +577,3 @@ class Datalab:
         load_message = f"Datalab loaded from folder: {path}"
         print(load_message)
         return datalab
-
-
-def _ensure_single_prediction_input(pred_probs: Any, predictions: Any, task: str) -> None:
-    """Helper function for resolving conflicting inputs.
-
-    For greater coverage, it checks if both pred_probs and predictions are provided, regardless of task.
-    If that's not the case, it checks if the provided input is unsupported for the given task.
-
-    Raises
-    ------
-    ValueError
-        If both `pred_probs` and `predictions` are provided.
-        Or if `pred_probs` is provided for a regression task.
-        Or if `predictions` is provided for a classification task.
-    """
-    # Edge-case, someone passes both pred_probs and predictions
-    error_msg = ""
-    if pred_probs is not None and predictions is not None:
-        error_msg = "Only one of `pred_probs` or `predictions` can be provided."
-        task_tips = {
-            "classification": "pred_probs",
-            "regression": "predictions",
-        }
-        if task in task_tips:
-            error_msg += f" For a {task} task, consider passing `{task_tips[task]}` instead."
-    elif task == "classification" and predictions is not None:
-        error_msg = "`predictions` is not supported for classification tasks. Consider passing `pred_probs` instead."
-    elif task == "regression" and pred_probs is not None:
-        error_msg = "`pred_probs` is not supported for regression tasks. Consider passing `predictions` instead."
-    if error_msg:
-        raise ValueError(error_msg)

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -187,8 +187,8 @@ class Datalab:
             Out-of-sample predicted class probabilities made by the model for every example in the dataset.
             To best detect label issues, provide this input obtained from the most accurate model you can produce.
 
-            If provided (for classification), this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
-            If provided (for regression), this must be a 1D array with shape (num_examples,).
+            If provided for classification, this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
+            If provided for regression, this must be a 1D array with shape (num_examples,).
 
         features : Optional[np.ndarray]
             Feature embeddings (vector representations) of every example in the dataset.

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -187,7 +187,8 @@ class Datalab:
             Out-of-sample predicted class probabilities made by the model for every example in the dataset.
             To best detect label issues, provide this input obtained from the most accurate model you can produce.
 
-            If provided, this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
+            If provided (for classification), this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
+            If provided (for regression), this must be a 1D array with shape (num_examples,).
 
         features : Optional[np.ndarray]
             Feature embeddings (vector representations) of every example in the dataset.

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -187,8 +187,8 @@ class Datalab:
             Out-of-sample predicted class probabilities made by the model for every example in the dataset.
             To best detect label issues, provide this input obtained from the most accurate model you can produce.
 
-            If provided for classification, this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
-            If provided for regression, this must be a 1D array with shape (num_examples,).
+            For classification data, this must be a 2D array with shape ``(num_examples, K)`` where ``K`` is the number of classes in the dataset.
+            For regression data, this must be a 1D array with shape ``(num_examples,)`` containing the predicted value for each example.
 
         features : Optional[np.ndarray]
             Feature embeddings (vector representations) of every example in the dataset.

--- a/cleanlab/datalab/internal/adapter/imagelab.py
+++ b/cleanlab/datalab/internal/adapter/imagelab.py
@@ -192,6 +192,7 @@ class ImagelabIssueFinderAdapter(IssueFinder):
         self,
         *,
         pred_probs: Optional[np.ndarray] = None,
+        predictions: Optional[np.ndarray] = None,
         features: Optional[npt.NDArray] = None,
         knn_graph: Optional[csr_matrix] = None,
         issue_types: Optional[Dict[str, Any]] = None,
@@ -203,6 +204,7 @@ class ImagelabIssueFinderAdapter(IssueFinder):
         )
         super().find_issues(
             pred_probs=pred_probs,
+            predictions=predictions,
             features=features,
             knn_graph=knn_graph,
             issue_types=datalab_issue_types,

--- a/cleanlab/datalab/internal/adapter/imagelab.py
+++ b/cleanlab/datalab/internal/adapter/imagelab.py
@@ -192,7 +192,6 @@ class ImagelabIssueFinderAdapter(IssueFinder):
         self,
         *,
         pred_probs: Optional[np.ndarray] = None,
-        predictions: Optional[np.ndarray] = None,
         features: Optional[npt.NDArray] = None,
         knn_graph: Optional[csr_matrix] = None,
         issue_types: Optional[Dict[str, Any]] = None,
@@ -204,7 +203,6 @@ class ImagelabIssueFinderAdapter(IssueFinder):
         )
         super().find_issues(
             pred_probs=pred_probs,
-            predictions=predictions,
             features=features,
             knn_graph=knn_graph,
             issue_types=datalab_issue_types,

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -211,8 +211,8 @@ class IssueFinder:
             Out-of-sample predicted class probabilities made by the model for every example in the dataset.
             To best detect label issues, provide this input obtained from the most accurate model you can produce.
 
-            If provided for classification, this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
-            If provided for regression, this must be a 1D array with shape (num_examples,).
+            If provided for classification, this must be a 2D array with shape ``(num_examples, K)`` where K is the number of classes in the dataset.
+            If provided for regression, this must be a 1D array with shape ``(num_examples,)``.
 
         features : Optional[np.ndarray]
             Feature embeddings (vector representations) of every example in the dataset.

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -211,8 +211,8 @@ class IssueFinder:
             Out-of-sample predicted class probabilities made by the model for every example in the dataset.
             To best detect label issues, provide this input obtained from the most accurate model you can produce.
 
-            If provided (for classification), this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
-            If provided (for regression), this must be a 1D array with shape (num_examples,).
+            If provided for classification, this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
+            If provided for regression, this must be a 1D array with shape (num_examples,).
 
         features : Optional[np.ndarray]
             Feature embeddings (vector representations) of every example in the dataset.

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -357,6 +357,7 @@ class IssueFinder:
         """Returns a dictionary of issue types that can be used in :py:meth:`Datalab.find_issues
         <cleanlab.datalab.datalab.Datalab.find_issues>` method."""
 
+        pred_probs = kwargs.get("pred_probs", None)
         features = kwargs.get("features", None)
         knn_graph = kwargs.get("knn_graph", None)
         issue_types = kwargs.get("issue_types", None)

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -203,8 +203,9 @@ class IssueFinder:
             Out-of-sample predicted class probabilities made by the model for every example in the dataset.
             To best detect label issues, provide this input obtained from the most accurate model you can produce.
 
-            If provided, this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
-
+            If provided (for classification), this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
+            If provided (for regression), this must be a 1D array with shape (num_examples,).
+            
         features : Optional[np.ndarray]
             Feature embeddings (vector representations) of every example in the dataset.
 

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -205,7 +205,7 @@ class IssueFinder:
 
             If provided (for classification), this must be a 2D array with shape (num_examples, K) where K is the number of classes in the dataset.
             If provided (for regression), this must be a 1D array with shape (num_examples,).
-            
+
         features : Optional[np.ndarray]
             Feature embeddings (vector representations) of every example in the dataset.
 

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -55,7 +55,7 @@ _CLASSIFICATION_ARGS_DICT = {
     "data_valuation": ["knn_graph"],
 }
 _REGRESSION_ARGS_DICT = {
-    "label": ["features"],
+    "label": ["features", "predictions"],
 }
 
 
@@ -175,6 +175,7 @@ class IssueFinder:
         self,
         *,
         pred_probs: Optional[np.ndarray] = None,
+        predictions: Optional[np.ndarray] = None,
         features: Optional[npt.NDArray] = None,
         knn_graph: Optional[csr_matrix] = None,
         issue_types: Optional[Dict[str, Any]] = None,
@@ -238,6 +239,7 @@ class IssueFinder:
 
         issue_types_copy = self.get_available_issue_types(
             pred_probs=pred_probs,
+            predictions=predictions,
             features=features,
             knn_graph=knn_graph,
             issue_types=issue_types,

--- a/cleanlab/datalab/internal/issue_manager/regression/label.py
+++ b/cleanlab/datalab/internal/issue_manager/regression/label.py
@@ -40,7 +40,8 @@ class RegressionLabelIssueManager(IssueManager):
         Keyword arguments to pass to the :py:meth:`CleanLearning <cleanlab.regression.learn.CleanLearning>` constructor.
 
     threshold :
-        The threshold to use to determine if an example has a label issue. Only used if
+        The threshold to use to determine if an example has a label issue. It is a multiplier
+        of the median label quality score that sets the absolute threshold. Only used if
         predictions are provided to `~RegressionLabelIssueManager.find_issues`, not if
         features are provided. Default is 0.1.
     """
@@ -84,6 +85,11 @@ class RegressionLabelIssueManager(IssueManager):
             raise ValueError(
                 "Regression requires numerical `features` or `predictions` "
                 "to be passed in as an argument to `find_issues`."
+            )
+        if features is None and self._uses_custom_model:
+            raise ValueError(
+                "Regression requires numerical `features` to be passed in as an argument to `find_issues` "
+                "when using a custom model."
             )
         # If features are provided and either a custom model is used or no predictions are provided
         use_features = features is not None and (self._uses_custom_model or predictions is None)
@@ -155,7 +161,8 @@ def find_issues_with_predictions(
         The given labels.
 
     threshold :
-        The threshold to use to determine if an example has a label issue.
+        The threshold to use to determine if an example has a label issue. It is a multiplier
+        of the median label quality score that sets the absolute threshold.
 
     **kwargs :
         Various keyword arguments.

--- a/cleanlab/datalab/internal/issue_manager/regression/label.py
+++ b/cleanlab/datalab/internal/issue_manager/regression/label.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class RegressionLabelIssueManager(IssueManager):
-    """Manages label issues in a Datalab.
+    """Manages label issues in a Datalab for regression tasks.
 
     Parameters
     ----------
@@ -80,7 +80,14 @@ class RegressionLabelIssueManager(IssueManager):
         predictions: Optional[np.ndarray] = None,
         **kwargs,
     ) -> None:
-        """Find label issues in the datalab."""
+        """Find label issues in the datalab.
+
+        .. admonition:: Priority Order for finding issues:
+
+            1. Custom Model: Requires `features` to be passed to this method. Used if a model is set up in the constructor.
+            2. Predictions: Uses `predictions` if provided and no model is set up in the constructor.
+            3. Default Model: Defaults to a standard model using `features` if no model or predictions are provided.
+        """
         if features is None and predictions is None:
             raise ValueError(
                 "Regression requires numerical `features` or `predictions` "

--- a/cleanlab/datalab/internal/issue_manager/regression/label.py
+++ b/cleanlab/datalab/internal/issue_manager/regression/label.py
@@ -37,7 +37,7 @@ class RegressionLabelIssueManager(IssueManager):
         A Datalab instance.
 
     clean_learning_kwargs :
-        Keyword arguments to pass to the :py:meth:`CleanLearning <cleanlab.regression.learn.CleanLearning>` constructor.
+        Keyword arguments to pass to the :py:meth:`regression.learn.CleanLearning <cleanlab.regression.learn.CleanLearning>` constructor.
 
     threshold :
         The threshold to use to determine if an example has a label issue. It is a multiplier

--- a/cleanlab/datalab/internal/model_outputs.py
+++ b/cleanlab/datalab/internal/model_outputs.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2017-2023  Cleanlab Inc.
+# This file is part of cleanlab.
+#
+# cleanlab is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cleanlab is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
+"""
+This module contains the ModelOutput class, which is used internally within Datalab
+to represent model outputs (e.g. predictions, probabilities, etc.) and process them
+for issue finding.
+This class and associated naming conventions are subject to change and is not meant
+to be used by users. 
+"""
+
+
+from abc import ABC, abstractmethod
+import numpy as np
+from dataclasses import dataclass
+
+
+@dataclass
+class ModelOutput(ABC):
+    """
+    An abstract class for representing model outputs (e.g. predictions, probabilities, etc.)
+    for internal use within Datalab. This class is not meant to be used by users.
+
+    It is used internally within the issue-finding process Datalab runs to assign
+    types to the data and process it accordingly.
+
+    Parameters
+    ----------
+    data : array-like
+        The model outputs. Not to be confused with the data used to train the model.
+        This is mainly intended for NumPy arrays.
+    """
+
+    data: np.ndarray
+
+    @abstractmethod
+    def validate(self):
+        """
+        Validate the data format and content.
+        E.g. a pred_probs object used for classification
+        should be a 2D array with values between 0 and 1 and sum to 1 for each row.
+        """
+        pass
+
+    @abstractmethod
+    def collect(self):
+        """
+        Fetch the data for issue finding.
+        Usually this is just the data itself, but sometimes it may be a transformation
+        of the data (e.g. a 1D array of predictions from a 2D array of predicted probabilities).
+        """
+        pass
+
+
+class MultiClassPredProbs(ModelOutput):
+    """
+    A class for representing a model's predicted probabilities for each class
+    in a multi-class classification problem. This class is not meant to be used by users.
+    """
+
+    argument = "pred_probs"
+
+    def validate(self):
+        pred_probs = self.data
+        if pred_probs.ndim != 2:
+            raise ValueError("pred_probs must be a 2D array for multi-class classification")
+        if not np.all(pred_probs >= 0) or not np.all(pred_probs <= 1):
+            raise ValueError("pred_probs must be between 0 and 1 for multi-class classification")
+        if not np.allclose(np.sum(pred_probs, axis=1), 1):
+            raise ValueError("pred_probs must sum to 1 for each row for multi-class classification")
+
+    def collect(self):
+        return self.data
+
+
+class RegressionPredictions(ModelOutput):
+    """
+    A class for representing a model's predictions for a regression problem.
+    This class is not meant to be used by users.
+    """
+
+    argument = "predictions"
+
+    def validate(self):
+        predictions = self.data
+        if predictions.ndim != 1:
+            raise ValueError("pred_probs must be a 1D array for regression")
+
+    def collect(self):
+        return self.data

--- a/docs/source/cleanlab/datalab/guide/custom_issue_manager.rst
+++ b/docs/source/cleanlab/datalab/guide/custom_issue_manager.rst
@@ -19,7 +19,7 @@ to detect a custom-defined type of issue alongside the pre-defined issue types i
 
             from cleanlab.datalab.internal.issue_manager_factory import register
             register(MyIssueManager)  # Defaults to task="classification"
-            # register(MyIssueManagerForRegression, task="regression") # For regression tasks
+            # register(MyIssueManagerForRegression, task="regression")  # Alternative for regression tasks
 
         or add as a decorator to the class definition (currently only works for classification tasks):
 

--- a/docs/source/cleanlab/datalab/guide/custom_issue_manager.rst
+++ b/docs/source/cleanlab/datalab/guide/custom_issue_manager.rst
@@ -21,7 +21,7 @@ to detect a custom-defined type of issue alongside the pre-defined issue types i
             register(MyIssueManager)  # Defaults to task="classification"
             # register(MyIssueManagerForRegression, task="regression") # For regression tasks
 
-        or add as a decorator to the class definition (currently only works for classification tasks)
+        or add as a decorator to the class definition (currently only works for classification tasks):
 
         .. code-block:: python
 

--- a/docs/source/cleanlab/datalab/guide/custom_issue_manager.rst
+++ b/docs/source/cleanlab/datalab/guide/custom_issue_manager.rst
@@ -18,9 +18,10 @@ to detect a custom-defined type of issue alongside the pre-defined issue types i
         .. code-block:: python
 
             from cleanlab.datalab.internal.issue_manager_factory import register
-            register(MyIssueManager)
+            register(MyIssueManager)  # Defaults to task="classification"
+            # register(MyIssueManagerForRegression, task="regression") # For regression tasks
 
-        or add as a decorator to the class definition:
+        or add as a decorator to the class definition (currently only works for classification tasks)
 
         .. code-block:: python
 

--- a/docs/source/cleanlab/datalab/internal/issue_manager/index.rst
+++ b/docs/source/cleanlab/datalab/internal/issue_manager/index.rst
@@ -25,4 +25,11 @@ These are the issue managers that Datalab has not registered (yet).
 
 .. toctree::
     null
+
+Task-specific issue managers
+----------------------------
+
+.. toctree::
+    regression/index
+
     

--- a/docs/source/cleanlab/datalab/internal/issue_manager/index.rst
+++ b/docs/source/cleanlab/datalab/internal/issue_manager/index.rst
@@ -26,8 +26,8 @@ These are the issue managers that Datalab has not registered (yet).
 .. toctree::
     null
 
-Task-specific issue managers
-----------------------------
+ML task-specific issue managers
+---------------------------------
 
 .. toctree::
     regression/index

--- a/docs/source/cleanlab/datalab/internal/issue_manager/regression/index.rst
+++ b/docs/source/cleanlab/datalab/internal/issue_manager/regression/index.rst
@@ -1,0 +1,8 @@
+regression
+==========
+
+.. warning::
+    Methods in this ``regression`` module are bleeding edge and may have sharp edges. They are not guaranteed to be stable between different ``cleanlab`` versions.
+
+.. toctree::
+    label

--- a/docs/source/cleanlab/datalab/internal/issue_manager/regression/label.rst
+++ b/docs/source/cleanlab/datalab/internal/issue_manager/regression/label.rst
@@ -1,0 +1,8 @@
+label
+=====
+
+.. automodule:: cleanlab.datalab.internal.issue_manager.regression.label
+    :autosummary:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tests/datalab/issue_manager/regression/test_label.py
+++ b/tests/datalab/issue_manager/regression/test_label.py
@@ -1,0 +1,147 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from cleanlab import Datalab
+from cleanlab.datalab.internal.issue_manager.regression.label import RegressionLabelIssueManager
+
+
+def ground_truth_target_function(x):
+    return 10 * x + 1
+
+
+@pytest.mark.cleanvision
+class TestRegressionLabelIssueManager:
+    def test_manager_found_in_registry(self):
+        from cleanlab.datalab.internal.issue_manager_factory import REGISTRY
+
+        error_msg = (
+            "RegressionLabelIssueManager should be registered to the regression task as 'label'"
+        )
+        assert REGISTRY["regression"].get("label") == RegressionLabelIssueManager, error_msg
+
+    @pytest.fixture
+    def features(self):
+        # 1 feature, 7 points
+        return np.array([0.1, 0.2, 0.3, 0.35, 0.4, 0.45, 0.5]).reshape(-1, 1)
+
+    @pytest.fixture
+    def regression_lab(self, features):
+        y = ground_truth_target_function(features)
+        # Flip the sign of the point x=0.4
+        y[features == 0.4] *= -1
+        y = y.ravel()
+        return Datalab({"y": y}, label_name="y", task="regression")
+
+    @pytest.fixture
+    def issue_manager(self, regression_lab):
+        return RegressionLabelIssueManager(datalab=regression_lab)
+
+    def test_find_issues_with_features(self, issue_manager, features):
+        issue_manager.find_issues(features=features)
+        issues = issue_manager.issues
+        assert isinstance(issues, pd.DataFrame), "Issues should be a dataframe"
+        expected_issue_mask = features.ravel() == 0.4
+        assert sum(expected_issue_mask) == 1, "There should be exactly one issue"
+
+        np.testing.assert_array_equal(issues["is_label_issue"].values, expected_issue_mask)
+        # Assert that he minimum score "label_score" is at the correct index
+        index_of_error = np.where(expected_issue_mask)[0][0]
+        assert issues["label_score"].values.argmin() == index_of_error
+
+    def test_init_with_model(self, issue_manager):
+        from sklearn.neighbors import KNeighborsRegressor
+
+        model = KNeighborsRegressor(n_neighbors=2)
+        assert issue_manager.cl.model != model
+
+        # Passing in a model to the constructor should set the cl.model field
+        clean_learning_kwargs = {"model": model}
+        lab = issue_manager.datalab
+        new_issue_manager = RegressionLabelIssueManager(
+            datalab=lab, clean_learning_kwargs=clean_learning_kwargs
+        )
+        assert new_issue_manager.cl.model == model
+
+    @pytest.fixture
+    def predictions(self, features):
+        y_ground_truth = ground_truth_target_function(features).ravel()
+        noise = 0.1 * np.random.randn(len(y_ground_truth))
+        return y_ground_truth + noise
+
+    def test_raises_find_issues_error_without_valid_inputs(self, issue_manager):
+        with pytest.raises(ValueError) as e:
+            expected_error_msg = (
+                "Regression requires numerical `features` or `predictions` "
+                "to be passed in as an argument to `find_issues`."
+            )
+            issue_manager.find_issues()
+            assert expected_error_msg in str(e)
+
+    def test_find_issue_with_predictions(self, issue_manager, features, predictions):
+        issue_manager.find_issues(predictions=predictions)
+        issues = issue_manager.issues
+        assert isinstance(issues, pd.DataFrame), "Issues should be a dataframe"
+        expected_issue_mask = features.ravel() == 0.4
+        assert sum(expected_issue_mask) == 1, "There should be exactly one issue"
+
+        np.testing.assert_array_equal(issues["is_label_issue"].values, expected_issue_mask)
+        # Assert that he minimum score "label_score" is at the correct index
+        index_of_error = np.where(expected_issue_mask)[0][0]
+        assert issues["label_score"].values.argmin() == index_of_error
+
+
+class TestRegressionLabelIssueManagerIntegration:
+
+    """This class contains tests for the find_issues method with a CleanLearning
+    object that behaves deterministically. This is useful to run a "regression"-test on
+    the results computed by the find_issues method.
+    The test dataset is a random toy regression dataset with 5 features and 100 samples.
+    The ground truth is a linear function of the first feature plus a bias defined in the
+    class attribute BIAS.
+    The ground truth is used to emulate a perfect model and compute the expected score
+    for the label issue detection. The gaussian noise contributes to lower label quality
+    scores.
+    """
+    BIAS = 1.0
+    
+    @pytest.fixture()
+    def regression_dataset(self):
+        """For integration tests, a simple regression dataset is simpler than
+        a tiny, hand-crafted one."""
+        from sklearn.datasets import make_regression
+
+        # Return coefficients as well for testing purposes,
+        # interpret as ground truth
+        X, y, coef = make_regression(
+            n_samples=100,
+            n_features=5,
+            n_informative=1,
+            n_targets=1,
+            bias=self.BIAS,
+            noise=0.1,
+            random_state=0,
+            coef=True,
+        )
+        return X, y, coef
+    
+    @pytest.fixture()
+    def issue_manager(self, regression_dataset):
+
+        _, y, _  = regression_dataset
+        lab = Datalab({"y": y}, label_name="y", task="regression")
+        return RegressionLabelIssueManager(datalab=lab, clean_learning_kwargs={"seed": 0})
+    
+    def test_find_issues_with_features(self, regression_dataset, issue_manager):
+        X, _, _ = regression_dataset
+        issue_manager.find_issues(features=X)
+        summary = issue_manager.summary
+        assert np.isclose(summary["score"], 0.262423, atol=1e-5)
+
+
+    def test_find_issues_with_predictions(self, regression_dataset, issue_manager):
+        X, _ , coef = regression_dataset
+        y_pred = X @ coef + self.BIAS
+        issue_manager.find_issues(predictions=y_pred)
+        summary = issue_manager.summary
+        assert np.isclose(summary["score"], 0.075765, atol=1e-5)

--- a/tests/datalab/issue_manager/regression/test_label.py
+++ b/tests/datalab/issue_manager/regression/test_label.py
@@ -103,8 +103,9 @@ class TestRegressionLabelIssueManagerIntegration:
     for the label issue detection. The gaussian noise contributes to lower label quality
     scores.
     """
+
     BIAS = 1.0
-    
+
     @pytest.fixture()
     def regression_dataset(self):
         """For integration tests, a simple regression dataset is simpler than
@@ -124,23 +125,21 @@ class TestRegressionLabelIssueManagerIntegration:
             coef=True,
         )
         return X, y, coef
-    
+
     @pytest.fixture()
     def issue_manager(self, regression_dataset):
-
-        _, y, _  = regression_dataset
+        _, y, _ = regression_dataset
         lab = Datalab({"y": y}, label_name="y", task="regression")
         return RegressionLabelIssueManager(datalab=lab, clean_learning_kwargs={"seed": 0})
-    
+
     def test_find_issues_with_features(self, regression_dataset, issue_manager):
         X, _, _ = regression_dataset
         issue_manager.find_issues(features=X)
         summary = issue_manager.summary
         assert np.isclose(summary["score"], 0.262423, atol=1e-5)
 
-
     def test_find_issues_with_predictions(self, regression_dataset, issue_manager):
-        X, _ , coef = regression_dataset
+        X, _, coef = regression_dataset
         y_pred = X @ coef + self.BIAS
         issue_manager.find_issues(predictions=y_pred)
         summary = issue_manager.summary

--- a/tests/datalab/issue_manager/regression/test_label.py
+++ b/tests/datalab/issue_manager/regression/test_label.py
@@ -10,7 +10,6 @@ def ground_truth_target_function(x):
     return 10 * x + 1
 
 
-@pytest.mark.cleanvision
 class TestRegressionLabelIssueManager:
     def test_manager_found_in_registry(self):
         from cleanlab.datalab.internal.issue_manager_factory import REGISTRY

--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -197,7 +197,9 @@ class TestNearDuplicateSets:
 
     @pytest.mark.slow
     @given(issue_manager=no_issue_issue_manager_strategy())
-    @settings(deadline=800, suppress_health_check=[HealthCheck.too_slow])
+    @settings(
+        deadline=800, suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large]
+    )
     def test_near_duplicate_sets_empty_if_no_issue_next(self, issue_manager):
         near_duplicate_sets = issue_manager.info["near_duplicate_sets"]
         assert all(len(near_duplicate_set) == 0 for near_duplicate_set in near_duplicate_sets)

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1063,6 +1063,16 @@ class TestDatalabForRegression:
         assert (summary[summary["issue_type"] == "label"]["num_issues"] == 22).all()
         assert np.isclose(summary[summary["issue_type"] == "label"]["score"].values[0], 0.58768, atol=1e-5)
         
+    def test_regression_with_model_and_features(self, lab, regression_data):
+        """Test that the regression issue checks find label issue with another model."""
+        from sklearn.neighbors import KNeighborsRegressor
+        model = KNeighborsRegressor(n_neighbors=5)
+        X = regression_data["X"]
+        lab.find_issues(features=X, issue_types={"label": {"clean_learning_kwargs": {"model": model}}})
+        summary = lab.get_issue_summary()
+        assert (summary[summary["issue_type"] == "label"]["num_issues"] == 30).all()
+        assert np.isclose(summary[summary["issue_type"] == "label"]["score"].values[0], 0.777305, atol=1e-5)
+        
 
 class TestDatalabFindOutlierIssues:
     @pytest.fixture

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1038,6 +1038,31 @@ class TestDatalabForRegression:
         assert (summary[summary["issue_type"] == "label"]["num_issues"] == 40).all()
         assert np.isclose(summary[summary["issue_type"] == "label"]["score"].values[0], 0.672974, atol=1e-5)
         
+    def test_regression_with_predictions(self, lab, regression_data):
+        """Test that the regression issue checks find 12 label issues, based on the
+        predictions of a model.
+        
+        Instead of running a model, we use the ground-truth to emulate a perfect model's predictions.
+        
+        Testing the default behavior, we expect to find some label issues with a given mean score.
+        Increasing a threshold for flagging issues will flag more issues, but won't change the score.
+        """
+        
+        # Use ground-truth to emulate a perfect model's predictions
+        y_pred = regression_data["true_y"]
+        
+        lab.find_issues(predictions=y_pred)
+        summary = lab.get_issue_summary()
+        assert (summary[summary["issue_type"] == "label"]["num_issues"] == 12).all()
+        assert np.isclose(summary[summary["issue_type"] == "label"]["score"].values[0], 0.58768, atol=1e-5)
+        
+        # Apply a threshold for flagging issues. A larger threshold will flag more issues,
+        # but won't change the score.
+        lab.find_issues(predictions=y_pred, issue_types={"label": {"threshold": 0.5}})
+        summary = lab.get_issue_summary()
+        assert (summary[summary["issue_type"] == "label"]["num_issues"] == 22).all()
+        assert np.isclose(summary[summary["issue_type"] == "label"]["score"].values[0], 0.58768, atol=1e-5)
+        
 
 class TestDatalabFindOutlierIssues:
     @pytest.fixture

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1030,7 +1030,7 @@ class TestDatalabForRegression:
         summary = lab.get_issue_summary()
 
         assert "label" in summary["issue_type"].values
-        assert (summary[summary["issue_type"] == "label"]["num_issues"] == 10).all()
+        assert summary[summary["issue_type"] == "label"]["num_issues"].values[0] == 10
         assert np.isclose(
             summary[summary["issue_type"] == "label"]["score"].values[0], 0.95, atol=1e-5
         )
@@ -1062,7 +1062,7 @@ class TestDatalabForRegression:
 
         lab.find_issues(pred_probs=y_pred)
         summary = lab.get_issue_summary()
-        assert (summary[summary["issue_type"] == "label"]["num_issues"] == 10).all()
+        assert summary[summary["issue_type"] == "label"]["num_issues"].values[0] == 10
         assert np.isclose(
             summary[summary["issue_type"] == "label"]["score"].values[0], 0.813172, atol=1e-5
         )
@@ -1084,7 +1084,7 @@ class TestDatalabForRegression:
         # but won't change the score.
         lab.find_issues(pred_probs=y_pred, issue_types={"label": {"threshold": 0.75}})
         summary = lab.get_issue_summary()
-        assert (summary[summary["issue_type"] == "label"]["num_issues"] == 13).all()
+        assert summary[summary["issue_type"] == "label"]["num_issues"].values[0] ==13
         assert np.isclose(
             summary[summary["issue_type"] == "label"]["score"].values[0], 0.813172, atol=1e-5
         )
@@ -1099,8 +1099,7 @@ class TestDatalabForRegression:
             features=X, issue_types={"label": {"clean_learning_kwargs": {"model": model}}}
         )
         summary = lab.get_issue_summary()
-        summary
-        assert (summary[summary["issue_type"] == "label"]["num_issues"] == 13).all()
+        assert summary[summary["issue_type"] == "label"]["num_issues"].values[0] ==13
         assert np.isclose(
             summary[summary["issue_type"] == "label"]["score"].values[0], 0.899407, atol=1e-5
         )

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1036,7 +1036,8 @@ class TestDatalabForRegression:
 
         assert "label" in summary["issue_type"].values
         assert (summary[summary["issue_type"] == "label"]["num_issues"] == 40).all()
-
+        assert np.isclose(summary[summary["issue_type"] == "label"]["score"].values[0], 0.672974, atol=1e-5)
+        
 
 class TestDatalabFindOutlierIssues:
     @pytest.fixture

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -980,53 +980,55 @@ class TestDatalabFindLabelIssues:
         )
 
 
-def make_data(num_examples=200, num_features=3, noise=0.2, error_frac=0.1, error_noise=5):
-    np.random.seed(SEED)
-    X = np.random.random(size=(num_examples, num_features))
-    coefficients = np.random.uniform(-1, 1, size=num_features)
-    label_noise = np.random.normal(scale=noise, size=num_examples)
+class TestDatalabForRegression:
+    @pytest.fixture
+    def regression_data(
+        self, num_examples=200, num_features=3, noise=0.2, error_frac=0.1, error_noise=5
+    ):
+        np.random.seed(SEED)
+        X = np.random.random(size=(num_examples, num_features))
+        coefficients = np.random.uniform(-1, 1, size=num_features)
+        label_noise = np.random.normal(scale=noise, size=num_examples)
 
-    true_y = np.dot(X, coefficients)
-    y = np.dot(X, coefficients) + label_noise
+        true_y = np.dot(X, coefficients)
+        y = np.dot(X, coefficients) + label_noise
 
-    # add extra noisy examples
-    num_errors = int(num_examples * error_frac)
-    extra_noise = np.random.normal(scale=error_noise, size=num_errors)
-    random_idx = np.random.choice(num_examples, num_errors)
-    y[random_idx] += extra_noise
-    error_idx = np.argsort(abs(y - true_y))[-num_errors:]  # get the noisiest examples idx
+        # add extra noisy examples
+        num_errors = int(num_examples * error_frac)
+        extra_noise = np.random.normal(scale=error_noise, size=num_errors)
+        random_idx = np.random.choice(num_examples, num_errors)
+        y[random_idx] += extra_noise
+        error_idx = np.argsort(abs(y - true_y))[-num_errors:]  # get the noisiest examples idx
 
-    # create test set
-    X_test = np.random.random(size=(num_examples, num_features))
-    label_noise = np.random.normal(scale=noise, size=num_examples)
-    y_test = np.dot(X_test, coefficients) + label_noise
+        # create test set
+        X_test = np.random.random(size=(num_examples, num_features))
+        label_noise = np.random.normal(scale=noise, size=num_examples)
+        y_test = np.dot(X_test, coefficients) + label_noise
 
-    return {
-        "X": X,
-        "y": y,
-        "true_y": true_y,
-        "X_test": X_test,
-        "y_test": y_test,
-        "error_idx": error_idx,
-    }
+        return {
+            "X": X,
+            "y": y,
+            "true_y": true_y,
+            "X_test": X_test,
+            "y_test": y_test,
+            "error_idx": error_idx,
+        }
 
+    def test_regression(self, regression_data):
+        X, y = regression_data["X"], regression_data["y"]
+        test_df = pd.DataFrame(X, columns=["c1", "c2", "c3"])
+        test_df["y"] = y
+        lab = Datalab(data=test_df, label_name="y", task="regression")
 
-def test_regression():
-    data = make_data()
-    X, y = data["X"], data["y"]
-    test_df = pd.DataFrame(X, columns=["c1", "c2", "c3"])
-    test_df["y"] = y
-    lab = Datalab(data=test_df, label_name="y", task="regression")
+        assert set(lab.list_default_issue_types()) == set(["label"])
+        assert set(lab.list_possible_issue_types()) == set(["label"])
 
-    assert set(lab.list_default_issue_types()) == set(["label"])
-    assert set(lab.list_possible_issue_types()) == set(["label"])
+        lab.find_issues(features=X)
+        lab.report()
+        summary = lab.get_issue_summary()
 
-    lab.find_issues(features=X)
-    lab.report()
-    summary = lab.get_issue_summary()
-
-    assert "label" in summary["issue_type"].values
-    assert (summary[summary["issue_type"] == "label"]["num_issues"] == 40).all()
+        assert "label" in summary["issue_type"].values
+        assert (summary[summary["issue_type"] == "label"]["num_issues"] == 40).all()
 
 
 class TestDatalabFindOutlierIssues:

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -983,9 +983,7 @@ class TestDatalabFindLabelIssues:
 
 class TestDatalabForRegression:
     @pytest.fixture
-    def regression_data(
-        self, num_examples=200, num_features=3, error_frac=0.05, error_noise=5
-    ):
+    def regression_data(self, num_examples=200, num_features=3, error_frac=0.05, error_noise=5):
         np.random.seed(SEED)
         X = np.random.random(size=(num_examples, num_features))
         coefficients = np.random.uniform(-1, 1, size=num_features)
@@ -994,7 +992,11 @@ class TestDatalabForRegression:
 
         # add extra noisy examples
         num_errors = int(num_examples * error_frac)
-        label_noise = np.clip(np.random.normal(loc=error_noise, scale=error_noise/4, size=num_errors), 2.0, 4*error_noise) * np.random.choice([-1, 1], size=num_errors)
+        label_noise = np.clip(
+            np.random.normal(loc=error_noise, scale=error_noise / 4, size=num_errors),
+            2.0,
+            4 * error_noise,
+        ) * np.random.choice([-1, 1], size=num_errors)
         random_idx = np.random.choice(num_examples, num_errors)
         y = true_y.copy()
         y[random_idx] += label_noise

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1048,12 +1048,11 @@ class TestDatalabForRegression:
         intersection = len(list(set(issue_ids).intersection(set(expected_issue_ids))))
         union = len(set(issue_ids)) + len(set(expected_issue_ids)) - intersection
         assert float(intersection) / union >= 0.6
-        
+
         # FPR
         fpr = len(list(set(issue_ids).difference(set(expected_issue_ids)))) / len(issue_ids)
         assert fpr < 0.05
-        
-        
+
     def test_regression_with_predictions(self, lab, regression_data):
         """Test that the regression issue checks find 9 label issues, based on the
         predictions of a model.
@@ -1073,20 +1072,20 @@ class TestDatalabForRegression:
         assert np.isclose(
             summary[summary["issue_type"] == "label"]["score"].values[0], 0.876453, atol=1e-5
         )
-        
+
         issues = lab.get_issues("label")
         issue_ids = issues.query("is_label_issue").index
         expected_issue_ids = regression_data["error_idx"]
-    
+
         # jaccard similarity
         intersection = len(list(set(issue_ids).intersection(set(expected_issue_ids))))
         union = len(set(issue_ids)) + len(set(expected_issue_ids)) - intersection
         assert float(intersection) / union >= 0.9
-        
+
         # FPR
         fpr = len(list(set(issue_ids).difference(set(expected_issue_ids)))) / len(issue_ids)
         assert fpr < 0.05
-        
+
         # Apply a threshold for flagging issues. A larger threshold will flag more issues,
         # but won't change the score.
         lab.find_issues(pred_probs=y_pred, issue_types={"label": {"threshold": 0.9}})
@@ -1112,13 +1111,15 @@ class TestDatalabForRegression:
         )
         issues = lab.get_issues("label")
         issue_ids = issues.query("is_label_issue").index
-        expected_issue_ids = regression_data["error_idx"]  # Set to 5% of the data, but random noise may be too small to detect
-        
+        expected_issue_ids = regression_data[
+            "error_idx"
+        ]  # Set to 5% of the data, but random noise may be too small to detect
+
         # jaccard similarity
         intersection = len(list(set(issue_ids).intersection(set(expected_issue_ids))))
         union = len(set(issue_ids)) + len(set(expected_issue_ids)) - intersection
         assert float(intersection) / union >= 0.80
-        
+
         # FPR
         fpr = len(list(set(issue_ids).difference(set(expected_issue_ids)))) / len(issue_ids)
         assert fpr < 0.05

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1084,7 +1084,7 @@ class TestDatalabForRegression:
         # but won't change the score.
         lab.find_issues(pred_probs=y_pred, issue_types={"label": {"threshold": 0.75}})
         summary = lab.get_issue_summary()
-        assert summary[summary["issue_type"] == "label"]["num_issues"].values[0] ==13
+        assert summary[summary["issue_type"] == "label"]["num_issues"].values[0] == 13
         assert np.isclose(
             summary[summary["issue_type"] == "label"]["score"].values[0], 0.813172, atol=1e-5
         )
@@ -1099,7 +1099,7 @@ class TestDatalabForRegression:
             features=X, issue_types={"label": {"clean_learning_kwargs": {"model": model}}}
         )
         summary = lab.get_issue_summary()
-        assert summary[summary["issue_type"] == "label"]["num_issues"].values[0] ==13
+        assert summary[summary["issue_type"] == "label"]["num_issues"].values[0] == 13
         assert np.isclose(
             summary[summary["issue_type"] == "label"]["score"].values[0], 0.899407, atol=1e-5
         )

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1053,7 +1053,7 @@ class TestDatalabForRegression:
         # Use ground-truth to emulate a perfect model's predictions
         y_pred = regression_data["true_y"]
 
-        lab.find_issues(predictions=y_pred)
+        lab.find_issues(pred_probs=y_pred)
         summary = lab.get_issue_summary()
         assert (summary[summary["issue_type"] == "label"]["num_issues"] == 12).all()
         assert np.isclose(
@@ -1062,7 +1062,7 @@ class TestDatalabForRegression:
 
         # Apply a threshold for flagging issues. A larger threshold will flag more issues,
         # but won't change the score.
-        lab.find_issues(predictions=y_pred, issue_types={"label": {"threshold": 0.5}})
+        lab.find_issues(pred_probs=y_pred, issue_types={"label": {"threshold": 0.5}})
         summary = lab.get_issue_summary()
         assert (summary[summary["issue_type"] == "label"]["num_issues"] == 22).all()
         assert np.isclose(

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1036,43 +1036,54 @@ class TestDatalabForRegression:
 
         assert "label" in summary["issue_type"].values
         assert (summary[summary["issue_type"] == "label"]["num_issues"] == 40).all()
-        assert np.isclose(summary[summary["issue_type"] == "label"]["score"].values[0], 0.672974, atol=1e-5)
-        
+        assert np.isclose(
+            summary[summary["issue_type"] == "label"]["score"].values[0], 0.672974, atol=1e-5
+        )
+
     def test_regression_with_predictions(self, lab, regression_data):
         """Test that the regression issue checks find 12 label issues, based on the
         predictions of a model.
-        
+
         Instead of running a model, we use the ground-truth to emulate a perfect model's predictions.
-        
+
         Testing the default behavior, we expect to find some label issues with a given mean score.
         Increasing a threshold for flagging issues will flag more issues, but won't change the score.
         """
-        
+
         # Use ground-truth to emulate a perfect model's predictions
         y_pred = regression_data["true_y"]
-        
+
         lab.find_issues(predictions=y_pred)
         summary = lab.get_issue_summary()
         assert (summary[summary["issue_type"] == "label"]["num_issues"] == 12).all()
-        assert np.isclose(summary[summary["issue_type"] == "label"]["score"].values[0], 0.58768, atol=1e-5)
-        
+        assert np.isclose(
+            summary[summary["issue_type"] == "label"]["score"].values[0], 0.58768, atol=1e-5
+        )
+
         # Apply a threshold for flagging issues. A larger threshold will flag more issues,
         # but won't change the score.
         lab.find_issues(predictions=y_pred, issue_types={"label": {"threshold": 0.5}})
         summary = lab.get_issue_summary()
         assert (summary[summary["issue_type"] == "label"]["num_issues"] == 22).all()
-        assert np.isclose(summary[summary["issue_type"] == "label"]["score"].values[0], 0.58768, atol=1e-5)
-        
+        assert np.isclose(
+            summary[summary["issue_type"] == "label"]["score"].values[0], 0.58768, atol=1e-5
+        )
+
     def test_regression_with_model_and_features(self, lab, regression_data):
         """Test that the regression issue checks find label issue with another model."""
         from sklearn.neighbors import KNeighborsRegressor
+
         model = KNeighborsRegressor(n_neighbors=5)
         X = regression_data["X"]
-        lab.find_issues(features=X, issue_types={"label": {"clean_learning_kwargs": {"model": model}}})
+        lab.find_issues(
+            features=X, issue_types={"label": {"clean_learning_kwargs": {"model": model}}}
+        )
         summary = lab.get_issue_summary()
         assert (summary[summary["issue_type"] == "label"]["num_issues"] == 30).all()
-        assert np.isclose(summary[summary["issue_type"] == "label"]["score"].values[0], 0.777305, atol=1e-5)
-        
+        assert np.isclose(
+            summary[summary["issue_type"] == "label"]["score"].values[0], 0.777305, atol=1e-5
+        )
+
 
 class TestDatalabFindOutlierIssues:
     @pytest.fixture

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1014,15 +1014,22 @@ class TestDatalabForRegression:
             "error_idx": error_idx,
         }
 
-    def test_regression(self, regression_data):
+    @pytest.fixture
+    def lab(self, regression_data):
         X, y = regression_data["X"], regression_data["y"]
         test_df = pd.DataFrame(X, columns=["c1", "c2", "c3"])
         test_df["y"] = y
         lab = Datalab(data=test_df, label_name="y", task="regression")
+        return lab
 
+    def test_available_issue_types(self, lab):
         assert set(lab.list_default_issue_types()) == set(["label"])
         assert set(lab.list_possible_issue_types()) == set(["label"])
 
+    def test_regression_with_features(self, lab, regression_data):
+        """Test that the regression issue checks finds 40 label issues, based on the
+        numerical features."""
+        X = regression_data["X"]
         lab.find_issues(features=X)
         lab.report()
         summary = lab.get_issue_summary()

--- a/tests/datalab/test_issue_finder.py
+++ b/tests/datalab/test_issue_finder.py
@@ -126,4 +126,9 @@ class TestRegressionIssueFinder:
         kwargs = {k: k for k in ["pred_probs", "features", "knn_graph"]}
         kwargs["issue_types"] = {"label": {}}
         available_issue_types = issue_finder.get_available_issue_types(**kwargs)
-        assert available_issue_types == {"label": {"features": "features"}}
+        assert available_issue_types == {
+            "label": {
+                "predictions": "pred_probs",  # Expect the ModelOutput.argument class variable to replace the key
+                "features": "features",
+            },
+        }


### PR DESCRIPTION
## Summary


Introduce the `predictions` argument to `RegressionLabelIssueManager.find_issues`.
The `pred_probs` argument will still be used on the Datalab-level. Internally, the `predictions` key will pick up the same value as the `pred_probs` key when setting up issue managers (for regression).

```python
# Example code snippet

from cleanlab import Datalab
import numpy as np
from sklearn.datasets import make_regression

# Generate some toy-examples
N = 100
X, y, W = make_regression(n_samples=N, n_features=3, noise=0.1, random_state=0, coef=True, bias=False)

# Get predictions from a regression model. Simplified for illustration.
y_pred = X @ W

# `predictions` used in find_issues
lab = Datalab(data={"y": y}, label_name='y', task="regression")
lab.find_issues(pred_probs=y_pred, issue_types= {"label": {}})

## Outputs
#Finding label issues ...
#
#Audit complete. 7 issues found in the dataset.
```

## Testing

> 🔍 Testing Done: Added specific tests for the RegressionLabelIssueManager. Write additional tests that run Datalab for regression with this new argument.


## Links to Relevant Issues or Conversations


- This is a follow-up to #796.
- This PR addresses #899.


```python
# How to set a threshold for flagging issues based on predictions
lab.find_issues(pred_probs=..., issue_types={"label":{"threshold": 1.0}}}
```

