### PR TITLE
class imbalance scores to still show rarest proportion even when is_i…

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -64,7 +64,7 @@ class ClassImbalanceIssueManager(IssueManager):
         imbalance_exists = class_probs[rarest_class_idx] < self.threshold * (1 / K)
         rarest_class = rarest_class_idx if imbalance_exists else -1
         is_issue_column = labels == rarest_class
-        scores = np.where(is_issue_column, class_probs[rarest_class], 1)
+        scores = np.where(rarest_class_idx, class_probs[rarest_class], 1)
 
         self.issues = pd.DataFrame(
             {

--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -60,7 +60,7 @@ class ClassImbalanceIssueManager(IssueManager):
         labels = self.datalab.labels
         K = len(self.datalab.class_names)
         class_probs = np.bincount(labels) / len(labels)
-        rarest_class_idx = int(np.argmin(class_probs))
+        rarest_class_idx = int(np.argmin(class_probs))  # solely one class is identified as rarest, ties go to class w smaller integer index
         imbalance_exists = class_probs[rarest_class_idx] < self.threshold * (1 / K)
         rarest_class = rarest_class_idx if imbalance_exists else -1
         is_issue_column = labels == rarest_class

--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -60,7 +60,8 @@ class ClassImbalanceIssueManager(IssueManager):
         labels = self.datalab.labels
         K = len(self.datalab.class_names)
         class_probs = np.bincount(labels) / len(labels)
-        rarest_class_idx = int(np.argmin(class_probs))  # solely one class is identified as rarest, ties go to class w smaller integer index
+        rarest_class_idx = int(np.argmin(class_probs))
+        # solely one class is identified as rarest, ties go to class w smaller integer index
         imbalance_exists = class_probs[rarest_class_idx] < self.threshold * (1 / K)
         rarest_class = rarest_class_idx if imbalance_exists else -1
         is_issue_column = labels == rarest_class

--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -66,7 +66,7 @@ class ClassImbalanceIssueManager(IssueManager):
         imbalance_exists = class_probs[rarest_class_idx] < self.threshold * (1 / K)
         rarest_class_issue = rarest_class_idx if imbalance_exists else -1
         is_issue_column = labels == rarest_class_issue
-        
+
         self.issues = pd.DataFrame(
             {
                 f"is_{self.issue_name}_issue": is_issue_column,

--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -62,11 +62,11 @@ class ClassImbalanceIssueManager(IssueManager):
         class_probs = np.bincount(labels) / len(labels)
         rarest_class_idx = int(np.argmin(class_probs))
         # solely one class is identified as rarest, ties go to class w smaller integer index
+        scores = np.where(labels == rarest_class_idx, class_probs[rarest_class_idx], 1)
         imbalance_exists = class_probs[rarest_class_idx] < self.threshold * (1 / K)
-        rarest_class = rarest_class_idx if imbalance_exists else -1
-        is_issue_column = labels == rarest_class
-        scores = np.where(rarest_class_idx, class_probs[rarest_class], 1)
-
+        rarest_class_issue = rarest_class_idx if imbalance_exists else -1
+        is_issue_column = labels == rarest_class_issue
+        
         self.issues = pd.DataFrame(
             {
                 f"is_{self.issue_name}_issue": is_issue_column,

--- a/docs/source/cleanlab/datalab/guide/issue_type_description.rst
+++ b/docs/source/cleanlab/datalab/guide/issue_type_description.rst
@@ -113,7 +113,7 @@ The assumption that examples in a dataset are Independent and Identically Distri
 
 For datasets with low non-IID score, you should consider why your data are not IID and act accordingly. For example, if the data distribution is drifting over time, consider employing a time-based train/test split instead of a random partition.  Note that shuffling the data ahead of time will ensure a good non-IID score, but this is not always a fix to the underlying problem (e.g. future deployment data may stem from a different distribution, or you may overlook the fact that examples influence each other). We thus recommend **not** shuffling your data to be able to diagnose this issue if it exists.
 
-Class-Imbalance Issue
+Class Imbalance Issue
 ---------------------
 
 Class imbalance is diagnosed just using the `labels` provided as part of the dataset. The overall class imbalance quality score of a dataset is the proportion of examples belonging to the rarest class `q`. If this proportion `q` falls below a threshold, then we say this dataset suffers from the class imbalance issue.

--- a/tests/datalab/issue_manager/test_imbalance.py
+++ b/tests/datalab/issue_manager/test_imbalance.py
@@ -51,8 +51,10 @@ class TestClassImbalanceIssueManager:
         assert np.all(
             issues["is_class_imbalance_issue"] == np.full(N, False)
         ), "Issue mask should be correct"
-        assert np.min(issues["class_imbalance_score"]) == 0.47
-        assert np.max(issues["class_imbalance_score"]) == 1
+        scores = issues["class_imbalance_score"]
+        expected_scores = np.ones_like(scores)
+        expected_scores[labels == 1] = 0.47 # Rare class proportion
+        np.testing.assert_allclose(scores, expected_scores, err_msg="Scores should be correct")
         assert summary["issue_type"][0] == "class_imbalance"
         assert summary["score"][0] == 0.47
 

--- a/tests/datalab/issue_manager/test_imbalance.py
+++ b/tests/datalab/issue_manager/test_imbalance.py
@@ -51,7 +51,8 @@ class TestClassImbalanceIssueManager:
         assert np.all(
             issues["is_class_imbalance_issue"] == np.full(N, False)
         ), "Issue mask should be correct"
-        assert np.all(issues["class_imbalance_score"] == np.ones(N)), "Scores should be correct"
+        assert np.min(issues["class_imbalance_score"]) == 0.47
+        assert np.max(issues["class_imbalance_score"]) == 1
         assert summary["issue_type"][0] == "class_imbalance"
         assert summary["score"][0] == 0.47
 

--- a/tests/datalab/issue_manager/test_imbalance.py
+++ b/tests/datalab/issue_manager/test_imbalance.py
@@ -53,7 +53,7 @@ class TestClassImbalanceIssueManager:
         ), "Issue mask should be correct"
         scores = issues["class_imbalance_score"]
         expected_scores = np.ones_like(scores)
-        expected_scores[labels == 1] = 0.47 # Rare class proportion
+        expected_scores[labels == 1] = 0.47  # Rare class proportion
         np.testing.assert_allclose(scores, expected_scores, err_msg="Scores should be correct")
         assert summary["issue_type"][0] == "class_imbalance"
         assert summary["score"][0] == 0.47


### PR DESCRIPTION
Update class imbalance scores to still show rarest proportion even when is_issue = False.

I don't see a reason not to show these scores; the proportion of rarest class seems like useful info regardless of the threshold for determining whether the dataset has this issue. 