### PR TITLE
Improve the datalab.display module

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -136,10 +136,10 @@ class Datalab:
 
     # todo: check displayer methods
     def __repr__(self) -> str:
-        return _Displayer(data_issues=self.data_issues).__repr__()
+        return _Displayer(data_issues=self.data_issues, task=self.task).__repr__()
 
     def __str__(self) -> str:
-        return _Displayer(data_issues=self.data_issues).__str__()
+        return _Displayer(data_issues=self.data_issues, task=self.task).__str__()
 
     @property
     def labels(self) -> Union[np.ndarray, List[List[int]]]:

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -65,6 +65,7 @@ class TestDatalab:
         captured = capsys.readouterr()
         expected_output = (
             "Datalab:\n"
+            "Task: Classification\n"
             "Checks run: No\n"
             "Number of examples: 5\n"
             "Number of classes: 3\n"


### PR DESCRIPTION
Introduce a strategy pattern for displaying Datalab for different kinds of tasks.
Configuring the strategy for different tasks involves selecting "show_x" methods from a parent strategy class.

Fixes #989

---

If Datalab is now instantiated without labels (i.e., for unsupervised learning tasks) or regression (that doesn't define classes), the displayer correctly handles such cases.