### PR TITLE
Add ignore_url for forbidden Stack Overflow link in links.yml

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -25,6 +25,8 @@ jobs:
           ignore_missing_alt: true
           tokens: |
             {"https://github.com": "${{ secrets.GITHUB_TOKEN }}"}
+          ignore_url: |
+            https://stackoverflow.com/questions/41573587/what-is-the-difference-between-venv-pyvenv-pyenv-virtualenv-virtualenvwrappe
           swap_urls: |
             {"^(\\..*)\\.md(#?.*)$": "\\1.md.html\\2",
              "^(https://github\\.com/.*)#.*$": "\\1"}


### PR DESCRIPTION
Let the link-checker ignore the following link:

https://stackoverflow.com/questions/41573587/what-is-the-difference-between-venv-pyvenv-pyenv-virtualenv-virtualenvwrappe

to pass CI. It's fine since it's a non-critical link in the development guide.

## Example of CI failing on this link

![image](https://github.com/cleanlab/cleanlab/assets/18127060/8d066c58-a3e9-4ea3-a50f-ef333b9df10d)
