### PR TITLE
remove class imbalance section from the quickstart

### DIFF
--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -739,26 +739,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Class Imbalance Issues \n",
-    "\n",
-    "Let's inspect the examples that are flagged to have class imbalance issue. \n",
-    "Each example below has been assigned the *rarest class label* in the dataset. The `class_imbalance_score` is the proportion of examples belonging to the rarest class. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lab.get_issues(\"class_imbalance\").query(\"is_class_imbalance_issue\").sort_values(\"class_imbalance_score\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`Datalab` makes it very easy to check your datasets for all sorts of issues that are important to deal with for training robust models. The inputs it uses to detect issues can come from *any* model you have trained (the better your model, the more accurate the issue detection will be).\n",
+    "Other issues detected in this tutorial dataset include **outliers** and **class imbalance**, see the [Issue Type Descriptions](../../cleanlab/datalab/guide/issue_type_description.html) for more information. `Datalab` makes it very easy to check your datasets for all sorts of issues that are important to deal with for training robust models. The inputs it uses to detect issues can come from *any* model you have trained (the better your model, the more accurate the issue detection will be).\n",
     "\n",
     "To learn more, check out this [example notebook](https://github.com/cleanlab/examples/blob/master/datalab_image_classification/datalab.ipynb) (demonstrates Datalab applied to a real dataset) and the [advanced Datalab tutorial](datalab_advanced.html) (demonstrates configuration and customization options to exert greater control)."
    ]


### PR DESCRIPTION
The quickstart tutorial is not for showcasing every type of issue. Let's do that in a different notebook mentioned here:

https://github.com/cleanlab/cleanlab/issues/920 