### PR TITLE
Fix dev dependencies (pytest and black formatter)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           pip install .
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-lazy-fixture pipdeptree hypothesis
+          pip install pytest pipdeptree hypothesis
           pipdeptree -j > deps.json
       - name: Install minimum versions
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.1.1
     hooks:
       - id: black

--- a/cleanlab/datalab/internal/issue_manager/imbalance.py
+++ b/cleanlab/datalab/internal/issue_manager/imbalance.py
@@ -38,9 +38,9 @@ class ClassImbalanceIssueManager(IssueManager):
 
     """
 
-    description: ClassVar[
-        str
-    ] = """Examples belonging to the most under-represented class in the dataset."""
+    description: ClassVar[str] = (
+        """Examples belonging to the most under-represented class in the dataset."""
+    )
 
     issue_name: ClassVar[str] = "class_imbalance"
     verbosity_levels = {

--- a/cleanlab/datalab/internal/issue_manager/outlier.py
+++ b/cleanlab/datalab/internal/issue_manager/outlier.py
@@ -191,7 +191,8 @@ class OutlierIssueManager(IssueManager):
         # Check if the weighted knn graph exists in info
         knn_graph = self.datalab.get_info("statistics").get("weighted_knn_graph", None)
 
-        k: int = 0  # Used to check if the knn graph needs to be recomputed, already set in the knn object
+        # Used to check if the knn graph needs to be recomputed, already set in the knn object
+        k: int = 0
         if knn_graph is not None:
             k = knn_graph.nnz // knn_graph.shape[0]
 

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -1507,9 +1507,11 @@ def _get_post_pred_probs_and_weights(
                 np.average(
                     [prior_pred_probs[i, true_label]]
                     + [
-                        consensus_likelihood
-                        if annotator_label == true_label
-                        else non_consensus_likelihood
+                        (
+                            consensus_likelihood
+                            if annotator_label == true_label
+                            else non_consensus_likelihood
+                        )
                         for annotator_label in labels_subset
                     ],
                     weights=np.concatenate(
@@ -1637,9 +1639,11 @@ def _get_post_pred_probs_and_weights_ensemble(
             np.average(
                 [prior_pred_probs[ind][i, true_label] for ind in range(prior_pred_probs.shape[0])]
                 + [
-                    consensus_likelihood
-                    if annotator_label == true_label
-                    else non_consensus_likelihood
+                    (
+                        consensus_likelihood
+                        if annotator_label == true_label
+                        else non_consensus_likelihood
+                    )
                     for annotator_label in labels_subset
                 ],
                 weights=np.concatenate((model_weight, adjusted_annotator_agreement[labels_mask])),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ pre-commit
 psutil
 pytest
 pytest-cov
-pytest-lazy-fixture
 requests
 scipy
 skorch

--- a/tests/datalab/issue_manager/regression/test_label.py
+++ b/tests/datalab/issue_manager/regression/test_label.py
@@ -91,7 +91,6 @@ class TestRegressionLabelIssueManager:
 
 
 class TestRegressionLabelIssueManagerIntegration:
-
     """This class contains tests for the find_issues method with a CleanLearning
     object that behaves deterministically. This is useful to run a "regression"-test on
     the results computed by the find_issues method.

--- a/tests/datalab/test_cleanvision_integration.py
+++ b/tests/datalab/test_cleanvision_integration.py
@@ -68,7 +68,7 @@ class TestCleanvisionIntegration:
             "outlier",
             "near_duplicate",
             "class_imbalance",
-            "null"
+            "null",
             # "non_iid",
         ]
 

--- a/tests/test_multilabel_classification.py
+++ b/tests/test_multilabel_classification.py
@@ -566,10 +566,15 @@ def test_stack_complement():
 
 @pytest.mark.parametrize(
     "pred_probs_test",
-    (None, pytest.lazy_fixture("pred_probs")),
+    (None, "pred_probs"),
     ids=["Without probabilities", "With probabilities"],
 )
-def test_get_onehot_num_classes(labels, pred_probs_test):
+def test_get_onehot_num_classes(labels, pred_probs_test, request):
+    pred_probs_test = (
+        request.getfixturevalue(pred_probs_test)
+        if isinstance(pred_probs_test, str)
+        else pred_probs_test
+    )
     labels_list = [np.nonzero(x)[0].tolist() for x in labels]
     _, num_classes = get_onehot_num_classes(labels_list, pred_probs_test)
     assert num_classes == 3
@@ -588,7 +593,7 @@ def test_get_label_quality_scores_output(labels, pred_probs, scorer):
     "given_labels,expected",
     [
         (
-            pytest.lazy_fixture("labels"),
+            "labels",
             np.full((3, 2), 0.5),
         ),
         (np.array([[0, 1], [0, 0], [1, 1]]), np.array([[2 / 3, 1 / 3], [1 / 3, 2 / 3]])),
@@ -605,7 +610,10 @@ def test_get_label_quality_scores_output(labels, pred_probs, scorer):
         "Handle more than 8 classes",
     ],
 )
-def test_multilabel_py(given_labels, expected):
+def test_multilabel_py(given_labels, expected, request):
+    given_labels = (
+        request.getfixturevalue(given_labels) if isinstance(given_labels, str) else given_labels
+    )
     py = ml_scorer.multilabel_py(given_labels)
     assert isinstance(py, np.ndarray)
     assert py.shape == (given_labels.shape[1], 2)


### PR DESCRIPTION
## Summary

### Update Pre-commit Configuration and Refactor Code for Clarity and Test Compatibility

This PR updates the pre-commit configuration by upgrading the version of the `black` formatter and includes several refactorings in the `cleanlab` codebase to enhance readability and maintain compatibility with pytest features. The changes primarily involve formatting adjustments and a workaround for the deprecated `pytest-lazy-fixture` plugin.

**Changes:**
1. Updated `.pre-commit-config.yaml` to use [`black` version 24.1.1](https://github.com/psf/black/releases/tag/24.1.1).
2. Adjusted black formatting of several long lines
    ```python
    # Example of formatting

    # Before:
    k: int = 0  # Used to check if the knn graph needs to be recomputed, already set in the knn object

    # After:
    # Used to check if the knn graph needs to be recomputed, already set in the knn object
    k: int = 0
    ```
3. Removed `pytest-lazy-fixture` from `requirements-dev.txt` as it is incompatible with the latest releases of pytest (8.0.0).
4. Updated tests to replace `pytest.lazy_fixture` with a workaround for handling test fixtures.
5. Only keep pytest versions compatible with v7.4
  - Pytest 8.0.0 is likely causing a single test case for the KerasModelWrapper to fail out of the blue.



## Impact

**Areas Affected:**
- Pre-commit configuration
- Code readability and formatting in `cleanlab/datalab/internal/issue_manager/`
- Test compatibility and setup in `tests/`

**Who’s Affected:**
- Developers working with the `cleanlab` codebase and tests.

## Testing

**Testing Done:**
- Verified that the updated pre-commit configuration works correctly with the new `black` version.
- Ensured that the refactored code retains its original functionality.
- Ran the modified tests to confirm they pass without `pytest-lazy-fixture`.

**Unaddressed Cases:**
- Further testing might be needed to ensure compatibility with future versions of related libraries.

## Links to Relevant Issues or Conversations

pytest-lazy-fixture doesn't fully support the recent release of pytest 8.0.0
[Here's the relevant issue](https://github.com/TvoroG/pytest-lazy-fixture/issues/65).
A suggested fix for that issue is applied to our tests in this PR.

<details><summary>Click to see original comment</summary>
<p>

[Link to original comment](https://github.com/TvoroG/pytest-lazy-fixture/issues/65#issuecomment-1914527162).

> Since this repo's main branch has been waiting for an update for two years, I've been looking for an alternative. In my case, I was using something like this:
> 
> ```python
> # In conftest.py:
> @pytest.fixture
> def test_api_sqlite_mp(test_sqlite_mp):
>     return Platform(_backend=RestTestBackend(test_sqlite_mp.backend))
> 
> 
> @pytest.fixture
> def test_api_pgsql_mp(test_pgsql_mp):
>     return Platform(_backend=RestTestBackend(test_pgsql_mp.backend))
> 
> # In another file:
> api_platforms = pytest.mark.parametrize(
>     "test_mp",
>     [
>         pytest.lazy_fixture("test_api_sqlite_mp"),
>         pytest.lazy_fixture("test_api_pgsql_mp"),
>     ],
> )
> 
> # And finally, for the function:
> @api_platforms
> def test_index_model(test_mp):
>     ...
> ```
> 
> So following suggestions on [StackOverflow](https://stackoverflow.com/questions/42014484/pytest-using-fixtures-as-arguments-in-parametrize) and [here](https://engineeringfordatascience.com/posts/pytest_fixtures_with_parameterize/), I changed that to
> 
> ```python
> # In conftest.py (everything stays the same):
> @pytest.fixture
> def test_api_sqlite_mp(test_sqlite_mp):
>     return Platform(_backend=RestTestBackend(test_sqlite_mp.backend))
> 
> 
> @pytest.fixture
> def test_api_pgsql_mp(test_pgsql_mp):
>     return Platform(_backend=RestTestBackend(test_pgsql_mp.backend))
> 
> # In another file:
> api_platforms = pytest.mark.parametrize(
>     "test_mp",
>     [
>         "test_api_sqlite_mp",
>         "test_api_pgsql_mp",
>     ],
> )
> 
> # And finally, for the function:
> @api_platforms
> def test_index_model(test_mp, request):
>     test_mp = request.getfixturevalue(test_mp)
>     ...
> ```
> 
> After uninstalling pytest-lazy-fixture, my tests are running just fine again. Hope this helps :)


</p>
</details> 

