### PR TITLE
Update tqdm import to use tqdm.autonotebook in image tutorial

### DIFF
--- a/docs/source/tutorials/image.ipynb
+++ b/docs/source/tutorials/image.ipynb
@@ -116,7 +116,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from tqdm import tqdm\n",
+    "from tqdm.autonotebook import tqdm\n",
     "import math\n",
     "import time\n",
     "import multiprocessing\n",


### PR DESCRIPTION
The customizable tqdm.tqdm progressbar gives weird output in nbsphinx.

### Before change
As seen on the docs page for master
![image](https://github.com/cleanlab/cleanlab/assets/18127060/a2bf261a-b51c-43ed-a2d9-253856f4a7e3)

### After change
Local build (ignore the long training time of each epoch):
![image](https://github.com/cleanlab/cleanlab/assets/18127060/51e377fb-6e27-4092-919f-75ed9a0a598a)
