### PR TITLE
Add underperforming_group issue type among the Datalab defaults

### DIFF
--- a/cleanlab/datalab/internal/issue_manager_factory.py
+++ b/cleanlab/datalab/internal/issue_manager_factory.py
@@ -223,6 +223,7 @@ def list_default_issue_types(task: str) -> List[str]:
             "near_duplicate",
             "non_iid",
             "class_imbalance",
+            "underperforming_group",
         ],
         "regression": [
             "null",

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -89,6 +89,7 @@ class TestDatalab:
             "near_duplicate",
             "non_iid",
             "class_imbalance",
+            "underperforming_group",
         ]
 
     def tmp_path(self):

--- a/tests/datalab/test_cleanvision_integration.py
+++ b/tests/datalab/test_cleanvision_integration.py
@@ -32,7 +32,7 @@ class TestCleanvisionIntegration:
 
     @pytest.fixture
     def num_datalab_issues(self):
-        return 5
+        return 6
 
     @pytest.fixture
     def pred_probs(self, image_dataset):
@@ -69,6 +69,7 @@ class TestCleanvisionIntegration:
             "near_duplicate",
             "class_imbalance",
             "null",
+            "underperforming_group",
             # "non_iid",
         ]
 
@@ -94,12 +95,14 @@ class TestCleanvisionIntegration:
                     "near_duplicate",
                     "class_imbalance",
                     "null",
+                    "underperforming_group",
                 ],
-                "num_issues": [1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+                "num_issues": [1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
             }
         )
         expected_count = df.sort_values(by="issue_type")["num_issues"].tolist()
         count = datalab.issue_summary.sort_values(by="issue_type")["num_issues"].tolist()
+        assert set(datalab.issue_summary["issue_type"].tolist()) == set(df["issue_type"].tolist())
         assert count == expected_count
         assert datalab.issue_summary["num_issues"].sum() == df["num_issues"].sum()
 
@@ -147,7 +150,15 @@ class TestCleanvisionIntegration:
         assert len(datalab.issues.columns) == num_datalab_issues * 2
         assert len(datalab.issue_summary) == num_datalab_issues
 
-        all_keys = ["statistics", "label", "outlier", "near_duplicate", "class_imbalance", "null"]
+        all_keys = [
+            "statistics",
+            "label",
+            "outlier",
+            "near_duplicate",
+            "class_imbalance",
+            "null",
+            "underperforming_group",
+        ]
 
         assert set(all_keys) == set(datalab.info.keys())
         datalab.report()


### PR DESCRIPTION
Closes #910
