### PR TITLE
Pin nbconvert version in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 jinja2==3.1.3
 sphinx==7.1.2
 sphinx-tabs==3.4.5
+nbconvert==7.13.1
 nbsphinx==0.9.3
 autodocsumm==0.2.12
 furo==2023.09.10


### PR DESCRIPTION
Pin it to version 7.13 to avoid possible tqdm error, discussed in https://github.com/jupyter/nbconvert/issues/2092

Possibly resolves weird tqdm outputs in notebook tutorials in the docs.