### PR TITLE
Null Issue Manager: Vectorize loops, Fix row index bug

### DIFF
--- a/tests/datalab/issue_manager/test_null.py
+++ b/tests/datalab/issue_manager/test_null.py
@@ -20,7 +20,7 @@ class TestNullIssueManager:
     def embeddings_with_null(self):
         np.random.seed(SEED)
         embeddings_array = np.random.random((4, 3))
-        embeddings_array[0][0] = np.NaN
+        embeddings_array[[0, 3], 0] = np.NaN
         embeddings_array[1] = np.NaN
         return embeddings_array
 
@@ -65,7 +65,7 @@ class TestNullIssueManager:
             issues_sort["is_null_issue"] == expected_sorted_issue_mask
         ), "Issue mask should be correct"
         assert summary_sort["issue_type"][0] == "null"
-        assert summary_sort["score"][0] == pytest.approx(expected=8 / 12, abs=1e-7)
+        assert summary_sort["score"][0] == pytest.approx(expected=7 / 12, abs=1e-7)
         assert (
             info_sort.get("average_null_score", None) is not None
         ), "Should have average null score"
@@ -133,11 +133,11 @@ class TestNullIssueManager:
         """Test some values in the info dict."""
         issue_manager.find_issues(features=embeddings_with_null)
         info = issue_manager.info
-        assert info["average_null_score"] == pytest.approx(expected=8 / 12, abs=1e-7)
+        assert info["average_null_score"] == pytest.approx(expected=7 / 12, abs=1e-7)
         assert info["most_common_issue"]["pattern"] == "100"
-        assert info["most_common_issue"]["count"] == 1
-        assert info["most_common_issue"]["rows_affected"] == [0]
-        assert info["column_impact"] == [0.5, 0.25, 0.25]
+        assert info["most_common_issue"]["count"] == 2
+        assert info["most_common_issue"]["rows_affected"] == [0, 3]
+        assert info["column_impact"] == [0.75, 0.25, 0.25]
 
     # Strategy for generating NaN values
     nan_strategy = just(np.nan)


### PR DESCRIPTION
## Summary

🎯 **Purpose**: This PR replaces expensive for-loops in the Null Issue Manager implementation with their vectorized equivalents. A bug related to row indices is also fixed and tests are improved to check these indices. 

**Row Indices bug**:
In the `_most_common_issue` function, the row ids with the most frequent pattern is determined. The [computation](https://github.com/cleanlab/cleanlab/blob/f3a65b8c18643e3fb9626988d606f839f8daea9b/cleanlab/datalab/internal/issue_manager/null.py#L108-L110) of these row ids is based on a list representing only null rows as a string. It is not with respect to the original feature matrix.  
The test for the `rows_affected` key was passing even with this bug, so it was updated. 

## Impact

🌐 Areas Affected: Null Issue Manager
 👥 Who’s Affected: NA


## Testing

🔍 Testing Done: Benchmarking was performed with the old and new versions of two functions. Here is the [notebook](https://gist.github.com/tataganesh/3fbf206bc809f519ed839146e68a36ea) to reproduce these benchmarks. 

Function `_calculate_null_issues`

![vectorized_func1](https://github.com/cleanlab/cleanlab/assets/23188723/45a88f16-4899-4eb7-8140-bc1db5168afe)

Function `_most_common_issue`

![vectorized_func2](https://github.com/cleanlab/cleanlab/assets/23188723/aa49b7dc-e8b2-4135-98e8-f4b4c6542e21)



## Links to Relevant Issues or Conversations

Part of #903 

