### PR TITLE
 Add Class Imbalance  issue type to Datalab defaults

### DIFF
--- a/cleanlab/datalab/internal/issue_manager_factory.py
+++ b/cleanlab/datalab/internal/issue_manager_factory.py
@@ -203,10 +203,5 @@ def list_default_issue_types(task: str) -> List[str]:
     if task == "regression":
         default_issue_types = ["label"]
     else:
-        default_issue_types = [
-            "label",
-            "outlier",
-            "near_duplicate",
-            "non_iid",
-        ]
+        default_issue_types = ["label", "outlier", "near_duplicate", "non_iid", "class_imbalance"]
     return default_issue_types

--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -323,6 +323,11 @@
     "\n",
     "    noisy_labels_idx = generate_noisy_labels(y_train_idx, noise_matrix)\n",
     "    noisy_labels = np.array([list(BINS_MAP.keys())[i] for i in noisy_labels_idx])\n",
+    "    # Assign few datapoints to rare class\n",
+    "    random_idx = np.random.randint(0, X_train.shape[0], 3)\n",
+    "    noisy_labels[random_idx] = \"max\"\n",
+    "    noisy_labels_idx[random_idx] = np.max(y_bin_idx) + 1\n",
+    "    \n",
     "\n",
     "    return X_train, y_train_idx, noisy_labels, noisy_labels_idx, X_out, X_duplicate"
    ]
@@ -728,6 +733,25 @@
    "outputs": [],
    "source": [
     "lab.get_issues(\"near_duplicate\").query(\"is_near_duplicate_issue\").sort_values(\"near_duplicate_score\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Class Imbalance Issues \n",
+    "\n",
+    "Let's inspect the examples that are flagged to have class imbalance issue. \n",
+    "Each example below has been assigned the *rarest class label* in the dataset. The `class_imbalance_score` is the proportion of examples belonging to the rarest class. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lab.get_issues(\"class_imbalance\").query(\"is_class_imbalance_issue\").sort_values(\"class_imbalance_score\")"
    ]
   },
   {

--- a/tests/datalab/test_cleanvision_integration.py
+++ b/tests/datalab/test_cleanvision_integration.py
@@ -32,7 +32,7 @@ class TestCleanvisionIntegration:
 
     @pytest.fixture
     def num_datalab_issues(self):
-        return 3
+        return 4
 
     @pytest.fixture
     def pred_probs(self, image_dataset):
@@ -67,6 +67,7 @@ class TestCleanvisionIntegration:
             "label",
             "outlier",
             "near_duplicate",
+            "class_imbalance"
             # "non_iid",
         ]
 
@@ -90,8 +91,9 @@ class TestCleanvisionIntegration:
                     "label",
                     "outlier",
                     "near_duplicate",
+                    "class_imbalance",
                 ],
-                "num_issues": [1, 1, 0, 1, 1, 1, 1, 0, 0, 0],
+                "num_issues": [1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0],
             }
         )
         expected_count = df.sort_values(by="issue_type")["num_issues"].tolist()
@@ -143,12 +145,7 @@ class TestCleanvisionIntegration:
         assert len(datalab.issues.columns) == num_datalab_issues * 2
         assert len(datalab.issue_summary) == num_datalab_issues
 
-        all_keys = [
-            "statistics",
-            "label",
-            "outlier",
-            "near_duplicate",
-        ]
+        all_keys = ["statistics", "label", "outlier", "near_duplicate", "class_imbalance"]
 
         assert set(all_keys) == set(datalab.info.keys())
         datalab.report()

--- a/tests/datalab/test_issue_finder.py
+++ b/tests/datalab/test_issue_finder.py
@@ -25,13 +25,13 @@ class TestIssueFinder:
         assert issue_finder.verbosity == 1
 
     def test_get_available_issue_types(self, issue_finder):
-        expected_issue_types = {}
+        expected_issue_types = {"class_imbalance": {}}
         # Test with no kwargs, no issue type expected to be returned
         for key in ["pred_probs", "features", "knn_graph"]:
             issue_types = issue_finder.get_available_issue_types(**{key: None})
             assert (
                 issue_types == expected_issue_types
-            ), "Every issue type for classification requires some kwargs, expected empty dict"
+            ), "Only class_imbalance issue type for classification requires no kwargs"
 
         # Test with only issue_types, input should be
         issue_types_dicts = [


### PR DESCRIPTION
## Summary

🎯 **Purpose**: Add the class imbalance issue type to Datalab defaults.

Example usage - 

```python
import numpy as np
from cleanlab import Datalab
features_list = [
        np.random.random((100, 3)),
        np.random.random((120, 3)) + 10,
        np.random.random((80, 3)) + 20,
    ]
features = np.vstack(features_list)
labels = np.array([0] * 100 + [1] * 120 + [2] * 80)
pred_probs = features / features.sum(axis=1, keepdims=True)

# Run Datalab
lab = Datalab(data={"features": features, "y": labels}, label_name="y")
lab.find_issues(features=features, pred_probs=pred_probs)
lab.report()

# Change Dataset to include rare class
features_list[2] = np.random.random((3, 3)) + 20
features = np.vstack(features_list)
labels = np.array([0] * 100 + [1] * 120 + [2] * 3)
pred_probs = features / features.sum(axis=1, keepdims=True)

# Run Datalab
lab = Datalab(data={"features": features, "y": labels}, label_name="y")
lab.find_issues(features=features, pred_probs=pred_probs)
lab.report()
```
Output

```
Dataset without Imbalance

------------------ class_imbalance issues ------------------

About this issue:
        Examples belonging to the most under-represented class in the dataset.

Number of examples with this issue: 0
Overall dataset quality in terms of this issue: 0.2667

Examples representing most severe instances of this issue:
     is_class_imbalance_issue  class_imbalance_score
0                       False                    1.0
203                     False                    1.0
202                     False                    1.0
201                     False                    1.0
200                     False                    1.0

Dataset with Imbalance

------------------ class_imbalance issues ------------------

About this issue:
        Examples belonging to the most under-represented class in the dataset.

Number of examples with this issue: 3
Overall dataset quality in terms of this issue: 0.0135

Examples representing most severe instances of this issue:
     is_class_imbalance_issue  class_imbalance_score
222                      True               0.013453
221                      True               0.013453
220                      True               0.013453
141                     False               1.000000
142                     False               1.000000
```


## Impact

🌐 Areas Affected: Datalab.find_issues. 

👥 Who’s Affected: Users running`find_issues` without specifying any issue types will now get class imbalance diagnosis for their datasets. 


## Testing

🔍 Testing Done: [Gist](https://gist.github.com/tataganesh/7d3e947e12afb2219701daf60d370f26) showing few imbalance cases. 



## Links to Relevant Issues or Conversations

Resolves #836 


## Reviewer Notes

As per discussion with @elisno,  this [conditional lambda](https://github.com/tataganesh/cleanlab/blob/005c2ddf45ccdfe0da418080b5a5eec540a30ddf/cleanlab/datalab/internal/issue_finder.py#L75) has been added to consider issue types with no required args. 

