### PR TITLE
Fix URL replacement regex in gh-pages.yaml

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -154,8 +154,8 @@ jobs:
           REF_URL_SEGMENT: ${{ (github.ref_type == 'tag' && steps.stable_release.outcome == 'success') && 'stable' || github.ref_name }}
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          find: '(<meta property="og:url" content="https?:\/\/[^\/]+\/)([^"]+")'
-          replace: '$1${{ env.REF_URL_SEGMENT }}/$2'
+          find: "(<meta property=\"og:url\" content=\"https?:\/\/[^\/]+)\/([^\"]+\")"
+          replace: "$1/${{ env.REF_URL_SEGMENT }}/$2"
           include: "cleanlab-docs/**/*.html"
           regex: true
       


### PR DESCRIPTION
- Switch to double-quoted scalar
- Escape double quotes in tag
- Omit ending backslash in first group to write a valid replace pattern