### PR TITLE
Ignore hash for GitHub URLs

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -26,4 +26,5 @@ jobs:
           tokens: |
             {"https://github.com": "${{ secrets.GITHUB_TOKEN }}"}
           swap_urls: |
-            {"^(\\..*)\\.md(#?.*)$": "\\1.md.html\\2"}
+            {"^(\\..*)\\.md(#?.*)$": "\\1.md.html\\2",
+             "^(https://github\\.com/.*)#.*$": "\\1"}


### PR DESCRIPTION
The HTML page returned by GitHub no longer contains ID attributes for line numbers or headers (from user's Markdown files); the functionality is implemented in JavaScript now.