### PR TITLE
Refactor batching logic in cleanlab.segmentation.filter.find_label_issues

### DIFF
--- a/cleanlab/internal/segmentation_utils.py
+++ b/cleanlab/internal/segmentation_utils.py
@@ -29,6 +29,9 @@ def _get_valid_optional_params(
     """Takes in optional args and returns good values for them if they are None."""
     if batch_size is None:
         batch_size = 10000
+
+    if batch_size <= 0:
+        raise ValueError(f"Batch size must be greater than 0, got {batch_size}")
     return batch_size, n_jobs
 
 

--- a/cleanlab/segmentation/filter.py
+++ b/cleanlab/segmentation/filter.py
@@ -153,7 +153,7 @@ def find_label_issues(
 
     # Precompute the size of each image in the batch
     image_size = np.prod(pre_pred_probs.shape[1:])
-    images_per_batch = max(batch_size // image_size + 1, 0)
+    images_per_batch = max(batch_size // image_size, 1)
 
     for start_index in range(0, n, images_per_batch):
         end_index = min(start_index + images_per_batch, n)

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -203,30 +203,53 @@ def test_get_label_quality_scores():
     )
     assert np.argmax(error) == np.argmin(image_scores_softmin)
 
-    with pytest.raises(Exception) as e:
-        get_label_quality_scores(labels, pred_probs, method="num_pixel_issues", downsample=4)
-
     image_scores_npi, pixel_scores = get_label_quality_scores(
         labels, pred_probs, method="num_pixel_issues", downsample=1
     )
-
     assert np.argmax(error) == np.argmin(image_scores_npi)
-
-    with pytest.raises(Exception):
-        get_label_quality_scores(labels, pred_probs, method="invalid_method")
 
     image_scores_softmin, pixel_scores = get_label_quality_scores(
         labels, pred_probs, downsample=1, method="softmin"
     )
-
     assert len(image_scores_softmin) == labels.shape[0]
     assert pixel_scores.shape == labels.shape
 
-    # with pytest.raises(ValueError):
-    #     get_label_quality_scores(labels, pred_probs, method="num_pixel_issues", batch_size=-1)
-    #     get_label_quality_scores(
-    #         labels, pred_probs, method="num_pixel_issues", downsample=1, batch_size=0
-    #     )
+
+@pytest.mark.parametrize(
+    "method, downsample, batch_size, expected_exception, expected_message",
+    [
+        (
+            "num_pixel_issues",
+            4,
+            None,
+            Exception,
+            "Height 10 and width 10 not divisible by downsample value of 4. Set kwarg downsample to 1 to avoid downsampling.",
+        ),
+        (
+            "invalid_method",
+            None,
+            None,
+            Exception,
+            "Invalid Method: Specify correct method. Currently only supports 'softmin'",
+        ),
+        ("num_pixel_issues", 1, -1, ValueError, "Batch size must be greater than 0, got -1"),
+        ("num_pixel_issues", 1, 0, ValueError, "Batch size must be greater than 0, got 0"),
+    ],
+    ids=["downsample", "method", "batch_size_negative", "batch_size_zero"],
+)
+def test_get_label_quality_scores_exceptions(
+    method, downsample, batch_size, expected_exception, expected_message
+):
+    args = {"labels": labels, "pred_probs": pred_probs, "method": method}
+    if downsample is not None:
+        args["downsample"] = downsample
+    if batch_size is not None:
+        args["batch_size"] = batch_size
+
+    with pytest.raises(expected_exception) as exc_info:
+        get_label_quality_scores(**args)
+
+    assert expected_message in str(exc_info.value)
 
 
 # different size inpits


### PR DESCRIPTION
## Summary

This update refactors a portion of the `find_label_issues` function geared towards segmentation tasks.

## Impact

### 🌐 Areas Affected

- Primarily affects the `cleanlab.segmentation.filter.find_label_issues()` function.
- Alters some tests related to PR #885.

### 👥 Who’s Affected

- Users utilizing features supporting segmentation tasks.

## Testing

### 🔍 Testing Conducted

- Changes primarily affect `test_get_label_quality_scores` in `tests/test_segmentation.py`, as per PR #885.
- Previously, tests designed to trigger expected exceptions were failing and have been temporarily disabled.
- To address this, the test function has been divided into:
  1. Evaluations of function outputs.
  2. Assessments of triggered exceptions, now including specific error message verifications.

### 🔗 Test Case Link

[Link to test case](https://github.com/elisno/cleanlab/blob/01deb3e09dc5d9d305a1715789fa9437e6c101c4/tests/test_segmentation.py#L199-L252)

### Unaddressed Cases

- Two tests for exceptions, discussed in [this thread](https://github.com/cleanlab/cleanlab/pull/885#discussion_r1393152485), were failing without clear insights into the tested exceptions.
  - In this PR, analogous tests are found here: [parametrized tests link](https://github.com/elisno/cleanlab/blob/01deb3e09dc5d9d305a1715789fa9437e6c101c4/tests/test_segmentation.py#L235-L236)

## Relevant Discussions

### 🔗 Related Git or Slack Items

- Review comment related to this PR can be found [here](https://github.com/cleanlab/cleanlab/pull/885#pullrequestreview-1782370266).
