### PR TITLE
Add imbalance class label to Issues Dataframe

### DIFF
--- a/cleanlab/datalab/internal/data.py
+++ b/cleanlab/datalab/internal/data.py
@@ -246,7 +246,7 @@ class Label:
         self._data = data
         self.label_name = label_name
         self.labels = labels_to_array([])
-        self.label_map: Mapping[str, Any] = {}
+        self.label_map: Mapping[Union[str, int], Any] = {}
         if label_name is not None:
             self.labels, self.label_map = _extract_labels(data, label_name, map_to_int)
             self._validate_labels()

--- a/cleanlab/datalab/internal/data_issues.py
+++ b/cleanlab/datalab/internal/data_issues.py
@@ -234,6 +234,11 @@ class DataIssues:
                 if info.get(k) is not None
             }
             specific_issues = specific_issues.assign(**column_dict)
+
+        if issue_name == "class_imbalance":
+            specific_issues = specific_issues.assign(
+                class_imbalance_class_name=info["Rarest Class"]
+            )
         return specific_issues
 
     def get_issue_summary(self, issue_name: Optional[str] = None) -> pd.DataFrame:

--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -44,7 +44,7 @@ class ClassImbalanceIssueManager(IssueManager):
 
     issue_name: ClassVar[str] = "class_imbalance"
     verbosity_levels = {
-        0: [],
+        0: ["imbalance_class"],
         1: [],
         2: [],
     }
@@ -65,17 +65,19 @@ class ClassImbalanceIssueManager(IssueManager):
         rarest_class = rarest_class_idx if imbalance_exists else -1
         is_issue_column = labels == rarest_class
         scores = np.where(is_issue_column, class_probs[rarest_class], 1)
+        rarest_class_name = self.datalab._label_map.get(rarest_class, "NA")
 
         self.issues = pd.DataFrame(
             {
                 f"is_{self.issue_name}_issue": is_issue_column,
                 self.issue_score_key: scores,
+                f"{self.issue_name}_label": [rarest_class_name] * len(scores),
             },
         )
         self.summary = self.make_summary(score=class_probs[rarest_class_idx])
-        self.info = self.collect_info()
+        self.info = self.collect_info(class_name=rarest_class_name)
 
-    def collect_info(self) -> dict:
-        params_dict = {"threshold": self.threshold}
+    def collect_info(self, class_name: str) -> dict:
+        params_dict = {"threshold": self.threshold, "imbalance_class": class_name}
         info_dict = {**params_dict}
         return info_dict

--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -71,7 +71,6 @@ class ClassImbalanceIssueManager(IssueManager):
             {
                 f"is_{self.issue_name}_issue": is_issue_column,
                 self.issue_score_key: scores,
-                f"{self.issue_name}_class_name": [rarest_class_name] * len(scores),
             },
         )
         self.summary = self.make_summary(score=class_probs[rarest_class_idx])

--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -44,7 +44,7 @@ class ClassImbalanceIssueManager(IssueManager):
 
     issue_name: ClassVar[str] = "class_imbalance"
     verbosity_levels = {
-        0: ["imbalance_class"],
+        0: ["Rarest Class"],
         1: [],
         2: [],
     }
@@ -78,6 +78,6 @@ class ClassImbalanceIssueManager(IssueManager):
         self.info = self.collect_info(class_name=rarest_class_name)
 
     def collect_info(self, class_name: str) -> dict:
-        params_dict = {"threshold": self.threshold, "imbalance_class": class_name}
+        params_dict = {"threshold": self.threshold, "Rarest Class": class_name}
         info_dict = {**params_dict}
         return info_dict

--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -71,7 +71,7 @@ class ClassImbalanceIssueManager(IssueManager):
             {
                 f"is_{self.issue_name}_issue": is_issue_column,
                 self.issue_score_key: scores,
-                f"{self.issue_name}_label": [rarest_class_name] * len(scores),
+                f"{self.issue_name}_class_name": [rarest_class_name] * len(scores),
             },
         )
         self.summary = self.make_summary(score=class_probs[rarest_class_idx])

--- a/tests/datalab/issue_manager/test_imbalance.py
+++ b/tests/datalab/issue_manager/test_imbalance.py
@@ -88,3 +88,16 @@ class TestClassImbalanceIssueManager:
             "------------------ class_imbalance issues ------------------\n\n"
             "Number of examples with this issue:"
         ) in report
+        assert ("Additional Information: \n" "Rarest Class:") in report
+
+    def test_collect_info(self, labels, create_issue_manager):
+        # With Imbalance
+        issue_manager = create_issue_manager(labels)
+        issue_manager.find_issues()
+        assert issue_manager.info["Rarest Class"] == 5
+
+        # Without Imbalance
+        labels[0] = 0
+        issue_manager = create_issue_manager(labels)
+        issue_manager.find_issues()
+        assert issue_manager.info["Rarest Class"] == "NA"

--- a/tests/datalab/issue_manager/test_imbalance.py
+++ b/tests/datalab/issue_manager/test_imbalance.py
@@ -40,11 +40,6 @@ class TestClassImbalanceIssueManager:
         )
         assert summary["issue_type"][0] == "class_imbalance"
         assert summary["score"][0] == 0.01
-        assert list(issues.columns) == [
-            "is_class_imbalance_issue",
-            "class_imbalance_score",
-            "class_imbalance_class_name",
-        ]
 
     def test_find_issues_no_imbalance(self, labels, create_issue_manager):
         N = len(labels)

--- a/tests/datalab/issue_manager/test_imbalance.py
+++ b/tests/datalab/issue_manager/test_imbalance.py
@@ -40,6 +40,11 @@ class TestClassImbalanceIssueManager:
         )
         assert summary["issue_type"][0] == "class_imbalance"
         assert summary["score"][0] == 0.01
+        assert list(issues.columns) == [
+            "is_class_imbalance_issue",
+            "class_imbalance_score",
+            "class_imbalance_class_name",
+        ]
 
     def test_find_issues_no_imbalance(self, labels, create_issue_manager):
         N = len(labels)

--- a/tests/datalab/test_cleanvision_integration.py
+++ b/tests/datalab/test_cleanvision_integration.py
@@ -58,8 +58,8 @@ class TestCleanvisionIntegration:
         assert "Failed to check for these issue types: [NonIIDIssueManager]" in captured.out
         assert len(datalab.issues) == len(image_dataset)
 
-        # add up imagelab + datalab issues
-        assert len(datalab.issues.columns) == (num_imagelab_issues + num_datalab_issues) * 2
+        # add up imagelab + datalab issues with extra column for imbalance issue
+        assert len(datalab.issues.columns) == (num_imagelab_issues + num_datalab_issues) * 2 + 1
         assert len(datalab.issue_summary) == num_imagelab_issues + num_datalab_issues
 
         all_keys = IMAGELAB_ISSUE_TYPES + [
@@ -142,7 +142,8 @@ class TestCleanvisionIntegration:
             not in captured.out
         )
         assert len(datalab.issues) == len(image_dataset)
-        assert len(datalab.issues.columns) == num_datalab_issues * 2
+        # number of datalab issue columns with extra column for imbalance issue
+        assert len(datalab.issues.columns) == num_datalab_issues * 2 + 1
         assert len(datalab.issue_summary) == num_datalab_issues
 
         all_keys = ["statistics", "label", "outlier", "near_duplicate", "class_imbalance"]

--- a/tests/datalab/test_cleanvision_integration.py
+++ b/tests/datalab/test_cleanvision_integration.py
@@ -58,8 +58,8 @@ class TestCleanvisionIntegration:
         assert "Failed to check for these issue types: [NonIIDIssueManager]" in captured.out
         assert len(datalab.issues) == len(image_dataset)
 
-        # add up imagelab + datalab issues with extra column for imbalance issue
-        assert len(datalab.issues.columns) == (num_imagelab_issues + num_datalab_issues) * 2 + 1
+        # add up imagelab + datalab issues
+        assert len(datalab.issues.columns) == (num_imagelab_issues + num_datalab_issues) * 2
         assert len(datalab.issue_summary) == num_imagelab_issues + num_datalab_issues
 
         all_keys = IMAGELAB_ISSUE_TYPES + [
@@ -142,8 +142,7 @@ class TestCleanvisionIntegration:
             not in captured.out
         )
         assert len(datalab.issues) == len(image_dataset)
-        # number of datalab issue columns with extra column for imbalance issue
-        assert len(datalab.issues.columns) == num_datalab_issues * 2 + 1
+        assert len(datalab.issues.columns) == num_datalab_issues * 2
         assert len(datalab.issue_summary) == num_datalab_issues
 
         all_keys = ["statistics", "label", "outlier", "near_duplicate", "class_imbalance"]

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -593,7 +593,11 @@ class TestDatalabUsingKNNGraph:
         # Test that a warning is raised
         lab.find_issues()
         # Only class_imbalance issue columns should be present
-        assert list(lab.issues.columns) == ["is_class_imbalance_issue", "class_imbalance_score"]
+        assert list(lab.issues.columns) == [
+            "is_class_imbalance_issue",
+            "class_imbalance_score",
+            "class_imbalance_class_name",
+        ]
 
     def test_data_valuation_issue_with_knn_graph(self, data_tuple):
         lab, knn_graph, features = data_tuple
@@ -1316,9 +1320,9 @@ class TestDatalabWithoutLabels:
         issues_with_labels = lab_with_labels.issues
         issues_without_label_name = lab_without_label_name.issues
 
-        # issues_with_labels should have four additional columns, which include label issues
+        # issues_with_labels should have five additional columns, which include label issues
         # and class_imbalance issues
-        assert len(issues_without_labels.columns) + 4 == len(issues_with_labels.columns)
+        assert len(issues_without_labels.columns) + 5 == len(issues_with_labels.columns)
         pd.testing.assert_frame_equal(issues_without_labels, issues_without_label_name)
 
 


### PR DESCRIPTION
## Summary

🎯 **Purpose**: This PR adds the rare class label as a column to the issues dataframe. The goal is to show which class is imbalanced. 


Example usage (from https://github.com/cleanlab/cleanlab/pull/912) - 

```python
import numpy as np
from cleanlab import Datalab
features_list = [
        np.random.random((100, 3)),
        np.random.random((120, 3)) + 10,
        np.random.random((80, 3)) + 20,
    ]
features = np.vstack(features_list)
labels = np.array([0] * 100 + [1] * 120 + [2] * 80)
pred_probs = features / features.sum(axis=1, keepdims=True)

# Run Datalab
lab = Datalab(data={"features": features, "y": labels}, label_name="y")
lab.find_issues(features=features, pred_probs=pred_probs)
lab.report()

# Change Dataset to include rare class
features_list[2] = np.random.random((3, 3)) + 20
features = np.vstack(features_list)
labels = np.array([0] * 100 + [1] * 120 + [2] * 3)
pred_probs = features / features.sum(axis=1, keepdims=True)

# Run Datalab
lab = Datalab(data={"features": features, "y": labels}, label_name="y")
lab.find_issues(features=features, pred_probs=pred_probs)
lab.report()
```
Output

```
Dataset without Imbalance

----------------- class_imbalance issues ------------------

About this issue:
        Examples belonging to the most under-represented class in the dataset.

Number of examples with this issue: 0
Overall dataset quality in terms of this issue: 0.2667

Examples representing most severe instances of this issue:
     is_class_imbalance_issue  class_imbalance_score class_imbalance_class_name
0                       False                    1.0                    NA
203                     False                    1.0                    NA
202                     False                    1.0                    NA
201                     False                    1.0                    NA
200                     False                    1.0                    NA

Additional Information: 
Rarest Class: NA

Dataset with Imbalance


------------------ class_imbalance issues ------------------

About this issue:
        Examples belonging to the most under-represented class in the dataset.

Number of examples with this issue: 3
Overall dataset quality in terms of this issue: 0.0135

Examples representing most severe instances of this issue:
     is_class_imbalance_issue  class_imbalance_score  class_imbalance_class_name
222                      True               0.013453                      2
221                      True               0.013453                      2
220                      True               0.013453                      2
141                     False               1.000000                      2
142                     False               1.000000                      2

Additional Information: 
Rarest Class: 2
```


## Impact

 🌐 Areas Affected: Datalab.find_issues.

 👥 Who’s Affected: Running class_imbalance issue type will result in the imbalance class label name in the report. 


## Testing

🔍 Testing Done: Outline what kinds of tests you performed.

 🔗 Test Case Link: Directly link to the most end-to-end check of your new functionality.



## Links to Relevant Issues or Conversations

[#921](https://github.com/cleanlab/cleanlab/issues/921)


## Reviewer Notes

* Check if using `label_map` is the correct way to map the integer label to its original representation. 
* Initially, the additional column in the issue df was named `class_imbalance_label`. However, this column is picked up when `lab.get_issues("label")` is performed. The column name has been changed to `class_imbalance_class_name`.

