### PR TITLE
Multilabel class order

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -194,10 +194,10 @@ class Datalab:
             To best detect label issues, provide this input obtained from the most accurate model you can produce.
 
             For classification data, this must be a 2D array with shape ``(num_examples, K)`` where ``K`` is the number of classes in the dataset.
-                The columns of this array should be lexicographically ordered by class name.
+                Make sure that the columns of your `pred_probs` are properly ordered with respect to the ordering of classes, which for Datalab is: lexicographically sorted by class name.
             For regression data, this must be a 1D array with shape ``(num_examples,)`` containing the predicted value for each example.
             For multilabel classification data, this must be a 2D array with shape ``(num_examples, K)`` where ``K`` is the number of classes in the dataset.
-                The columns of this array should be lexicographically ordered by class name.
+                Make sure that the columns of your `pred_probs` are properly ordered with respect to the ordering of classes, which for Datalab is: lexicographically sorted by class name.
 
 
         features : Optional[np.ndarray]

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -90,9 +90,6 @@ class Datalab:
     label_name : str, optional
         The name of the label column in the dataset.
 
-        In the case of classification (both multiclass and multilabel), the labels are internally mapped to integers in a [0, 1, ..., K-1] format,
-        ordered lexicographically by class name. Make sure that your model's predictions reflect this ordering.
-
     image_key : str, optional
         Optional key that can be specified for image datasets to point to the field containing the actual images themselves.
         If specified, additional image-specific issue types can be detected in the dataset.

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -90,6 +90,9 @@ class Datalab:
     label_name : str, optional
         The name of the label column in the dataset.
 
+        In the case of classification (both multiclass and multilabel), the labels are internally mapped to integers in a [0, 1, ..., K-1] format,
+        ordered lexicographically by class name. Make sure that your model's predictions reflect this ordering.
+
     image_key : str, optional
         Optional key that can be specified for image datasets to point to the field containing the actual images themselves.
         If specified, additional image-specific issue types can be detected in the dataset.
@@ -191,7 +194,11 @@ class Datalab:
             To best detect label issues, provide this input obtained from the most accurate model you can produce.
 
             For classification data, this must be a 2D array with shape ``(num_examples, K)`` where ``K`` is the number of classes in the dataset.
+                The columns of this array should be lexicographically ordered by class name.
             For regression data, this must be a 1D array with shape ``(num_examples,)`` containing the predicted value for each example.
+            For multilabel classification data, this must be a 2D array with shape ``(num_examples, K)`` where ``K`` is the number of classes in the dataset.
+                The columns of this array should be lexicographically ordered by class name.
+
 
         features : Optional[np.ndarray]
             Feature embeddings (vector representations) of every example in the dataset.

--- a/cleanlab/datalab/internal/data.py
+++ b/cleanlab/datalab/internal/data.py
@@ -327,7 +327,8 @@ class MultiLabel(Label):
         self, data: Dataset, label_name: str, map_to_int: bool
     ) -> Tuple[List[List[int]], Dict[int, Any]]:
         labels: List[List[int]] = labels_to_list_multilabel(data[label_name])
-        unique_labels = set((x for ele in labels for x in ele))
+        # label_map needs to be lexicographically sorted. np.unique should sort it
+        unique_labels = np.unique([x for ele in labels for x in ele])
         label_map = {label: i for i, label in enumerate(unique_labels)}
         formatted_labels = [[label_map[item] for item in label] for label in labels]
         inverse_map = {i: label for label, i in label_map.items()}

--- a/docs/source/tutorials/audio.ipynb
+++ b/docs/source/tutorials/audio.ipynb
@@ -479,7 +479,7 @@
     "To identify label issues, cleanlab requires a probabilistic prediction from your model for every datapoint that should be considered. However these predictions will be _overfit_ (and thus unreliable) for datapoints the model was previously trained on. cleanlab is intended to only be used with **out-of-sample** predicted probabilities, i.e. on datapoints held-out from the model during the training.\n",
     "\n",
     "K-fold cross-validation is a straightforward way to produce out-of-sample predicted probabilities for every datapoint in the dataset, by training K copies of our model on different data subsets and using each copy to predict on the subset of data it did not see during training. An additional benefit of cross-validation is that it provides more reliable evaluation of our model than a single training/validation split. We can obtain cross-validated out-of-sample predicted probabilities from any classifier via the [cross_val_predict](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_val_predict.html) wrapper provided in scikit-learn.\n",
-    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name.\n"
+    "Make sure that the columns of your `pred_probs` are properly ordered with respect to the ordering of classes, which for Datalab is: lexicographically sorted by class name.\n"
    ]
   },
   {

--- a/docs/source/tutorials/audio.ipynb
+++ b/docs/source/tutorials/audio.ipynb
@@ -478,7 +478,8 @@
     "\n",
     "To identify label issues, cleanlab requires a probabilistic prediction from your model for every datapoint that should be considered. However these predictions will be _overfit_ (and thus unreliable) for datapoints the model was previously trained on. cleanlab is intended to only be used with **out-of-sample** predicted probabilities, i.e. on datapoints held-out from the model during the training.\n",
     "\n",
-    "K-fold cross-validation is a straightforward way to produce out-of-sample predicted probabilities for every datapoint in the dataset, by training K copies of our model on different data subsets and using each copy to predict on the subset of data it did not see during training. An additional benefit of cross-validation is that it provides more reliable evaluation of our model than a single training/validation split. We can obtain cross-validated out-of-sample predicted probabilities from any classifier via the [cross_val_predict](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_val_predict.html) wrapper provided in scikit-learn.\n"
+    "K-fold cross-validation is a straightforward way to produce out-of-sample predicted probabilities for every datapoint in the dataset, by training K copies of our model on different data subsets and using each copy to predict on the subset of data it did not see during training. An additional benefit of cross-validation is that it provides more reliable evaluation of our model than a single training/validation split. We can obtain cross-validated out-of-sample predicted probabilities from any classifier via the [cross_val_predict](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_val_predict.html) wrapper provided in scikit-learn.\n",
+    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name.\n"
    ]
   },
   {
@@ -776,7 +777,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/datalab/datalab_advanced.ipynb
+++ b/docs/source/tutorials/datalab/datalab_advanced.ipynb
@@ -510,7 +510,8 @@
     "To detect certain types of issues in classification data (e.g. label errors), `Datalab` relies on predicted class probabilities from a trained model. Ideally, the prediction for each example should be out-of-sample (to avoid overfitting), coming from a copy of the model that was not trained on this example. \n",
     "\n",
     "This tutorial uses a simple logistic regression model \n",
-    "and the `cross_val_predict()` function from scikit-learn to generate out-of-sample predicted class probabilities for every example in the training set. You can replace this with *any* other classifier model and train it with cross-validation to get out-of-sample predictions."
+    "and the `cross_val_predict()` function from scikit-learn to generate out-of-sample predicted class probabilities for every example in the training set. You can replace this with *any* other classifier model and train it with cross-validation to get out-of-sample predictions.\n",
+    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name."
    ]
   },
   {

--- a/docs/source/tutorials/datalab/datalab_advanced.ipynb
+++ b/docs/source/tutorials/datalab/datalab_advanced.ipynb
@@ -511,7 +511,7 @@
     "\n",
     "This tutorial uses a simple logistic regression model \n",
     "and the `cross_val_predict()` function from scikit-learn to generate out-of-sample predicted class probabilities for every example in the training set. You can replace this with *any* other classifier model and train it with cross-validation to get out-of-sample predictions.\n",
-    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name."
+    "Make sure that the columns of your `pred_probs` are properly ordered with respect to the ordering of classes, which for Datalab is: lexicographically sorted by class name."
    ]
   },
   {

--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -537,7 +537,7 @@
     "\n",
     "This tutorial uses a simple logistic regression model \n",
     "and the `cross_val_predict()` function from scikit-learn to generate out-of-sample predicted class probabilities for every example in the training set. You can replace this with *any* other classifier model and train it with cross-validation to get out-of-sample predictions.\n",
-    "Make sure that the columns of are ordered lexigoraphically by class name."
+    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name."
    ]
   },
   {

--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -537,7 +537,7 @@
     "\n",
     "This tutorial uses a simple logistic regression model \n",
     "and the `cross_val_predict()` function from scikit-learn to generate out-of-sample predicted class probabilities for every example in the training set. You can replace this with *any* other classifier model and train it with cross-validation to get out-of-sample predictions.\n",
-    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name."
+    "Make sure that the columns of your `pred_probs` are properly ordered with respect to the ordering of classes, which for Datalab is: lexicographically sorted by class name."
    ]
   },
   {
@@ -681,15 +681,6 @@
     ")\n",
     "\n",
     "examples_w_issue.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lab._label_map"
    ]
   },
   {

--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -536,7 +536,8 @@
     "To detect certain types of issues in classification data (e.g. label errors), `Datalab` relies on predicted class probabilities from a trained model. Ideally, the prediction for each example should be out-of-sample (to avoid overfitting), coming from a copy of the model that was not trained on this example. \n",
     "\n",
     "This tutorial uses a simple logistic regression model \n",
-    "and the `cross_val_predict()` function from scikit-learn to generate out-of-sample predicted class probabilities for every example in the training set. You can replace this with *any* other classifier model and train it with cross-validation to get out-of-sample predictions."
+    "and the `cross_val_predict()` function from scikit-learn to generate out-of-sample predicted class probabilities for every example in the training set. You can replace this with *any* other classifier model and train it with cross-validation to get out-of-sample predictions.\n",
+    "Make sure that the columns of are ordered lexigoraphically by class name."
    ]
   },
   {
@@ -683,6 +684,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lab._label_map"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -763,7 +773,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   },
   "vscode": {
    "interpreter": {

--- a/docs/source/tutorials/datalab/tabular.ipynb
+++ b/docs/source/tutorials/datalab/tabular.ipynb
@@ -220,7 +220,8 @@
    "source": [
     "To find potential labeling errors, cleanlab requires a probabilistic prediction from your model for every datapoint. However, these predictions will be _overfitted_ (and thus unreliable) for examples the model was previously trained on. For the best results, cleanlab should be applied with **out-of-sample** predicted class probabilities, i.e., on examples held out from the model during the training.\n",
     "\n",
-    "K-fold cross-validation is a straightforward way to produce out-of-sample predicted probabilities for every datapoint in the dataset by training K copies of our model on different data subsets and using each copy to predict on the subset of data it did not see during training. We can implement this via the `cross_val_predict` method from scikit-learn:\n"
+    "K-fold cross-validation is a straightforward way to produce out-of-sample predicted probabilities for every datapoint in the dataset by training K copies of our model on different data subsets and using each copy to predict on the subset of data it did not see during training. Make sure that the columns of your `pred_probs` are lexicographically ordered by class name.\n",
+    "We can implement this via the `cross_val_predict` method from scikit-learn.\n"
    ]
   },
   {

--- a/docs/source/tutorials/datalab/tabular.ipynb
+++ b/docs/source/tutorials/datalab/tabular.ipynb
@@ -220,7 +220,7 @@
    "source": [
     "To find potential labeling errors, cleanlab requires a probabilistic prediction from your model for every datapoint. However, these predictions will be _overfitted_ (and thus unreliable) for examples the model was previously trained on. For the best results, cleanlab should be applied with **out-of-sample** predicted class probabilities, i.e., on examples held out from the model during the training.\n",
     "\n",
-    "K-fold cross-validation is a straightforward way to produce out-of-sample predicted probabilities for every datapoint in the dataset by training K copies of our model on different data subsets and using each copy to predict on the subset of data it did not see during training. Make sure that the columns of your `pred_probs` are lexicographically ordered by class name.\n",
+    "K-fold cross-validation is a straightforward way to produce out-of-sample predicted probabilities for every datapoint in the dataset by training K copies of our model on different data subsets and using each copy to predict on the subset of data it did not see during training. Make sure that the columns of your `pred_probs` are properly ordered with respect to the ordering of classes, which for Datalab is: lexicographically sorted by class name.\n",
     "We can implement this via the `cross_val_predict` method from scikit-learn.\n"
    ]
   },

--- a/docs/source/tutorials/datalab/text.ipynb
+++ b/docs/source/tutorials/datalab/text.ipynb
@@ -259,7 +259,7 @@
     "To identify label issues, cleanlab requires a probabilistic prediction from your model for each datapoint. However these predictions will be _overfit_ (and thus unreliable) for datapoints the model was previously trained on. cleanlab is intended to only be used with **out-of-sample** predicted class probabilities, i.e. on datapoints held-out from the model during the training.\n",
     "\n",
     "Here we obtain out-of-sample predicted class probabilities for every example in our dataset using a Logistic Regression model with cross-validation.\n",
-    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name."
+    "Make sure that the columns of your `pred_probs` are properly ordered with respect to the ordering of classes, which for Datalab is: lexicographically sorted by class name."
    ]
   },
   {

--- a/docs/source/tutorials/datalab/text.ipynb
+++ b/docs/source/tutorials/datalab/text.ipynb
@@ -258,7 +258,8 @@
     "\n",
     "To identify label issues, cleanlab requires a probabilistic prediction from your model for each datapoint. However these predictions will be _overfit_ (and thus unreliable) for datapoints the model was previously trained on. cleanlab is intended to only be used with **out-of-sample** predicted class probabilities, i.e. on datapoints held-out from the model during the training.\n",
     "\n",
-    "Here we obtain out-of-sample predicted class probabilities for every example in our dataset using a Logistic Regression model with cross-validation."
+    "Here we obtain out-of-sample predicted class probabilities for every example in our dataset using a Logistic Regression model with cross-validation.\n",
+    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name."
    ]
   },
   {
@@ -596,7 +597,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/image.ipynb
+++ b/docs/source/tutorials/image.ipynb
@@ -595,7 +595,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Reorder rows of the dataset based on row order in `features` and `pred_probs`. **Carefully ensure your ordering of the dataset matches these objects!**"
+    "Reorder rows of the dataset based on row order in `features` and `pred_probs`. **Carefully ensure your ordering of the dataset matches these objects!**\n",
+    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name."
    ]
   },
   {
@@ -1311,7 +1312,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.11.7"
   },
   "orig_nbformat": 4
  },

--- a/docs/source/tutorials/image.ipynb
+++ b/docs/source/tutorials/image.ipynb
@@ -596,7 +596,7 @@
    "metadata": {},
    "source": [
     "Reorder rows of the dataset based on row order in `features` and `pred_probs`. **Carefully ensure your ordering of the dataset matches these objects!**\n",
-    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name."
+    "Make sure that the columns of your `pred_probs` are properly ordered with respect to the ordering of classes, which for Datalab is: lexicographically sorted by class name."
    ]
   },
   {

--- a/docs/source/tutorials/indepth_overview.ipynb
+++ b/docs/source/tutorials/indepth_overview.ipynb
@@ -377,7 +377,7 @@
     "\n",
     "Pass in the predicted probabilities and feature embeddings for your data and Datalab will do all the work!\n",
     "You do not necessarily need to provide all of this information depending on which types of issues you are interested in, but the more inputs you provide, the more types of issues `Datalab` can detect in your data. Using a better model to produce these inputs will ensure cleanlab more accurately estimates issues.\n",
-    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name."
+    "Make sure that the columns of your `pred_probs` are properly ordered with respect to the ordering of classes, which for Datalab is: lexicographically sorted by class name."
    ]
   },
   {

--- a/docs/source/tutorials/indepth_overview.ipynb
+++ b/docs/source/tutorials/indepth_overview.ipynb
@@ -376,7 +376,8 @@
     "All that is need to audit your data is initalize a Datalab object with your dataset and call `find_issues()`. \n",
     "\n",
     "Pass in the predicted probabilities and feature embeddings for your data and Datalab will do all the work!\n",
-    "You do not necessarily need to provide all of this information depending on which types of issues you are interested in, but the more inputs you provide, the more types of issues `Datalab` can detect in your data. Using a better model to produce these inputs will ensure cleanlab more accurately estimates issues."
+    "You do not necessarily need to provide all of this information depending on which types of issues you are interested in, but the more inputs you provide, the more types of issues `Datalab` can detect in your data. Using a better model to produce these inputs will ensure cleanlab more accurately estimates issues.\n",
+    "Make sure that the columns of your `pred_probs` are lexicographically ordered by class name."
    ]
   },
   {

--- a/docs/source/tutorials/multilabel_classification.ipynb
+++ b/docs/source/tutorials/multilabel_classification.ipynb
@@ -404,7 +404,9 @@
     "## 2. Format data, labels, and model predictions\n",
     "\n",
     "In multi-label classification, each example in the dataset is labeled as belonging to one **or more** of *K* possible classes (or none of the classes at all). To find label issues, cleanlab requires predicted class probabilities from a trained classifier. \n",
-    "Here we produce out-of-sample `pred_probs` by employing cross-validation to fit a multi-label **RandomForestClassifier** model via sklearn's [OneVsRestClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.multiclass.OneVsRestClassifier.html) framework. `OneVsRestClassifier` offers an easy way to apply any multi-class classifier model from sklearn to multi-label classification tasks. It is done for simplicity here, but we advise against this approach as it does not properly model dependencies between classes.\n",
+    "Here we produce out-of-sample `pred_probs` by employing cross-validation to fit a multi-label **RandomForestClassifier** model via sklearn's [OneVsRestClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.multiclass.OneVsRestClassifier.html) framework. \n",
+    "Note that the columns of `pred_probs` need to be lexicographically ordered by class name (i.e. the first column corresponds to the first class, the second column to the second class, and so on).\n",
+    "`OneVsRestClassifier` offers an easy way to apply any multi-class classifier model from sklearn to multi-label classification tasks. It is done for simplicity here, but we advise against this approach as it does not properly model dependencies between classes.\n",
     "\n",
     "To instead train a state-of-the-art Pytorch neural network for multi-label classification and produce `pred_probs` on a real image dataset (that properly account for dependencies between classes), see our [example](https://github.com/cleanlab/examples) notebook [\"Train a neural network for multi-label classification on the CelebA dataset\"](https://github.com/cleanlab/examples/blob/master/multilabel_classification/pytorch_network_training.ipynb). "
    ]

--- a/docs/source/tutorials/multilabel_classification.ipynb
+++ b/docs/source/tutorials/multilabel_classification.ipynb
@@ -405,7 +405,7 @@
     "\n",
     "In multi-label classification, each example in the dataset is labeled as belonging to one **or more** of *K* possible classes (or none of the classes at all). To find label issues, cleanlab requires predicted class probabilities from a trained classifier. \n",
     "Here we produce out-of-sample `pred_probs` by employing cross-validation to fit a multi-label **RandomForestClassifier** model via sklearn's [OneVsRestClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.multiclass.OneVsRestClassifier.html) framework. \n",
-    "Note that the columns of `pred_probs` need to be lexicographically ordered by class name (i.e. the first column corresponds to the first class, the second column to the second class, and so on).\n",
+    "Make sure that the columns of your `pred_probs` are properly ordered with respect to the ordering of classes, which for Datalab is: lexicographically sorted by class name.\n",
     "`OneVsRestClassifier` offers an easy way to apply any multi-class classifier model from sklearn to multi-label classification tasks. It is done for simplicity here, but we advise against this approach as it does not properly model dependencies between classes.\n",
     "\n",
     "To instead train a state-of-the-art Pytorch neural network for multi-label classification and produce `pred_probs` on a real image dataset (that properly account for dependencies between classes), see our [example](https://github.com/cleanlab/examples) notebook [\"Train a neural network for multi-label classification on the CelebA dataset\"](https://github.com/cleanlab/examples/blob/master/multilabel_classification/pytorch_network_training.ipynb). "

--- a/docs/source/tutorials/regression.ipynb
+++ b/docs/source/tutorials/regression.ipynb
@@ -742,7 +742,7 @@
     "    label_issues_cl.rename(columns={\"label_quality\": \"label_score\"}), \n",
     "    # Datalab DataFrame\n",
     "    label_issues,\n",
-    ")\n"
+    ")"
    ]
   }
  ],

--- a/tests/datalab/test_data.py
+++ b/tests/datalab/test_data.py
@@ -14,8 +14,8 @@ NUM_COLS = 2
 
 
 @st.composite
-def dataset_strategy(draw):
-    # Deifine strategies
+def multiclass_dataset_strategy(draw):
+    # Define strategies
     int_feature_strategy = st.integers(min_value=-10, max_value=10)
     float_feature_strategy = st.floats(min_value=-10, max_value=10)
     column_name_strategy = st.text(min_size=5, max_size=5)
@@ -36,6 +36,52 @@ def dataset_strategy(draw):
     assume(len(set(dataset["label"])) > 1)
 
     return dataset
+
+
+@st.composite
+def multilabel_dataset_strategy(draw):
+    # Define strategies
+    int_feature_strategy = st.integers(min_value=-10, max_value=10)
+    float_feature_strategy = st.floats(min_value=-10, max_value=10)
+    column_name_strategy = st.text(min_size=5, max_size=5)
+    column_data_strategy = st.one_of(int_feature_strategy, float_feature_strategy)
+
+    # Draw values
+    col_names = draw(
+        st.lists(column_name_strategy, min_size=NUM_COLS, max_size=NUM_COLS + 1, unique=True)
+    )
+    label_name = draw(st.sampled_from(col_names))
+    classes_strategy = st.lists(
+        st.text(min_size=3, max_size=3), min_size=2, max_size=3, unique=True
+    )
+    classes = draw(classes_strategy)
+    labels_strategy = st.lists(
+        st.lists(st.sampled_from(classes), min_size=1, max_size=3, unique=True),
+        min_size=5,
+        max_size=5,
+    )
+    # TODO - Make the sampling work nicely for min_size=0 (i.e. no labels for a sample)
+    data = {
+        name: draw(st.lists(column_data_strategy, min_size=5, max_size=5)) for name in col_names
+    }
+    data[label_name] = draw(labels_strategy)
+    dataset = Dataset.from_dict(data)
+    dataset = dataset.rename_column(label_name, "label")
+
+    # Make assertions about drawn values
+    assume(len(set(l for labels in dataset["label"] for l in labels)) > 1)
+
+    return dataset
+
+
+@st.composite
+def dataset_strategy(draw, task=Task.CLASSIFICATION):
+    if task == Task.CLASSIFICATION:
+        return draw(multiclass_dataset_strategy())
+    elif task == Task.MULTILABEL:
+        return draw(multilabel_dataset_strategy())
+    else:
+        raise ValueError(f"Unsupported task: {task}")
 
 
 class TestData:
@@ -162,3 +208,15 @@ class TestData:
                 Data._load_dataset_from_string("non_external_dataset")
 
             expected_error_substring = "Failed to load dataset from <class 'str'>.\n"
+
+    @given(dataset=dataset_strategy(task=Task.CLASSIFICATION))
+    def test_label_map_is_lexicographically_ordered(self, dataset):
+        data = Data(data=dataset, task=Task.CLASSIFICATION, label_name="label")
+        label_map = data.labels.label_map
+        assert list(label_map.keys()) == sorted(label_map.keys())
+
+    @given(dataset=dataset_strategy(task=Task.MULTILABEL))
+    def test_label_map_is_lexicographically_ordered_multilabel(self, dataset):
+        data = Data(data=dataset, task=Task.MULTILABEL, label_name="label")
+        label_map = data.labels.label_map
+        assert list(label_map.keys()) == sorted(label_map.keys())


### PR DESCRIPTION
Fix class order for multilabel support in Datalab.

The label map previously wasn't always sorted by class names lexicographically.
I've added a property-based test that ensures that internally that the map respects that order (for classification).
I've also added a comment on this on some of the major docs.

Addresses #991 