### PR TITLE
ensure near-predicted labels are not flagged as label issue

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -229,6 +229,7 @@ def _num_label_issues_multilabel(
 
 
 def _reduce_issues(pred_probs, labels, num_classes):
+    """Returns a boolean mask denoting correct predictions or predictions within a margin around 0.5 for binary classification, suitable for filtering out indices in 'is_label_issue'."""
     pred = pred_probs.argmax(axis=1)
     mask = pred == labels
     if num_classes == 2:

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -155,8 +155,8 @@ def num_label_issues(
         label_issues_mask[cl_error_indices] = True
 
         # Remove label issues if model prediction is close to given label
-        mask = _reduce_issues(pred_probs=pred_probs, labels=labels)
-        label_issues_mask[mask] = False
+        mask = _reduce_issues(pred_probs=pred_probs[cl_error_indices], labels=labels[cl_error_indices])
+        label_issues_mask[cl_error_indices[mask]] = False
         num_issues = np.sum(label_issues_mask)
     elif estimation_method == "off_diagonal_calibrated":
         calculated_confident_joint = compute_confident_joint(

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -230,10 +230,11 @@ def _num_label_issues_multilabel(
 
 def _reduce_issues(pred_probs, labels):
     """Returns a boolean mask denoting correct predictions or predictions within a margin around 0.5 for binary classification, suitable for filtering out indices in 'is_label_issue'."""
-    pred_probs[np.arange(len(labels)), labels] += FLOATING_POINT_COMPARISON
-    pred = pred_probs.argmax(axis=1)
+    pred_probs_copy = np.copy(pred_probs)  # Make a copy of the original array
+    pred_probs_copy[np.arange(len(labels)), labels] += FLOATING_POINT_COMPARISON
+    pred = pred_probs_copy.argmax(axis=1)
     mask = pred == labels
-    pred_probs[np.arange(len(labels)), labels] -= FLOATING_POINT_COMPARISON
+    del pred_probs_copy  # Delete copy
     return mask
 
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -233,6 +233,7 @@ def _reduce_issues(pred_probs, labels):
     pred_probs[np.arange(len(labels)), labels] += FLOATING_POINT_COMPARISON
     pred = pred_probs.argmax(axis=1)
     mask = pred == labels
+    pred_probs[np.arange(len(labels)), labels] -= FLOATING_POINT_COMPARISON
     return mask
 
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -154,7 +154,7 @@ def num_label_issues(
         label_issues_mask = np.zeros(len(labels), dtype=bool)
         label_issues_mask[cl_error_indices] = True
 
-        # Remove label issues if given label == model prediction
+        # Remove label issues if model prediction is close to given label
         mask = _reduce_issues(pred_probs=pred_probs, labels=labels)
         label_issues_mask[mask] = False
         num_issues = np.sum(label_issues_mask)

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -233,8 +233,6 @@ def _reduce_issues(pred_probs, labels):
     pred_probs[np.arange(len(labels)), labels] += FLOATING_POINT_COMPARISON
     pred = pred_probs.argmax(axis=1)
     mask = pred == labels
-    # if num_classes == 2:
-    #     mask = mask | ((pred_probs[:, 0] >= 0.5 - FLOATING_POINT_COMPARISON) & (pred_probs[:, 0] <= 0.5 + FLOATING_POINT_COMPARISON))
     return mask
 
 

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -155,8 +155,8 @@ def num_label_issues(
         label_issues_mask[cl_error_indices] = True
 
         # Remove label issues if model prediction is close to given label
-        mask = _reduce_issues(pred_probs=pred_probs[cl_error_indices], labels=labels[cl_error_indices])
-        label_issues_mask[cl_error_indices[mask]] = False
+        mask = _reduce_issues(pred_probs=pred_probs, labels=labels)
+        label_issues_mask[mask] = False
         num_issues = np.sum(label_issues_mask)
     elif estimation_method == "off_diagonal_calibrated":
         calculated_confident_joint = compute_confident_joint(

--- a/cleanlab/experimental/label_issues_batched.py
+++ b/cleanlab/experimental/label_issues_batched.py
@@ -236,8 +236,8 @@ def find_label_issues_batched(
     label_issues_indices = lab.get_label_issues()
     label_issues_mask = np.zeros(len(labels), dtype=bool)
     label_issues_mask[label_issues_indices] = True
-    mask = _reduce_issues(pred_probs=pred_probs[label_issues_indices], labels=labels[label_issues_indices])
-    label_issues_mask[label_issues_indices[mask]] = False
+    mask = _reduce_issues(pred_probs=pred_probs, labels=labels)
+    label_issues_mask[mask] = False
     if return_mask:
         return label_issues_mask
     return np.where(label_issues_mask)[0]

--- a/cleanlab/experimental/label_issues_batched.py
+++ b/cleanlab/experimental/label_issues_batched.py
@@ -236,8 +236,8 @@ def find_label_issues_batched(
     label_issues_indices = lab.get_label_issues()
     label_issues_mask = np.zeros(len(labels), dtype=bool)
     label_issues_mask[label_issues_indices] = True
-    mask = _reduce_issues(pred_probs=pred_probs, labels=labels)
-    label_issues_mask[mask] = False
+    mask = _reduce_issues(pred_probs=pred_probs[label_issues_indices], labels=labels[label_issues_indices])
+    label_issues_mask[label_issues_indices[mask]] = False
     if return_mask:
         return label_issues_mask
     return np.where(label_issues_mask)[0]

--- a/cleanlab/experimental/label_issues_batched.py
+++ b/cleanlab/experimental/label_issues_batched.py
@@ -236,11 +236,7 @@ def find_label_issues_batched(
     label_issues_indices = lab.get_label_issues()
     label_issues_mask = np.zeros(len(labels), dtype=bool)
     label_issues_mask[label_issues_indices] = True
-    mask = _reduce_issues(
-        pred_probs=pred_probs,
-        labels=labels,
-        num_classes=get_num_classes(labels=labels, pred_probs=pred_probs),
-    )
+    mask = _reduce_issues(pred_probs=pred_probs, labels=labels)
     label_issues_mask[mask] = False
     if return_mask:
         return label_issues_mask

--- a/cleanlab/experimental/label_issues_batched.py
+++ b/cleanlab/experimental/label_issues_batched.py
@@ -30,10 +30,10 @@ or follow the examples script for the ``LabelInspector`` class if you require gr
 import numpy as np
 from typing import Optional, List, Tuple, Any
 
-from cleanlab.count import get_confident_thresholds
+from cleanlab.count import get_confident_thresholds, _reduce_issues
 from cleanlab.rank import find_top_issues, _compute_label_quality_scores
 from cleanlab.typing import LabelLike
-from cleanlab.internal.util import value_counts_fill_missing_classes
+from cleanlab.internal.util import value_counts_fill_missing_classes, get_num_classes
 from cleanlab.internal.constants import (
     CONFIDENT_THRESHOLDS_LOWER_BOUND,
     FLOATING_POINT_COMPARISON,
@@ -234,11 +234,17 @@ def find_label_issues_batched(
         pbar.close()
 
     label_issues_indices = lab.get_label_issues()
+    label_issues_mask = np.zeros(len(labels), dtype=bool)
+    label_issues_mask[label_issues_indices] = True
+    mask = _reduce_issues(
+        pred_probs=pred_probs,
+        labels=labels,
+        num_classes=get_num_classes(labels=labels, pred_probs=pred_probs),
+    )
+    label_issues_mask[mask] = False
     if return_mask:
-        label_issues_mask = np.zeros(len(labels), dtype=bool)
-        label_issues_mask[label_issues_indices] = True
         return label_issues_mask
-    return label_issues_indices
+    return np.where(label_issues_mask)[0]
 
 
 class LabelInspector:
@@ -694,6 +700,7 @@ def _compute_num_issues(arg: Tuple[np.ndarray, bool]) -> int:
     pred_prob = pred_probs_shared[ind, :]
     pred_class = np.argmax(pred_prob, axis=-1)
     batch_size = len(label)
+
     if thorough:
         pred_gt_thresholds = pred_prob >= adj_confident_thresholds_shared
         max_ind = np.argmax(pred_prob * pred_gt_thresholds, axis=-1)

--- a/cleanlab/experimental/label_issues_batched.py
+++ b/cleanlab/experimental/label_issues_batched.py
@@ -33,7 +33,7 @@ from typing import Optional, List, Tuple, Any
 from cleanlab.count import get_confident_thresholds, _reduce_issues
 from cleanlab.rank import find_top_issues, _compute_label_quality_scores
 from cleanlab.typing import LabelLike
-from cleanlab.internal.util import value_counts_fill_missing_classes, get_num_classes
+from cleanlab.internal.util import value_counts_fill_missing_classes
 from cleanlab.internal.constants import (
     CONFIDENT_THRESHOLDS_LOWER_BOUND,
     FLOATING_POINT_COMPARISON,

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -445,11 +445,7 @@ def find_label_issues(
 
     if filter_by not in ["low_self_confidence", "low_normalized_margin"]:
         # Remove label issues if given label == model prediction if issues haven't been removed yet
-        mask = _reduce_issues(
-            pred_probs=pred_probs,
-            labels=labels,
-            num_classes=K,
-        )
+        mask = _reduce_issues(pred_probs=pred_probs, labels=labels)
         label_issues_mask[mask] = False
 
     if verbose:

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -444,7 +444,7 @@ def find_label_issues(
         label_issues_mask = find_predicted_neq_given(labels, pred_probs, multi_label=multi_label)
 
     if filter_by not in ["low_self_confidence", "low_normalized_margin"]:
-        # Remove label issues if given label == model prediction if issues haven't been removed yet
+        # Remove label issues if model prediction is close to given label
         mask = _reduce_issues(pred_probs=pred_probs, labels=labels)
         label_issues_mask[mask] = False
 

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -445,8 +445,8 @@ def find_label_issues(
 
     if filter_by not in ["low_self_confidence", "low_normalized_margin"]:
         # Remove label issues if model prediction is close to given label
-        mask = _reduce_issues(pred_probs=pred_probs, labels=labels)
-        label_issues_mask[mask] = False
+        mask = _reduce_issues(pred_probs=pred_probs[cl_error_indices], labels=labels[cl_error_indices])
+        label_issues_mask[cl_error_indices[mask]] = False
 
     if verbose:
         print("Number of label issues found: {}".format(sum(label_issues_mask)))

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -31,7 +31,7 @@ from typing import Any, Dict, Optional, Tuple, List
 from functools import reduce
 import platform
 
-from cleanlab.count import calibrate_confident_joint, num_label_issues
+from cleanlab.count import calibrate_confident_joint, num_label_issues, _reduce_issues
 from cleanlab.rank import order_label_issues, get_label_quality_scores
 import cleanlab.internal.multilabel_scorer as ml_scorer
 from cleanlab.internal.validation import assert_valid_inputs
@@ -445,8 +445,12 @@ def find_label_issues(
 
     if filter_by not in ["low_self_confidence", "low_normalized_margin"]:
         # Remove label issues if given label == model prediction if issues haven't been removed yet
-        pred = pred_probs.argmax(axis=1)
-        label_issues_mask[pred == labels] = False
+        mask = _reduce_issues(
+            pred_probs=pred_probs,
+            labels=labels,
+            num_classes=K,
+        )
+        label_issues_mask[mask] = False
 
     if verbose:
         print("Number of label issues found: {}".format(sum(label_issues_mask)))

--- a/cleanlab/filter.py
+++ b/cleanlab/filter.py
@@ -445,8 +445,8 @@ def find_label_issues(
 
     if filter_by not in ["low_self_confidence", "low_normalized_margin"]:
         # Remove label issues if model prediction is close to given label
-        mask = _reduce_issues(pred_probs=pred_probs[cl_error_indices], labels=labels[cl_error_indices])
-        label_issues_mask[cl_error_indices[mask]] = False
+        mask = _reduce_issues(pred_probs=pred_probs, labels=labels)
+        label_issues_mask[mask] = False
 
     if verbose:
         print("Number of label issues found: {}".format(sum(label_issues_mask)))


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Add support for binary classifier where pred probs are close to 0.5

Ignore cases where for a binary classifier, the probability is very close to 0.5 for both classes, and avoid that being flagged as a label issue.
