### PR TITLE
Make features optional in Underperforming Group issue check

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/underperforming_group.py
+++ b/cleanlab/datalab/internal/issue_manager/underperforming_group.py
@@ -95,8 +95,8 @@ class UnderperformingGroupIssueManager(IssueManager):
 
     def find_issues(
         self,
-        features: npt.NDArray,
         pred_probs: npt.NDArray,
+        features: Optional[npt.NDArray] = None,
         cluster_ids: Optional[npt.NDArray[np.int_]] = None,
         **kwargs: Any,
     ) -> None:
@@ -145,7 +145,7 @@ class UnderperformingGroupIssueManager(IssueManager):
         )
 
     def set_knn_graph(
-        self, features: npt.NDArray, find_issues_kwargs: Dict[str, Any]
+        self, features: Optional[npt.NDArray], find_issues_kwargs: Dict[str, Any]
     ) -> csr_matrix:
         knn_graph = self._process_knn_graph_from_inputs(find_issues_kwargs)
         old_knn_metric = self.datalab.get_info("statistics").get("knn_metric")


### PR DESCRIPTION
The issue manager will resolve whether it requires features or not.

This should fix the tabular tutorial:

**Before the change**

`Datalab.find_issues` would output:

``` 
Finding label issues ...
Finding outlier issues ...
Finding near_duplicate issues ...
Finding non_iid issues ...
Finding class_imbalance issues ...
Finding underperforming_group issues ...
Error in underperforming_group: UnderperformingGroupIssueManager.find_issues() missing 1 required positional argument: 'features'
Failed to check for these issue types: [UnderperformingGroupIssueManager]
```



**After change**

Now it outputs

```
Finding label issues ...
Finding outlier issues ...
Finding near_duplicate issues ...
Finding non_iid issues ...
Finding class_imbalance issues ...
Finding underperforming_group issues ...
```