### PR TITLE
Restrict termcolor dependency to versions below 2.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         "scikit-learn>=1.0",
         "tqdm>=4.53.0",
         "pandas>=1.1.5",
-        "termcolor>=2.0.0",
+        "termcolor>=2.0.0,<2.4.0",
     ],
     extras_require=EXTRAS_REQUIRE,
 )


### PR DESCRIPTION
## Summary

This PR is made in response to [failing tests](https://github.com/cleanlab/cleanlab/actions/runs/7086305947/job/19284309530#step:8:1426) caused by the [recent 2.4.0 release](https://github.com/termcolor/termcolor/releases/tag/2.4.0) of `termcolor`. This version constraint is only temporary.
