### PR TITLE
Add Non-IID section for datalab text tutorial

### DIFF
--- a/docs/source/tutorials/datalab/text.ipynb
+++ b/docs/source/tutorials/datalab/text.ipynb
@@ -539,6 +539,31 @@
     "if not all(x in identified_duplicate_issues.index for x in duplicate_issue_indices):\n",
     "    raise Exception(\"Some highlighted examples are missing from identified_duplicate_issues.\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Non-IID issues (data drift)\n",
+    "According to the report, our dataset contains non-iid issues. Below, we display the overall non-iid score for the dataset, which is the `p-value` of a statistical test for whether adjacent samples in the original ordering of the dataset have similar feature values. A low `p-value` provides strong evidence that the dataset is not IID. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p_value = lab.get_info('non_iid')['p-value']\n",
+    "p_value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, our dataset was flagged as non-IID because the rows were sorted by class label in the original data, which may be benign if we remember to shuffle them before model training and data splitting. However, if you don't know why your data was flagged as non-IID, this indicates worrisome data drift. You should think carefully about what future test data may look like (and whether your data is representative of the population you care about). Do not shuffle the data before the non-IID test runs."
+   ]
   }
  ],
  "metadata": {

--- a/docs/source/tutorials/datalab/text.ipynb
+++ b/docs/source/tutorials/datalab/text.ipynb
@@ -545,7 +545,7 @@
    "metadata": {},
    "source": [
     "### Non-IID issues (data drift)\n",
-    "According to the report, our dataset contains non-iid issues. Below, we display the overall non-iid score for the dataset, which is the `p-value` of a statistical test for whether adjacent samples in the original ordering of the dataset have similar feature values. A low `p-value` provides strong evidence that the dataset is not IID. "
+    "According to the report, our dataset does not appear to be Independent and Identically Distributed (IID).  The overall non-iid score for the dataset (displayed below) corresponds to the `p-value` of a statistical test for whether the ordering of samples in the dataset appears related to the similarity between their feature values.  A low `p-value` strongly suggests that the dataset violates the IID assumption, which is a key assumption required for conclusions (models) produced from the dataset to generalize to a larger population."
    ]
   },
   {

--- a/docs/source/tutorials/datalab/text.ipynb
+++ b/docs/source/tutorials/datalab/text.ipynb
@@ -562,7 +562,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, our dataset was flagged as non-IID because the rows were sorted by class label in the original data, which may be benign if we remember to shuffle them before model training and data splitting. However, if you don't know why your data was flagged as non-IID, this indicates worrisome data drift. You should think carefully about what future test data may look like (and whether your data is representative of the population you care about). Do not shuffle the data before the non-IID test runs."
+    "Here, our dataset was flagged as non-IID because the rows happened to be sorted by class label in the original data. This may be benign if we remember to shuffle rows before model training and data splitting. But if you don't know why your data was flagged as non-IID, then you should be worried about potential data drift or unexpected interactions between data points (their values may not be statistically independent). Think carefully about what future test data may look like (and whether your data is representative of the population you care about). You should not shuffle your data before the non-IID test runs (will invalidate its conclusions)."
    ]
   }
  ],


### PR DESCRIPTION
## Summary

 🎯 **Purpose**:  The non-iid issue is reported in datalab's text tutorial. The PR adds a section to discuss this issue and elaborate on potential reasons for datasets being non-IID. 

## Impact

🌐 Areas Affected: Datalab [text tutorial](https://docs.cleanlab.ai/master/tutorials/datalab/text.html).
 👥 Who’s Affected: Users referring to the Datalab text tutorial. 

**Screenshots**

![image](https://github.com/cleanlab/cleanlab/assets/23188723/6477d426-08b5-485a-bff2-3b426b5c1dbf)


## Testing

🔍 Testing Done:  Check screenshot. 

## Links to Relevant Issues or Conversations

#884 

