### PR TITLE
Add missing ref to url links in OpenGraph metadata

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -143,6 +143,16 @@ jobs:
         if: ${{ github.ref_type == 'tag' }}
         run: cp docs/source/_templates/redirect-to-stable.html cleanlab-docs/index.html
 
+      - name: Update OpenGraph URLs in HTML files
+        env:
+          REF_URL_SEGMENT: ${{ (github.ref_type == 'tag' && steps.stable_release.outcome == 'success') && 'stable' || github.ref_name }}
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: '<meta property="og:url" content="${{ env.DOCS_SITE_URL }}'
+          replace: '<meta property="og:url" content="${{ env.DOCS_SITE_URL }}${{ env.REF_URL_SEGMENT }}/'
+          include: "cleanlab-docs/**/*.html"
+          regex: false
+      
       - name: Deploy
         if: ${{ (github.ref == 'refs/heads/master') || (github.ref_type == 'tag') }}
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
The opengraph extension for sphinx only links to `https://docs.cleanlab.ai/[path/to/page].html`, but should be `https://docs.cleanlab.ai/[ref_name]/[path/to/page].html`.

where `ref_name` should be either `stable`, master or a released version (e.g. v.2.6.0 in the future).

Without this fix, all the links will fail a link-check.

This PR aims to fix that issue.
