### PR TITLE
make data valuation issue manager  user facing

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/data_valuation.py
+++ b/cleanlab/datalab/internal/issue_manager/data_valuation.py
@@ -37,7 +37,22 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class DataValuationIssueManager(IssueManager):
-    """Manages data sample with low valuation."""
+    """
+    Manages data sample with low valuation.
+
+    Examples
+    --------
+    >>> from cleanlab import Datalab
+    >>> import numpy as np
+    >>> X = np.random.normal(size=(50, 2))
+    >>> y = np.random.randint(2, size=50)
+    >>> pred_probs = X / X.sum(axis=1, keepdims=True)
+    >>> data = {"X": X, "y": y}
+    >>> lab = Datalab(data, label_name="y")
+    >>> lab.find_issues()
+    >>> issue_types={"data_valuation": {"k": 10, "threshold": 1e-6}}
+    >>> lab.find_issues(issue_types=issue_types)
+    """
 
     description: ClassVar[
         str

--- a/cleanlab/datalab/internal/issue_manager/data_valuation.py
+++ b/cleanlab/datalab/internal/issue_manager/data_valuation.py
@@ -81,7 +81,7 @@ class DataValuationIssueManager(IssueManager):
         assert knn_graph is not None, "knn_graph must be already calculated by other issue managers"
         assert labels is not None, "labels must be provided"
 
-        scores = _knn_shapley_score(knn_graph, labels)
+        scores = _knn_shapley_score(knn_graph, labels, self.k)
 
         self.issues = pd.DataFrame(
             {
@@ -125,12 +125,15 @@ class DataValuationIssueManager(IssueManager):
         return info_dict
 
 
-def _knn_shapley_score(knn_graph: csr_matrix, labels: np.ndarray) -> np.ndarray:
+def _knn_shapley_score(knn_graph: csr_matrix, labels: np.ndarray, k: int) -> np.ndarray:
     """Compute the Shapley values of data points based on a knn graph."""
     N = labels.shape[0]
     scores = np.zeros((N, N))
     dist = knn_graph.indices.reshape(N, -1)
-    k = dist.shape[1]
+    knn_graph_k = dist.shape[1]
+    if k > knn_graph_k:
+        k = knn_graph_k
+        Warning(f"k is larger than the number of neighbors in the knn graph. Using k={k} instead.")
 
     for i, y in enumerate(labels):
         idx = dist[i][::-1]

--- a/docs/source/cleanlab/datalab/guide/issue_type_description.rst
+++ b/docs/source/cleanlab/datalab/guide/issue_type_description.rst
@@ -141,6 +141,14 @@ To find the underperforming group, Cleanlab clusters the data using the provided
 The underperforming group quality score is equal to `q/r` for examples belonging to the underperforming group, and is equal to 1 for all other examples.
 Advanced users:  If you have pre-computed cluster assignments for each example in the dataset, you can pass them explicitly to :py:meth:`Datalab.find_issues <cleanlab.datalab.datalab.Datalab.find_issues>` using the `cluster_ids` key in the `issue_types` dict argument.  This is useful for tabular datasets where you want to group/slice the data based on a categorical column. An integer encoding of the categorical column can be passed as cluster assignments for finding the underperforming group, based on the data slices you define.
 
+Data Valuation Issue
+--------------------
+
+An Example that contribute minimally to a model's training have low data valuation scores.
+
+Data valuation issues can only use a `knn_graph`` passed by user or pre-computed from other issue managers. If you do not provide this argument, or there isn't a `knn_graph` already computed and store in the Datalab object, this type of issue will not be considered.
+
+The data valuation score is a approximate form of shapley value, which is calculated by the label of top k nearest neighbors of an example. The detail of the knn-shapley value could be found in the paper: `Efficient Task-Specific Data Valuation for Nearest Neighbor Algorithms <https://arxiv.org/abs/1908.08619>`_ and `Scalability vs. Utility: Do We Have to Sacrifice One for the Other in Data Importance Quantification? <https://arxiv.org/abs/1911.07128>`_.
 
 Optional Issue Parameters
 =========================
@@ -283,3 +291,16 @@ Underperforming Group Issue Parameters
     For more information, view the source code of:  :py:class:`datalab.internal.issue_manager.underperforming_group.UnderperformingGroupIssueManager <cleanlab.datalab.internal.issue_manager.underperforming_group.UnderperformingGroupIssueManager>`.
 
     For more information on generating `cluster_ids` for this issue manager, refer to this `FAQ Section <../../../tutorials/faq.html#How-do-I-specify-pre-computed-data-slices/clusters-when-detecting-the-Underperforming-Group-Issue?>`_.
+
+Data Valuation Issue Parameters
+--------------------------
+
+.. code-block:: python
+
+    data_valuation_kwargs = {
+        "k": # Number of nearest neighbors to calculate the data valuation score,
+        "thresholds": # Thresholds for determing if an example has a data valuation issue,
+    }
+
+.. note::
+    For more information, view the source code of:  :py:class:`datalab.internal.issue_manager.data_valuation.DataValuationIssueManager <cleanlab.datalab.internal.issue_manager.data_valuation.DataValuationIssueManager>`.

--- a/docs/source/cleanlab/datalab/internal/issue_manager/data_valuation.rst
+++ b/docs/source/cleanlab/datalab/internal/issue_manager/data_valuation.rst
@@ -1,0 +1,9 @@
+data_valuation
+=======
+
+
+.. automodule:: cleanlab.datalab.internal.issue_manager.data_valuation
+    :autosummary:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/cleanlab/datalab/internal/issue_manager/index.rst
+++ b/docs/source/cleanlab/datalab/internal/issue_manager/index.rst
@@ -26,6 +26,7 @@ These are the issue managers that Datalab has not registered (yet).
 
 .. toctree::
     null
+    data_valuation
 
 ML task-specific issue managers
 ---------------------------------


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Make the data valuation issue manager user facing.

## Impact

> 🌐 Areas Affected: [issue_type_descriptions.rst](https://github.com/cleanlab/cleanlab/blob/master/docs/source/cleanlab/datalab/guide/issue_type_description.rst).

## Links to Relevant Issues or Conversations

#886 

