### PR TITLE
Near duplicate score transformation

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/duplicate.py
+++ b/cleanlab/datalab/internal/issue_manager/duplicate.py
@@ -104,7 +104,7 @@ class NearDuplicateIssueManager(IssueManager):
         all_near_duplicates = np.unique(np.concatenate(self.near_duplicate_sets))
         is_issue_column = np.zeros(N, dtype=bool)
         is_issue_column[all_near_duplicates] = True
-        scores = np.tanh(nn_distances)
+        scores = compute_scores(nn_distances)
         self.issues = pd.DataFrame(
             {
                 f"is_{self.issue_name}_issue": is_issue_column,
@@ -233,3 +233,8 @@ class NearDuplicateIssueManager(IssueManager):
             )
             threshold = 0
         return threshold
+
+
+def compute_scores(nn_distances):
+    scores = np.tanh(nn_distances)
+    return scores

--- a/cleanlab/datalab/internal/issue_manager/duplicate.py
+++ b/cleanlab/datalab/internal/issue_manager/duplicate.py
@@ -98,13 +98,13 @@ class NearDuplicateIssueManager(IssueManager):
             knn_graph = knn.kneighbors_graph(mode="distance")
         N = knn_graph.shape[0]
         nn_distances = knn_graph.data.reshape(N, -1)[:, 0]
-        scores = np.tanh(nn_distances)
         self.near_duplicate_sets = self._neighbors_within_radius(knn_graph, self.threshold)
 
         # Flag every example in a near-duplicate set as a near-duplicate issue
         all_near_duplicates = np.unique(np.concatenate(self.near_duplicate_sets))
         is_issue_column = np.zeros(N, dtype=bool)
         is_issue_column[all_near_duplicates] = True
+        scores = np.tanh(nn_distances)
         self.issues = pd.DataFrame(
             {
                 f"is_{self.issue_name}_issue": is_issue_column,

--- a/cleanlab/datalab/internal/issue_manager/duplicate.py
+++ b/cleanlab/datalab/internal/issue_manager/duplicate.py
@@ -240,6 +240,25 @@ class NearDuplicateIssueManager(IssueManager):
         return threshold
 
 
-def compute_scores(nn_distances):
+def compute_scores(nn_distances: np.ndarray) -> np.ndarray:
+    """Compute near-duplicate scores from nearest neighbor distances.
+
+    This is a non-linear transformation of the nearest neighbor distances that
+    maps distances to scores in the range [0, 1].  The score for each example is
+    its nearest neighbor distance transformed by the tanh function.
+
+    Parameters
+    ----------
+    nn_distances :
+        The nearest neighbor distances for each example.
+
+    Returns
+    -------
+    scores :
+        The near-duplicate scores for each example. The scores are in the range [0, 1].
+        A lower score indicates that an example is more likely to be a near-duplicate than
+        an example with a higher score.
+        A score of 0 indicates that an example has an exact duplicate.
+    """
     scores = np.tanh(nn_distances)
     return scores

--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -86,6 +86,17 @@ class TestNearDuplicateIssueManager:
         )
         new_issue_manager.find_issues(features=embeddings["embedding"])
 
+    def test_scores_of_examples_with_issues_are_smaller_than_those_without(
+        self, issue_manager, embeddings
+    ):
+        # TODO: Turn this into a property-based test
+        issue_manager.find_issues(features=embeddings["embedding"])
+        is_issue = issue_manager.issues["is_near_duplicate_issue"]
+        scores = issue_manager.issues["near_duplicate_score"]
+        max_issue_score = np.max(scores[is_issue])
+        min_non_issue_score = np.min(scores[~is_issue])
+        assert max_issue_score < min_non_issue_score
+
     def test_report(self, issue_manager, embeddings):
         issue_manager.find_issues(features=embeddings["embedding"])
         report = issue_manager.report(

--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -72,7 +72,7 @@ class TestNearDuplicateIssueManager:
             issues["is_near_duplicate_issue"] == expected_issue_mask
         ), "Issue mask should be correct"
         assert summary["issue_type"][0] == "near_duplicate"
-        assert summary["score"][0] == pytest.approx(expected=0.03122489, abs=1e-7)
+        assert summary["score"][0] == pytest.approx(expected=0.4734458, abs=1e-7)
 
         assert (
             info.get("near_duplicate_sets", None) is not None


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Standardize distance scoring function for near-duplicates.


In this PR, when computing near-duplicate scores in Datalab, we switch from tanh-transformed distances ($`x \rightarrow \tanh(x)`$) to an exponential-transformed distance ($`x \rightarrow 1 - \exp(-tx)`$) where $`t`$ is a temperature parameter.

![image](https://github.com/cleanlab/cleanlab/assets/18127060/908dd1d4-b5c9-4690-a2c6-661e8eb191d2)



## Reviewer Notes
> This PR does not affect how near-duplicates are detected.
> This PR only affects how the scores are represented to cover the scoring range across different scales in the embedding space. This is achieved with the temperature parameter.
![image](https://github.com/cleanlab/cleanlab/assets/18127060/a7e0ed8d-9be2-424d-b3ba-9ba1f505cc33)


