### PR TITLE
Fix broken link to SSH deploy key guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -162,7 +162,7 @@ pip install -r docs/requirements.txt
 
 3. In the `cleanlab-docs` repo, [configure GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site#creating-a-repository-for-your-site); under the **Source** section, select the `master` branch and `/(root)` folder. Take note of the URL where your site is published.
 
-4. [Generate SSH deploy key](https://github.com/peaceiris/actions-gh-pages#user-content-️-create-ssh-deploy-key) and add them to your repos as such:
+4. [Generate SSH deploy key](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-create-ssh-deploy-key) and add them to your repos as such:
 
    * In the `cleanlab-docs` repo, go to **Settings > Deploy Keys > Add deploy key** and add your **public key** with the **Allow write access**
    * In the `cleanlab` repo, go to **Settings > Secrets > New repository secrets** and add your **private key** named `ACTIONS_DEPLOY_KEY`


### PR DESCRIPTION
This PR addresses a broken link found in the documentation (`docs/README.md`). The link in question, previously leading to an SSH deploy key generation guide, failed during external link validation. The specific error encountered was:

```
External link https://github.com/peaceiris/actions-gh-pages#user-content-%EF%B8%8F-create-ssh-deploy-key
failed: https://github.com/peaceiris/actions-gh-pages exists,
but the hash 'user-content-%EF%B8%8F-create-ssh-deploy-key' does not (status code 200)
```