### PR TITLE
Patch: epsilon for near duplicate

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/duplicate.py
+++ b/cleanlab/datalab/internal/issue_manager/duplicate.py
@@ -128,7 +128,7 @@ class NearDuplicateIssueManager(IssueManager):
         N = knn_graph.shape[0]
         distances = knn_graph.data.reshape(N, -1)
         # Create a mask for the threshold
-        median = max(np.median(distances[:, 0]), np.finfo(np.float_).eps) # avoid threshold = 0
+        median = max(np.median(distances[:, 0]), np.finfo(np.float_).eps)  # avoid threshold = 0
         mask = distances < threshold * median
 
         # Update the indptr to reflect the new number of neighbors

--- a/cleanlab/datalab/internal/issue_manager/duplicate.py
+++ b/cleanlab/datalab/internal/issue_manager/duplicate.py
@@ -128,7 +128,8 @@ class NearDuplicateIssueManager(IssueManager):
         N = knn_graph.shape[0]
         distances = knn_graph.data.reshape(N, -1)
         # Create a mask for the threshold
-        mask = distances < threshold * np.median(distances[:, 0])
+        median = max(np.median(distances[:, 0]), np.finfo(np.float_).eps) # avoid threshold = 0
+        mask = distances < threshold * median
 
         # Update the indptr to reflect the new number of neighbors
         indptr = np.zeros(knn_graph.indptr.shape, dtype=knn_graph.indptr.dtype)

--- a/tests/datalab/issue_manager/conftest.py
+++ b/tests/datalab/issue_manager/conftest.py
@@ -4,7 +4,7 @@ from scipy.sparse import csr_matrix
 
 
 @st.composite
-def knn_graph_strategy(draw, num_samples, k_neighbors):
+def knn_graph_strategy(draw, num_samples, k_neighbors, min_distance=0.0, max_distance=100.0):
     """
     Generate a K-nearest neighbors (KNN) graph based on the given parameters.
 
@@ -47,7 +47,13 @@ def knn_graph_strategy(draw, num_samples, k_neighbors):
     upper_triangle = [
         draw(
             st.lists(
-                st.floats(min_value=0, max_value=100, allow_nan=False, allow_infinity=False),
+                st.floats(
+                    min_value=min_distance,
+                    max_value=max_distance,
+                    allow_nan=False,
+                    allow_infinity=False,
+                    allow_subnormal=False,
+                ),
                 min_size=i,
                 max_size=i,
                 unique=True,

--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -151,9 +151,17 @@ def build_issue_manager(
     A threshold can be provided to control the number of issues for small graphs.
     A with_issues flag can be provided to control whether the issue manager should have issues.
     """
-    knn_graph = draw(
-        knn_graph_strategy(num_samples=num_samples_strategy, k_neighbors=k_neighbors_strategy)
-    )
+
+    if with_issues:
+        knn_graph = draw(
+            knn_graph_strategy(num_samples=num_samples_strategy, k_neighbors=k_neighbors_strategy)
+        )
+    else:
+        knn_graph = draw(
+            knn_graph_strategy(
+                num_samples=num_samples_strategy, k_neighbors=k_neighbors_strategy, min_distance=0.1
+            )
+        )
 
     lab = Datalab(data={})
     inputs = {"datalab": lab, "threshold": threshold}
@@ -177,6 +185,7 @@ def no_issue_issue_manager_strategy(draw):
         st.integers(min_value=10, max_value=50),
         st.integers(min_value=2, max_value=5),
         with_issues=False,
+        threshold=0.0001,
     )
 
 

--- a/tests/datalab/issue_manager/test_null.py
+++ b/tests/datalab/issue_manager/test_null.py
@@ -154,7 +154,8 @@ class TestNullIssueManager:
     )
 
     @settings(
-        suppress_health_check=[HealthCheck.function_scoped_fixture]
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+        deadline=None,
     )  # No need to reset state of issue_manager fixture
     @given(embeddings=features_with_nan_strategy)
     def test_quality_scores_and_full_null_row_identification(self, issue_manager, embeddings):


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Update near duplicate check to ensure threshold is non-zero. This allows for datasets with majority of examples containing near duplicate to be more correctly marked as duplicates. Previously, no example in such dataset was correctly marked as near duplicate. With a non-zero threshold, any dataset has a chance of containing a near duplicate now based on the near-duplicate score.

## Impact

> 👥 Who’s Affected: Any near duplicate benchmark test with datasets containing significant amount of near duplicates will now see more examples correctly marked as near duplicates.

