### PR TITLE
Add a `show_all_issues`  optional argument to Datalab.report()

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -377,6 +377,7 @@ class Datalab:
         verbosity: Optional[int] = None,
         include_description: bool = True,
         show_summary_score: bool = False,
+        show_all_issues: bool = False,
     ) -> None:
         """Prints informative summary of all issues.
 
@@ -392,6 +393,13 @@ class Datalab:
         include_description :
             Whether or not to include a description of each issue type in the report.
             Consider setting this to ``False`` once you're familiar with how each issue type is defined.
+
+        show_summary_score :
+            Whether or not to include the overall severity of each issue type in the report.
+
+        show_all_issues :
+            Whether or not to show all issues in the report, or only the top `num_examples` instances that suffer the most from each type of issue.
+            With this set to ``True``, the report may include more types of issues that were not detected in the dataset.
 
         See Also
         --------
@@ -410,6 +418,7 @@ class Datalab:
             verbosity=verbosity,
             include_description=include_description,
             show_summary_score=show_summary_score,
+            show_all_issues=show_all_issues,
             imagelab=self._imagelab,
         )
         reporter.report(num_examples=num_examples)

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -398,7 +398,7 @@ class Datalab:
             Whether or not to include the overall severity of each issue type in the report.
 
         show_all_issues :
-            Whether or not to show all issues in the report, or only the top `num_examples` instances that suffer the most from each type of issue.
+            Whether or not to show all issues in the report, or only the issues for which examples were found in the dataset
             With this set to ``True``, the report may include more types of issues that were not detected in the dataset.
 
         See Also

--- a/cleanlab/datalab/internal/adapter/imagelab.py
+++ b/cleanlab/datalab/internal/adapter/imagelab.py
@@ -149,6 +149,7 @@ class ImagelabReporterAdapter(Reporter):
         verbosity: int = 1,
         include_description: bool = True,
         show_summary_score: bool = False,
+        show_all_issues: bool = False,
     ):
         super().__init__(
             data_issues=data_issues,
@@ -156,6 +157,7 @@ class ImagelabReporterAdapter(Reporter):
             verbosity=verbosity,
             include_description=include_description,
             show_summary_score=show_summary_score,
+            show_all_issues=show_all_issues,
         )
         self.imagelab = imagelab
 

--- a/cleanlab/datalab/internal/report.py
+++ b/cleanlab/datalab/internal/report.py
@@ -151,7 +151,6 @@ class Reporter:
                 include_description=self.include_description,
             )
             for key in issue_types
-            if add_issue_to_report(key)
         ]
 
         report_str += "\n\n\n".join(issue_reports)

--- a/cleanlab/datalab/internal/report.py
+++ b/cleanlab/datalab/internal/report.py
@@ -73,6 +73,12 @@ class Reporter:
         self.show_summary_score = show_summary_score
         self.show_all_issues = show_all_issues
 
+    @staticmethod
+    def _get_empty_report() -> str:
+        """This method is used to return a report when there are no issues found in the data."""
+
+        return "No issues found in the data. Good job!"
+
     def report(self, num_examples: int) -> None:
         """Prints a report about identified issues in the data.
 
@@ -106,6 +112,8 @@ class Reporter:
         """
         report_str = ""
         issue_summary = self.data_issues.issue_summary
+        if not issue_summary.empty and issue_summary["num_issues"].sum() == 0:
+            return self._get_empty_report()
         issue_summary_sorted = issue_summary.sort_values(by="num_issues", ascending=False)
         report_str += self._write_summary(summary=issue_summary_sorted)
 

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -1786,3 +1786,24 @@ class TestIssueManagersReuseKnnGraph:
         assert (
             time_underperforming_after_outlier < time_only_underperforming_group
         ), "KNN graph reuse should make this run of find_issues faster."
+
+
+class TestDatalabReportWithNoIssues:
+    @pytest.fixture
+    def data(self):
+        np.random.seed(SEED)
+        X = np.random.rand(100, 10)
+        y = np.random.randint(0, 2, 100)
+
+        X[y == 1] += 1.5
+        return {"X": X, "y": y}
+
+    def test_report(self, data):
+        lab = Datalab(data=data, label_name="y")
+        lab.find_issues(features=data["X"], issue_types={"label": {}})
+        with contextlib.redirect_stdout(io.StringIO()) as f:
+            lab.report()
+        report = f.getvalue()
+        assert (
+            "No issues found in the data." in report
+        ), "Report should contain a message for no issues found"

--- a/tests/datalab/test_report.py
+++ b/tests/datalab/test_report.py
@@ -166,7 +166,7 @@ class TestReporter:
 
         reporter = Reporter(
             data_issues=data_issues,
-            task=Task.CLASSIFICATION,
+            task="classification",
             verbosity=0,
             include_description=False,
             show_all_issues=show_all_issues,

--- a/tests/datalab/test_report.py
+++ b/tests/datalab/test_report.py
@@ -100,3 +100,82 @@ class TestReporter:
         report = reporter.get_report(num_examples=3)
         expected_report = "\n\n".join(["Here is a lab summary", "foo report"])
         assert report == expected_report
+
+    @pytest.mark.parametrize(
+        "show_all_issues, expected_report",
+        [
+            (True, "Here is a lab summary\n\nfoo report\n\n\nbar report"),
+            (False, "Here is a lab summary\n\nfoo report"),
+        ],
+    )
+    def test_show_all_issues(
+        self, reporter, data_issues, monkeypatch, show_all_issues, expected_report
+    ):
+        """Test that the report method works. Assuming we have two issue managers, each should add
+        their section to the report."""
+
+        mock_issue_manager_foo = Mock()
+        mock_issue_manager_foo.issue_name = "foo"
+        mock_issue_manager_foo.report.return_value = "foo report"
+
+        mock_issue_manager_bar = Mock()
+        mock_issue_manager_bar.issue_name = "bar"
+        mock_issue_manager_bar.report.return_value = "bar report"
+
+        class MockIssueManagerFactory:
+            @staticmethod
+            def from_str(*args, **kwargs):
+                name = kwargs["issue_type"]
+                issue_managers = {
+                    "foo": mock_issue_manager_foo,
+                    "bar": mock_issue_manager_bar,
+                }
+                issue_manager = issue_managers.get(name)
+                if issue_manager is None:
+                    raise ValueError(f"Unknown issue manager name: {name}")
+                return issue_manager
+
+        monkeypatch.setattr(
+            "cleanlab.datalab.internal.report._IssueManagerFactory", MockIssueManagerFactory
+        )
+        mock_issues = pd.DataFrame(
+            {
+                "is_foo_issue": [False, True, False, False, False],
+                "foo_score": [0.6, 0.2, 0.7, 0.7, 0.8],
+                "is_bar_issue": [False, False, False, False, False],
+                "bar_score": [0.7, 0.9, 0.8, 0.8, 0.8],
+            }
+        )
+        monkeypatch.setattr(data_issues, "issues", mock_issues)
+
+        # "bar" issue may be omitted in report, unless show_all_issues is True
+        mock_issue_summary = pd.DataFrame(
+            {
+                "issue_type": ["foo", "bar"],
+                "score": [0.6, 0.8],
+                "num_issues": [1, 0],
+            }
+        )
+
+        mock_info = {
+            "foo": {"foobar": "baz"},
+            "bar": {"barfoo": "bazbar"},
+        }
+
+        monkeypatch.setattr(data_issues, "issue_summary", mock_issue_summary)
+
+        reporter = Reporter(
+            data_issues=data_issues,
+            task=Task.CLASSIFICATION,
+            verbosity=0,
+            include_description=False,
+            show_all_issues=show_all_issues,
+        )
+        monkeypatch.setattr(data_issues, "issues", mock_issues, raising=False)
+        monkeypatch.setattr(data_issues, "info", mock_info, raising=False)
+
+        monkeypatch.setattr(
+            reporter, "_write_summary", lambda *args, **kwargs: "Here is a lab summary\n\n"
+        )
+        report = reporter.get_report(num_examples=3)
+        assert report == expected_report


### PR DESCRIPTION
## Summary

Omit undetected issue types in Datalab.report() with optional `show_all_issues` argument.

### If `show_all_issues = False` (default)
If no issues are found, a new "empty" report is used. All issue types with num_issues = 0 are omitted.

```python
lab.report(show_all_issues = False)
# No issues found in the data. ...
# ...
```


### If `show_all_issues = True`
No issue type is omitted and the original report is shown.
```python
lab.report(show_all_issues = True)
# Here is a summary of the different kinds of issues found in the data:
# 
# issue_type  num_issues
#      label           0
# 
# Dataset Information: ...
```


## Other changes

A docstring for the `show_summary_score`  argument is added to `Datalab.report()` method.

Closes #922 .