### PR TITLE
Increase deadline for test_find_label_issues for multilabel data

### DIFF
--- a/tests/test_multilabel_classification.py
+++ b/tests/test_multilabel_classification.py
@@ -774,7 +774,7 @@ def cleanlab_data_strategy(draw):
 
 class TestMultiLabel:
     @given(cleanlab_data_strategy())
-    @settings(deadline=10000)
+    @settings(deadline=20000)
     def test_find_label_issues(self, data):
         true_labels, noisy_labels, pred_probs = data
         noisy_labels_list = onehot2int(noisy_labels)


### PR DESCRIPTION
The multilabel property-based test for find_label_issue is flaky (on macOS in CI), with some runs exceeding the deadline but making it in a subsequent run.
To address this, I'm increasing the deadline from 10 seconds to 20 seconds.