### PR TITLE
Revert sklearn and tf version caps

### DIFF
--- a/docs/source/tutorials/audio.ipynb
+++ b/docs/source/tutorials/audio.ipynb
@@ -490,7 +490,7 @@
     "from sklearn.linear_model import LogisticRegression\n",
     "from sklearn.model_selection import cross_val_predict\n",
     "\n",
-    "model = LogisticRegression(C=0.01, max_iter=1000, tol=1e-1, random_state=SEED)\n",
+    "model = LogisticRegression(C=0.01, max_iter=1000, tol=1e-2, random_state=SEED)\n",
     "\n",
     "num_crossval_folds = 5  # can decrease this value to reduce runtime, or increase it to get better results\n",
     "pred_probs = cross_val_predict(\n",
@@ -774,7 +774,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/audio.ipynb
+++ b/docs/source/tutorials/audio.ipynb
@@ -774,7 +774,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,9 +12,7 @@ pytest-lazy-fixture
 requests
 scipy
 skorch
-# Cap tensorflow at version 2.15.0 or below. 2.16.0 is not released but avaiable on PyPI. Some test are breaking on 2.16.0.
-# TODO: Remove cap before v2.6.0 release.
-tensorflow<2.16.0
+tensorflow
 torch
 torchvision
 typing-extensions>=4.1.1

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/
     install_requires=[
         "numpy>=1.20.0",
-        "scikit-learn>=1.0,<1.4.0",
+        "scikit-learn>=1.0",
         "tqdm>=4.53.0",
         "pandas>=1.1.5",
         "termcolor>=2.0.0,<2.4.0",


### PR DESCRIPTION
This PR resolves #962.

The versions were capped to deploy #959 (and the related PRs) successfully.
The main culprit was the latest release of scikit-learn (1.4). TF 2.16.0 was temporarily available on PyPI, before being pulled back.

The only file affected by this change is the audio tutorial, which may be [getting different coefficients in the LogisticRegression model](https://scikit-learn.org/stable/whats_new/v1.4.html#changed-models) when the stopping criterion threshold is set so high. This PR updates the value of the threshold in an attempt to get more precise results.