### PR TITLE
Support features as input for data valuation check in Datalab

### DIFF
--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -59,7 +59,7 @@ _CLASSIFICATION_ARGS_DICT = {
     "near_duplicate": ["features", "knn_graph"],
     "non_iid": ["pred_probs", "features", "knn_graph"],
     "underperforming_group": ["pred_probs", "features", "knn_graph", "cluster_ids"],
-    "data_valuation": ["knn_graph"],
+    "data_valuation": ["features", "knn_graph"],
     "class_imbalance": [],
     "null": ["features"],
 }
@@ -68,6 +68,7 @@ _REGRESSION_ARGS_DICT = {
     "outlier": ["features", "knn_graph"],
     "near_duplicate": ["features", "knn_graph"],
     "non_iid": ["features", "knn_graph"],
+    "data_valuation": ["features", "knn_graph"],
     "null": ["features"],
 }
 
@@ -76,6 +77,7 @@ _MULTILABEL_ARGS_DICT = {
     "outlier": ["features", "knn_graph"],
     "near_duplicate": ["features", "knn_graph"],
     "non_iid": ["features", "knn_graph"],
+    "data_valuation": ["features", "knn_graph"],
     "null": ["features"],
 }
 

--- a/cleanlab/datalab/internal/issue_manager/data_valuation.py
+++ b/cleanlab/datalab/internal/issue_manager/data_valuation.py
@@ -24,6 +24,8 @@ from typing import (
     Optional,
     Union,
 )
+import warnings
+
 
 import numpy as np
 import pandas as pd

--- a/cleanlab/datalab/internal/issue_manager_factory.py
+++ b/cleanlab/datalab/internal/issue_manager_factory.py
@@ -74,6 +74,7 @@ REGISTRY: Dict[Task, Dict[str, Type[IssueManager]]] = {
         "outlier": OutlierIssueManager,
         "near_duplicate": NearDuplicateIssueManager,
         "non_iid": NonIIDIssueManager,
+        "data_valuation": DataValuationIssueManager,
         "null": NullIssueManager,
     },
     Task.MULTILABEL: {
@@ -81,6 +82,7 @@ REGISTRY: Dict[Task, Dict[str, Type[IssueManager]]] = {
         "outlier": OutlierIssueManager,
         "near_duplicate": NearDuplicateIssueManager,
         "non_iid": NonIIDIssueManager,
+        "data_valuation": DataValuationIssueManager,
         "null": NullIssueManager,
     },
 }

--- a/tests/datalab/datalab/test_multilabel.py
+++ b/tests/datalab/datalab/test_multilabel.py
@@ -119,7 +119,7 @@ class TestDatalabForMultilabelClassification:
             ["label", "near_duplicate", "non_iid", "outlier", "null"]
         )
         assert set(lab.list_possible_issue_types()) == set(
-            ["label", "near_duplicate", "non_iid", "outlier", "null"]
+            ["label", "near_duplicate", "non_iid", "outlier", "null", "data_valuation"]
         )
 
     @pytest.mark.parametrize(

--- a/tests/datalab/datalab/test_regression.py
+++ b/tests/datalab/datalab/test_regression.py
@@ -154,7 +154,7 @@ class TestDatalabForRegression:
             ["label", "outlier", "near_duplicate", "non_iid", "null"]
         )
         assert set(lab.list_possible_issue_types()) == set(
-            ["label", "outlier", "near_duplicate", "non_iid", "null"]
+            ["label", "outlier", "near_duplicate", "non_iid", "null", "data_valuation"]
         )
 
     def test_regression_with_features_finds_label_issues(self, lab, regression_data):


### PR DESCRIPTION
## Summary

Let `DataValuationIssueManager` accept `features` as input to construct a `knn_graph` for estimating Data Shapely 
 values of every data point in the dataset.

```python
# Example code snippet
import numpy as np
from cleanlab import Datalab

X, y = np.random.rand(20, 2), np.random.randint(0,2,20)
lab = Datalab(data={"X": X, "y": y}, label_name="y")

# Passing in `features` should work with this change
lab.find_issues(features=X, issue_types={"data_valuation": {}})

# data-valuation results should appear in the report like so
lab.report(show_all_issues = True)
```

## Links to Relevant Issues or Conversations

Closes #928 

