### PR TITLE
Temporarily cap Tensorflow version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,9 @@ pytest-lazy-fixture
 requests
 scipy
 skorch
-tensorflow
+# Cap tensorflow at version 2.15.0 or below. 2.16.0 is not released but avaiable on PyPI. Some test are breaking on 2.16.0.
+# TODO: Remove cap before v2.6.0 release.
+tensorflow<2.16.0
 torch
 torchvision
 typing-extensions>=4.1.1

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/
     install_requires=[
         "numpy>=1.20.0",
-        "scikit-learn>=1.0",
+        "scikit-learn>=1.0,<1.4.0",
         "tqdm>=4.53.0",
         "pandas>=1.1.5",
         "termcolor>=2.0.0,<2.4.0",


### PR DESCRIPTION
## Main changes

- Tensorflow version temporarily has an upper bound (`tensorflow<2.16.0`) in requirements-dev.txt.
- scikit-learn version temporarily has an upper bound (`scikit-learn>=1.0,<1.4.0`) in setup.py

## Background

Tensorflow has released version 2.16.0 [on PyPI](https://pypi.org/project/tensorflow), messing with CI where some tests fail.

**PyPI site:**
![image](https://github.com/cleanlab/cleanlab/assets/18127060/a59ba01f-0b88-4be0-b61f-6a78b23c18b9)

**From the [tensorflow/tensorflow repo](https://github.com/tensorflow/tensorflow):**
![image](https://github.com/cleanlab/cleanlab/assets/18127060/ba6568ba-9391-45c8-8657-c3b26bd54e1b)


### Outputs from failing CI job:
```
# Installing dev dependencies in CPythonpython 3.10 on Ubuntu
Collecting tensorflow (from -r requirements-dev.txt (line 15))
  Downloading tensorflow-2.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.4 kB)

# ...

=========================== short test summary info ============================
FAILED tests/test_frameworks.py::test_tensorflow_sequential[1-0] - ValueError: `clf` must be clonable via: sklearn.base.clone(clf). You can either implement instance method `clf.get_params()` to produce a fresh untrained copy of this model, or you can implement the cross-validation outside of cleanlab and pass in the obtained `pred_probs` to skip cleanlab's internal cross-validation
FAILED tests/test_frameworks.py::test_tensorflow_sequential[32-0] - ValueError: `clf` must be clonable via: sklearn.base.clone(clf). You can either implement instance method `clf.get_params()` to produce a fresh untrained copy of this model, or you can implement the cross-validation outside of cleanlab and pass in the obtained `pred_probs` to skip cleanlab's internal cross-validation
FAILED tests/test_frameworks.py::test_tensorflow_sequential[32-1] - ValueError: `clf` must be clonable via: sklearn.base.clone(clf). You can either implement instance method `clf.get_params()` to produce a fresh untrained copy of this model, or you can implement the cross-validation outside of cleanlab and pass in the obtained `pred_probs` to skip cleanlab's internal cross-validation
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 3 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
=========== 3 failed, 789 passed, 2734 warnings in 198.17s (0:03:18) ===========
Error: Process completed with exit code 1.
```


This change should be reverted in the near future before our next release. In the meantime, this new version of tensorflow should not block other features being developed.


## Another note on scikit-learn

Another note is that scikit-learn [just released 1.4.0](https://scikit-learn.org/stable/whats_new/v1.4.html#changes-1-4) yesterday, which may have caused the audio tutorial notebook to fail spontaneously.

I include a version cap for scikit-learn for installing cleanlab. It will have to be reverted along with the Tensorflow cap.