### PR TITLE
Make Null issue manager user-facing 

### DIFF
--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -56,10 +56,9 @@ _CLASSIFICATION_ARGS_DICT = {
     "underperforming_group": ["pred_probs", "features", "knn_graph", "cluster_ids"],
     "data_valuation": ["knn_graph"],
     "class_imbalance": [],
+    "null": ["features"],
 }
-_REGRESSION_ARGS_DICT = {
-    "label": ["features", "predictions"],
-}
+_REGRESSION_ARGS_DICT = {"label": ["features", "predictions"], "null": ["features"]}
 
 
 def _resolve_required_args_for_classification(**kwargs):

--- a/cleanlab/datalab/internal/issue_manager/__init__.py
+++ b/cleanlab/datalab/internal/issue_manager/__init__.py
@@ -6,3 +6,4 @@ from .noniid import NonIIDIssueManager
 from .imbalance import ClassImbalanceIssueManager
 from .underperforming_group import UnderperformingGroupIssueManager
 from .data_valuation import DataValuationIssueManager
+from .null import NullIssueManager

--- a/cleanlab/datalab/internal/issue_manager_factory.py
+++ b/cleanlab/datalab/internal/issue_manager_factory.py
@@ -51,6 +51,7 @@ from cleanlab.datalab.internal.issue_manager import (
     UnderperformingGroupIssueManager,
     DataValuationIssueManager,
     OutlierIssueManager,
+    NullIssueManager,
 )
 from cleanlab.datalab.internal.issue_manager.regression import RegressionLabelIssueManager
 
@@ -63,10 +64,9 @@ REGISTRY: Dict[str, Dict[str, Type[IssueManager]]] = {
         "class_imbalance": ClassImbalanceIssueManager,
         "underperforming_group": UnderperformingGroupIssueManager,
         "data_valuation": DataValuationIssueManager,
+        "null": NullIssueManager,
     },
-    "regression": {
-        "label": RegressionLabelIssueManager,
-    },
+    "regression": {"label": RegressionLabelIssueManager, "null": NullIssueManager},
 }
 """Registry of issue managers that can be constructed from a string
 and used in the Datalab class.
@@ -201,7 +201,14 @@ def list_default_issue_types(task: str) -> List[str]:
     :py:class:`REGISTRY <cleanlab.datalab.internal.issue_manager_factory.REGISTRY>` : All available issue types and their corresponding issue managers can be found here.
     """
     if task == "regression":
-        default_issue_types = ["label"]
+        default_issue_types = ["label", "null"]
     else:
-        default_issue_types = ["label", "outlier", "near_duplicate", "non_iid", "class_imbalance"]
+        default_issue_types = [
+            "label",
+            "outlier",
+            "near_duplicate",
+            "non_iid",
+            "class_imbalance",
+            "null",
+        ]
     return default_issue_types

--- a/docs/source/cleanlab/datalab/guide/issue_type_description.rst
+++ b/docs/source/cleanlab/datalab/guide/issue_type_description.rst
@@ -141,6 +141,16 @@ To find the underperforming group, Cleanlab clusters the data using the provided
 The underperforming group quality score is equal to `q/r` for examples belonging to the underperforming group, and is equal to 1 for all other examples.
 Advanced users:  If you have pre-computed cluster assignments for each example in the dataset, you can pass them explicitly to :py:meth:`Datalab.find_issues <cleanlab.datalab.datalab.Datalab.find_issues>` using the `cluster_ids` key in the `issue_types` dict argument.  This is useful for tabular datasets where you want to group/slice the data based on a categorical column. An integer encoding of the categorical column can be passed as cluster assignments for finding the underperforming group, based on the data slices you define.
 
+Null Issue
+-----------
+
+Examples flagged with null issue have null/missing values across all feature columns.
+
+The null issue quality score for each example is the proportion of features values that are not null. The overall null issue quality score
+is the mean of the individual quality scores.
+
+Presence of null examples in the dataset can lead to errors when training ML models. It can also
+result in the model learning incorrect patterns due to the null values.
 
 Optional Issue Parameters
 =========================
@@ -154,7 +164,8 @@ Appropriate defaults are used for any parameters you do not specify, so no need 
     possible_issue_types = {
         "label": label_kwargs, "outlier": outlier_kwargs,
         "near_duplicate": near_duplicate_kwargs, "non_iid": non_iid_kwargs,
-        "class_imbalance": class_imbalance_kwargs, "underperforming_group": underperforming_group_kwargs
+        "class_imbalance": class_imbalance_kwargs, "underperforming_group": underperforming_group_kwargs,
+        "null": null_kwargs
     }
 
 
@@ -283,3 +294,15 @@ Underperforming Group Issue Parameters
     For more information, view the source code of:  :py:class:`datalab.internal.issue_manager.underperforming_group.UnderperformingGroupIssueManager <cleanlab.datalab.internal.issue_manager.underperforming_group.UnderperformingGroupIssueManager>`.
 
     For more information on generating `cluster_ids` for this issue manager, refer to this `FAQ Section <../../../tutorials/faq.html#How-do-I-specify-pre-computed-data-slices/clusters-when-detecting-the-Underperforming-Group-Issue?>`_.
+
+Null Issue Parameters
+--------------------------
+
+.. code-block:: python
+
+    null_kwargs = {
+    }
+
+.. note::
+
+    For more information, view the source code of:  :py:class:`datalab.internal.issue_manager.null.NullIssueManager <cleanlab.datalab.internal.issue_manager.null.NullIssueManager>`.

--- a/tests/datalab/test_cleanvision_integration.py
+++ b/tests/datalab/test_cleanvision_integration.py
@@ -32,7 +32,7 @@ class TestCleanvisionIntegration:
 
     @pytest.fixture
     def num_datalab_issues(self):
-        return 4
+        return 5
 
     @pytest.fixture
     def pred_probs(self, image_dataset):
@@ -67,7 +67,8 @@ class TestCleanvisionIntegration:
             "label",
             "outlier",
             "near_duplicate",
-            "class_imbalance"
+            "class_imbalance",
+            "null"
             # "non_iid",
         ]
 
@@ -92,8 +93,9 @@ class TestCleanvisionIntegration:
                     "outlier",
                     "near_duplicate",
                     "class_imbalance",
+                    "null",
                 ],
-                "num_issues": [1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0],
+                "num_issues": [1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0],
             }
         )
         expected_count = df.sort_values(by="issue_type")["num_issues"].tolist()
@@ -145,7 +147,7 @@ class TestCleanvisionIntegration:
         assert len(datalab.issues.columns) == num_datalab_issues * 2
         assert len(datalab.issue_summary) == num_datalab_issues
 
-        all_keys = ["statistics", "label", "outlier", "near_duplicate", "class_imbalance"]
+        all_keys = ["statistics", "label", "outlier", "near_duplicate", "class_imbalance", "null"]
 
         assert set(all_keys) == set(datalab.info.keys())
         datalab.report()


### PR DESCRIPTION
## Summary

🎯 **Purpose**: Make the null issue manager user-facing. Changes in the PR include

- Adding Null Issue type to datalab defaults for both classification and regression tasks.
- End-to-end datalab test for null issue type
- Brief description. 

 📜 **Example Usage**:



```python
TODO
```

## Impact

🌐 Areas Affected: Enumerate modules, functions, or documentation impacted by your code.

👥 Who’s Affected: All Datalab users. 

**Screenshots**
TODO


## Testing

🔍 Testing Done: Todo

## Links to Relevant Issues or Conversations

Resolves #903



## Reviewer Notes

Check if including null issue type for regression tasks is okay.

