### PR TITLE
List out issue names for each issue type in Datalab Issue Type Guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -240,7 +240,7 @@ Do not add your new issue type to the set of issues that Datalab detects by defa
 
 Don't forget to update the [issue type descriptions guide](https://github.com/cleanlab/cleanlab/blob/master/docs/source/cleanlab/datalab/guide/issue_type_description.rst) with a brief description of your new issue type.
 It is ideal to stick to a format that maintains consistency and readability.
-Generally, the format includes a title, explanation, required arguments, then any additional information.
+Generally, the format includes a title, explanation of the issue, required arguments, then any additional information.
 It would be helpful to include a tip for users on how to detect the issue using Datalab.
 
 Try to add tests for this new issue type. It's a good idea to start with some tests in a separate module in the [issue manager test directory](https://github.com/cleanlab/cleanlab/tree/master/tests/datalab/issue_manager). 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -239,8 +239,24 @@ To contribute a new type of issue that Datalab can automatically detect in any d
 Do not add your new issue type to the set of issues that Datalab detects by default, our team can add it to this default set later on once it's utility has been thoroughly validated.
 
 Don't forget to update the [issue type descriptions guide](https://github.com/cleanlab/cleanlab/blob/master/docs/source/cleanlab/datalab/guide/issue_type_description.rst) with a brief description of your new issue type.
+It is crucial to follow the specified format to maintain consistency and readability.
+The format includes a title, explanation, required arguments, and additional information, like how the scoring mechanism works and the impact of having this issue in the dataset.
+End the section with a short tip for users on how to detect the issue using Datalab ([see below](#using-the-jinja-template-block) for details on including this with a Jinja template block).
 
 Try to add tests for this new issue type. It's a good idea to start with some tests in a separate module in the [issue manager test directory](https://github.com/cleanlab/cleanlab/tree/master/tests/datalab/issue_manager). 
+
+
+### Using the Jinja Template Block
+
+When adding a new issue type description, incorporate a Jinja template block to insert a specific tip for users. Copy the snippet below and update `<your_issue_name_here>` with the name of your issue type. This inclusion ensures that the documentation offers a tip on how to detect the issue with Datalab, directly within the guide.
+
+```rst
+.. jinja ::
+
+    {% with issue_name = "<your_issue_name_here>" %}
+    {% include "cleanlab/datalab/guide/_templates/issue_types_tip.rst" %}
+    {% endwith %}
+```
 
 ## Documentation
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -239,24 +239,12 @@ To contribute a new type of issue that Datalab can automatically detect in any d
 Do not add your new issue type to the set of issues that Datalab detects by default, our team can add it to this default set later on once it's utility has been thoroughly validated.
 
 Don't forget to update the [issue type descriptions guide](https://github.com/cleanlab/cleanlab/blob/master/docs/source/cleanlab/datalab/guide/issue_type_description.rst) with a brief description of your new issue type.
-It is crucial to follow the specified format to maintain consistency and readability.
-The format includes a title, explanation, required arguments, and additional information, like how the scoring mechanism works and the impact of having this issue in the dataset.
-End the section with a short tip for users on how to detect the issue using Datalab ([see below](#using-the-jinja-template-block) for details on including this with a Jinja template block).
+It is ideal to stick to a format that maintains consistency and readability.
+Generally, the format includes a title, explanation, required arguments, then any additional information.
+It would be helpful to include a tip for users on how to detect the issue using Datalab.
 
 Try to add tests for this new issue type. It's a good idea to start with some tests in a separate module in the [issue manager test directory](https://github.com/cleanlab/cleanlab/tree/master/tests/datalab/issue_manager). 
 
-
-### Using the Jinja Template Block
-
-When adding a new issue type description, incorporate a Jinja template block to insert a specific tip for users. Copy the snippet below and update `<your_issue_name_here>` with the name of your issue type. This inclusion ensures that the documentation offers a tip on how to detect the issue with Datalab, directly within the guide.
-
-```rst
-.. jinja ::
-
-    {% with issue_name = "<your_issue_name_here>" %}
-    {% include "cleanlab/datalab/guide/_templates/issue_types_tip.rst" %}
-    {% endwith %}
-```
 
 ## Documentation
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -253,7 +253,6 @@ instructions](./docs/README.md#build-the-cleanlab-docs-locally).
 
 If editing existing docs or adding new tutorials, please first read through our [guidelines](./docs/README.md#tips-for-editing-docstutorials).
 
-
 ## Documentation style
 
 cleanlab uses [NumPy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,6 +12,7 @@ sphinx-multiversion==0.2.4
 sphinx-copybutton==0.5.2
 sphinxcontrib-katex==0.9.9
 sphinxcontrib-gtagjs==0.2.1
+sphinx-jinja==2.0.2
 sphinx-autodoc-typehints==1.25.2
 sphinxext-opengraph==0.9.1
 matplotlib==3.7.4

--- a/docs/source/cleanlab/datalab/guide/_templates/issue_types_tip.rst
+++ b/docs/source/cleanlab/datalab/guide/_templates/issue_types_tip.rst
@@ -1,0 +1,10 @@
+.. tip::
+
+        This type of issue has the issue name `"{{issue_name}}"`.
+
+        Run a check for this particular kind of issue by calling :py:meth:`Datalab.find_issues() <cleanlab.datalab.datalab.Datalab.find_issues>` like so:
+
+        .. code-block:: python
+
+            # `lab` is a Datalab instance
+            lab.find_issues(..., issue_types = {"{{issue_name}}": {}})

--- a/docs/source/cleanlab/datalab/guide/issue_type_description.rst
+++ b/docs/source/cleanlab/datalab/guide/issue_type_description.rst
@@ -45,8 +45,8 @@ Label Issue
 Examples whose given label is estimated to be potentially incorrect (e.g. due to annotation error) are flagged as having label issues.
 Datalab estimates which examples appear mislabeled as well as a numeric label quality score for each, which quantifies the likelihood that an example is correctly labeled.
 
-For now, Datalab can only detect label issues in a multi-class classification dataset.
-The cleanlab library has alternative methods you can us to detect label issues in other types of datasets (multi-label, multi-annotator, token classification, etc.).
+For now, Datalab can only detect label issues in multi-class classification datasets, regression datasets, and multi-label classification datasets.
+The cleanlab library has alternative methods you can us to detect label issues in other types of datasets (multi-annotator, token classification, etc.).
 
 Label issues are calculated based on provided `pred_probs` from a trained model. If you do not provide this argument, but you do provide `features`, then a K Nearest Neighbor model will be fit to produce `pred_probs` based on your `features`. Otherwise if neither `pred_probs` nor `features` is provided, then this type of issue will not be considered.
 For the most accurate results, provide out-of-sample `pred_probs` which can be obtained for a dataset via `cross-validation <https://docs.cleanlab.ai/stable/tutorials/pred_probs_cross_val.html>`_.
@@ -153,7 +153,12 @@ Underperforming Group Issue
 
 An underperforming group refers to a cluster of similar examples (i.e. a slice) in the dataset for which the ML model predictions are poor.  The examples in this underperforming group may have noisy labels or feature values, or the trained ML model may not have learned how to properly handle them (consider collecting more data from this subpopulation or up-weighting the existing data from this group).
 
-Underperforming Group issues are detected based on provided `features`  and `pred_probs`.
+Underperforming Group issues are detected based on one of:
+
+- provided `pred_probs` and `features`,
+- provided `pred_probs` and `knn_graph`, or
+- provided `pred_probs` and `cluster_ids`. (This option is for advanced users, see the `FAQ <../../../tutorials/faq.html#How-do-I-specify-pre-computed-data-slices/clusters-when-detecting-the-Underperforming-Group-Issue?>`_ for more details.)
+
 If you do not provide both these arguments, this type of issue will not be considered.
 
 To find the underperforming group, Cleanlab clusters the data using the provided `features` and determines the cluster `c` with the lowest average model predictive performance. Model predictive performance is evaluated via the model's self-confidence of the given labels, calculated using :py:func:`rank.get_self_confidence_for_each_label <cleanlab.rank.get_self_confidence_for_each_label>`. Suppose the average predictive power across the full dataset is `r` and is `q` within a cluster of examples. This cluster is considered to be an underperforming group if `q/r` falls below a threshold. A dataset suffers from the Underperforming Group issue if there exists such a cluster within it.
@@ -184,7 +189,7 @@ Data Valuation Issue
 
 The examples in the dataset with lowest data valuation scores contribute least to a trained ML model's performance (those whose value falls below a threshold are flagged with this type of issue).
 
-Data valuation issues can only be detected based on a provided `knn_graph`` (or one pre-computed during the computation of other issue types).  If you do not provide this argument and there isn't a `knn_graph` already stored in the Datalab object, this type of issue will not be considered.
+Data valuation issues can only be detected based on a provided `knn_graph` (or one pre-computed during the computation of other issue types).  If you do not provide this argument and there isn't a `knn_graph` already stored in the Datalab object, this type of issue will not be considered.
 
 The data valuation score is an approximate Data Shapley value, calculated based on the labels of the top k nearest neighbors of an example. The details of this KNN-Shapley value could be found in the papers: `Efficient Task-Specific Data Valuation for Nearest Neighbor Algorithms <https://arxiv.org/abs/1908.08619>`_ and `Scalability vs. Utility: Do We Have to Sacrifice One for the Other in Data Importance Quantification? <https://arxiv.org/abs/1911.07128>`_.
 
@@ -201,7 +206,7 @@ Appropriate defaults are used for any parameters you do not specify, so no need 
         "label": label_kwargs, "outlier": outlier_kwargs,
         "near_duplicate": near_duplicate_kwargs, "non_iid": non_iid_kwargs,
         "class_imbalance": class_imbalance_kwargs, "underperforming_group": underperforming_group_kwargs,
-        "null": null_kwargs
+        "null": null_kwargs, "data_valuation": data_valuation_kwargs,
     }
 
 
@@ -309,7 +314,7 @@ Imbalance Issue Parameters
     For more information, view the source code of:  :py:class:`datalab.internal.issue_manager.imbalance.ClassImbalanceIssueManager <cleanlab.datalab.internal.issue_manager.imbalance.ClassImbalanceIssueManager>`.
 
 Underperforming Group Issue Parameters
---------------------------
+--------------------------------------
 
 .. code-block:: python
 
@@ -343,7 +348,7 @@ Null Issue Parameters
     For more information, view the source code of:  :py:class:`datalab.internal.issue_manager.null.NullIssueManager <cleanlab.datalab.internal.issue_manager.null.NullIssueManager>`.
 
 Data Valuation Issue Parameters
---------------------------
+-------------------------------
 
 .. code-block:: python
 
@@ -356,7 +361,7 @@ Data Valuation Issue Parameters
     For more information, view the source code of:  :py:class:`datalab.internal.issue_manager.data_valuation.DataValuationIssueManager <cleanlab.datalab.internal.issue_manager.data_valuation.DataValuationIssueManager>`.
 
 Image Issue Parameters
---------------------------
+----------------------
 
 To customize optional parameters for specific image issue types, you can provide a dictionary format corresponding to each image issue. The following codeblock demonstrates how to specify optional parameters for all image issues. However, it's important to note that providing optional parameters for specific image issues is not mandatory. If no specific parameters are provided, defaults will be used for those issues.
 

--- a/docs/source/cleanlab/datalab/guide/issue_type_description.rst
+++ b/docs/source/cleanlab/datalab/guide/issue_type_description.rst
@@ -38,10 +38,6 @@ Each input is optional, if you do not provide it, Datalab will skip checks for t
 Label Issue
 -----------
 
-.. jinja:: label_context
-    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
-
-
 Examples whose given label is estimated to be potentially incorrect (e.g. due to annotation error) are flagged as having label issues.
 Datalab estimates which examples appear mislabeled as well as a numeric label quality score for each, which quantifies the likelihood that an example is correctly labeled.
 
@@ -57,12 +53,15 @@ To handle mislabeled examples, you can either filter out the data with label iss
 
 Learn more about the method used to detect label issues in our paper: `Confident Learning: Estimating Uncertainty in Dataset Labels <https://arxiv.org/abs/1911.00068>`_
 
+.. jinja ::
+
+    {% with issue_name = "label" %}
+    {% include "cleanlab/datalab/guide/_templates/issue_types_tip.rst" %}
+    {% endwith %}
+
 
 Outlier Issue
 -------------
-
-.. jinja:: outlier_context
-    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 Examples that are very different from the rest of the dataset (i.e. potentially out-of-distribution or rare/anomalous instances).
 
@@ -80,11 +79,14 @@ Closely inspect them and consider removing some outliers that may be negatively 
 
 Learn more about the methods used to detect outliers in our article: `Out-of-Distribution Detection via Embeddings or Predictions <https://cleanlab.ai/blog/outlier-detection/>`_
 
+.. jinja ::
+
+    {% with issue_name = "outlier" %}
+    {% include "cleanlab/datalab/guide/_templates/issue_types_tip.rst" %}
+    {% endwith %}
+
 (Near) Duplicate Issue
 ----------------------
-
-.. jinja:: near_duplicate_context
-    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 A (near) duplicate issue refers to two or more examples in a dataset that are extremely similar to each other, relative to the rest of the dataset.
 The examples flagged with this issue may be exactly duplicated, or lie atypically close together when represented as vectors (i.e. feature embeddings).
@@ -104,12 +106,14 @@ Including near-duplicate examples in a dataset may negatively impact a ML model'
 In particular, it is questionable to include examples in a test dataset which are (nearly) duplicated in the corresponding training dataset.
 More generally, examples which happen to be duplicated can affect the final modeling results much more than other examples — so you should at least be aware of their presence.
 
+.. jinja ::
+
+    {% with issue_name = "near_duplicate" %}
+    {% include "cleanlab/datalab/guide/_templates/issue_types_tip.rst" %}
+    {% endwith %}
 
 Non-IID Issue
 -------------
-
-.. jinja:: non_iid_context
-    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 Whether the dataset exhibits statistically significant violations of the IID assumption like:  changepoints or shift, drift, autocorrelation, etc. The specific form of violation considered is whether the examples are ordered such that almost adjacent examples tend to have more similar feature values. If you care about this check, do **not** first shuffle your dataset -- this check is entirely based on the sequential order of your data.
 
@@ -126,17 +130,26 @@ The assumption that examples in a dataset are Independent and Identically Distri
 
 For datasets with low non-IID score, you should consider why your data are not IID and act accordingly. For example, if the data distribution is drifting over time, consider employing a time-based train/test split instead of a random partition.  Note that shuffling the data ahead of time will ensure a good non-IID score, but this is not always a fix to the underlying problem (e.g. future deployment data may stem from a different distribution, or you may overlook the fact that examples influence each other). We thus recommend **not** shuffling your data to be able to diagnose this issue if it exists.
 
+.. jinja ::
+
+    {% with issue_name = "non_iid" %}
+    {% include "cleanlab/datalab/guide/_templates/issue_types_tip.rst" %}
+    {% endwith %}
+
 Class Imbalance Issue
 ---------------------
-
-.. jinja:: class_imbalance_context
-    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 Class imbalance is diagnosed just using the `labels` provided as part of the dataset. The overall class imbalance quality score of a dataset is the proportion of examples belonging to the rarest class `q`. If this proportion `q` falls below a threshold, then we say this dataset suffers from the class imbalance issue.
 
 In a dataset identified as having class imbalance, the class imbalance quality score for each example is set equal to `q` if it is labeled as the rarest class, and is equal to 1 for all other examples.
 
 Class imbalance in a dataset can lead to subpar model performance for the under-represented class. Consider collecting more data from the under-represented class, or at least take special care while modeling via techniques like over/under-sampling, SMOTE, asymmetric class weighting, etc.
+
+.. jinja ::
+
+    {% with issue_name = "class_imbalance" %}
+    {% include "cleanlab/datalab/guide/_templates/issue_types_tip.rst" %}
+    {% endwith %}
 
 Image-specific Issues
 ---------------------
@@ -147,9 +160,6 @@ Descriptions of these image-specific issues are provided in the `CleanVision pac
 
 Underperforming Group Issue
 ---------------------------
-
-.. jinja:: underperforming_group_context
-    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 An underperforming group refers to a cluster of similar examples (i.e. a slice) in the dataset for which the ML model predictions are poor.  The examples in this underperforming group may have noisy labels or feature values, or the trained ML model may not have learned how to properly handle them (consider collecting more data from this subpopulation or up-weighting the existing data from this group).
 
@@ -165,11 +175,14 @@ To find the underperforming group, Cleanlab clusters the data using the provided
 The underperforming group quality score is equal to `q/r` for examples belonging to the underperforming group, and is equal to 1 for all other examples.
 Advanced users:  If you have pre-computed cluster assignments for each example in the dataset, you can pass them explicitly to :py:meth:`Datalab.find_issues <cleanlab.datalab.datalab.Datalab.find_issues>` using the `cluster_ids` key in the `issue_types` dict argument.  This is useful for tabular datasets where you want to group/slice the data based on a categorical column. An integer encoding of the categorical column can be passed as cluster assignments for finding the underperforming group, based on the data slices you define.
 
+.. jinja ::
+
+    {% with issue_name = "underperforming_group" %}
+    {% include "cleanlab/datalab/guide/_templates/issue_types_tip.rst" %}
+    {% endwith %}
+
 Null Issue
 ----------
-
-.. jinja:: null_context
-    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 Examples identified with the null issue correspond to rows that have null/missing values across all feature columns (i.e. the entire row is missing values).
 
@@ -181,17 +194,26 @@ equals the average of the individual examples' quality scores.
 Presence of null examples in the dataset can lead to errors when training ML models. It can also
 result in the model learning incorrect patterns due to the null values.
 
+.. jinja ::
+
+    {% with issue_name = "null"%}
+    {% include "cleanlab/datalab/guide/_templates/issue_types_tip.rst" %}
+    {% endwith %}
+
 Data Valuation Issue
 --------------------
-
-.. jinja:: data_valuation_context
-    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 The examples in the dataset with lowest data valuation scores contribute least to a trained ML model's performance (those whose value falls below a threshold are flagged with this type of issue).
 
 Data valuation issues can only be detected based on a provided `knn_graph` (or one pre-computed during the computation of other issue types).  If you do not provide this argument and there isn't a `knn_graph` already stored in the Datalab object, this type of issue will not be considered.
 
 The data valuation score is an approximate Data Shapley value, calculated based on the labels of the top k nearest neighbors of an example. The details of this KNN-Shapley value could be found in the papers: `Efficient Task-Specific Data Valuation for Nearest Neighbor Algorithms <https://arxiv.org/abs/1908.08619>`_ and `Scalability vs. Utility: Do We Have to Sacrifice One for the Other in Data Importance Quantification? <https://arxiv.org/abs/1911.07128>`_.
+
+.. jinja ::
+
+    {% with issue_name = "data_valuation"%}
+    {% include "cleanlab/datalab/guide/_templates/issue_types_tip.rst" %}
+    {% endwith %}
 
 Optional Issue Parameters
 =========================

--- a/docs/source/cleanlab/datalab/guide/issue_type_description.rst
+++ b/docs/source/cleanlab/datalab/guide/issue_type_description.rst
@@ -38,6 +38,10 @@ Each input is optional, if you do not provide it, Datalab will skip checks for t
 Label Issue
 -----------
 
+.. jinja:: label_context
+    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
+
+
 Examples whose given label is estimated to be potentially incorrect (e.g. due to annotation error) are flagged as having label issues.
 Datalab estimates which examples appear mislabeled as well as a numeric label quality score for each, which quantifies the likelihood that an example is correctly labeled.
 
@@ -57,6 +61,9 @@ Learn more about the method used to detect label issues in our paper: `Confident
 Outlier Issue
 -------------
 
+.. jinja:: outlier_context
+    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
+
 Examples that are very different from the rest of the dataset (i.e. potentially out-of-distribution or rare/anomalous instances).
 
 Outlier issues are calculated based on provided `features` , `knn_graph` , or `pred_probs`.
@@ -75,6 +82,9 @@ Learn more about the methods used to detect outliers in our article: `Out-of-Dis
 
 (Near) Duplicate Issue
 ----------------------
+
+.. jinja:: near_duplicate_context
+    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 A (near) duplicate issue refers to two or more examples in a dataset that are extremely similar to each other, relative to the rest of the dataset.
 The examples flagged with this issue may be exactly duplicated, or lie atypically close together when represented as vectors (i.e. feature embeddings).
@@ -98,6 +108,9 @@ More generally, examples which happen to be duplicated can affect the final mod
 Non-IID Issue
 -------------
 
+.. jinja:: non_iid_context
+    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
+
 Whether the dataset exhibits statistically significant violations of the IID assumption like:  changepoints or shift, drift, autocorrelation, etc. The specific form of violation considered is whether the examples are ordered such that almost adjacent examples tend to have more similar feature values. If you care about this check, do **not** first shuffle your dataset -- this check is entirely based on the sequential order of your data.
 
 The Non-IID issue is detected based on provided `features` or `knn_graph`. If you do not provide one of these arguments, this type of issue will not be considered.
@@ -116,6 +129,9 @@ For datasets with low non-IID score, you should consider why your data are not I
 Class Imbalance Issue
 ---------------------
 
+.. jinja:: class_imbalance_context
+    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
+
 Class imbalance is diagnosed just using the `labels` provided as part of the dataset. The overall class imbalance quality score of a dataset is the proportion of examples belonging to the rarest class `q`. If this proportion `q` falls below a threshold, then we say this dataset suffers from the class imbalance issue.
 
 In a dataset identified as having class imbalance, the class imbalance quality score for each example is set equal to `q` if it is labeled as the rarest class, and is equal to 1 for all other examples.
@@ -130,7 +146,10 @@ Specifically, low-quality images which are too: dark/bright, blurry, low informa
 Descriptions of these image-specific issues are provided in the `CleanVision package <https://github.com/cleanlab/cleanvision>`_ and its documentation.
 
 Underperforming Group Issue
-------------------------------
+---------------------------
+
+.. jinja:: underperforming_group_context
+    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 An underperforming group refers to a cluster of similar examples (i.e. a slice) in the dataset for which the ML model predictions are poor.  The examples in this underperforming group may have noisy labels or feature values, or the trained ML model may not have learned how to properly handle them (consider collecting more data from this subpopulation or up-weighting the existing data from this group).
 
@@ -142,7 +161,10 @@ The underperforming group quality score is equal to `q/r` for examples belonging
 Advanced users:  If you have pre-computed cluster assignments for each example in the dataset, you can pass them explicitly to :py:meth:`Datalab.find_issues <cleanlab.datalab.datalab.Datalab.find_issues>` using the `cluster_ids` key in the `issue_types` dict argument.  This is useful for tabular datasets where you want to group/slice the data based on a categorical column. An integer encoding of the categorical column can be passed as cluster assignments for finding the underperforming group, based on the data slices you define.
 
 Null Issue
------------
+----------
+
+.. jinja:: null_context
+    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 Examples identified with the null issue correspond to rows that have null/missing values across all feature columns (i.e. the entire row is missing values).
 
@@ -156,6 +178,9 @@ result in the model learning incorrect patterns due to the null values.
 
 Data Valuation Issue
 --------------------
+
+.. jinja:: data_valuation_context
+    :file:  cleanlab/datalab/guide/_templates/issue_types_tip.rst
 
 The examples in the dataset with lowest data valuation scores contribute least to a trained ML model's performance (those whose value falls below a threshold are flagged with this type of issue).
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -149,27 +149,6 @@ if os.getenv("CI") or shutil.which("katex") is not None:
 
 gtagjs_ids = ["G-EV8RVEFX82"]
 
-# -- Options for sphinx_jinja extension -------------------------------------------
-
-
-def fetch_all_registered_issue_names():
-    """This helper function fetches all registered issue names from the issue manager registry, across all tasks.
-
-    This function is used to generate the context for the Jinja templates.
-    """
-    from cleanlab.datalab.internal.issue_manager_factory import REGISTRY
-
-    return set([issue_name for entries in REGISTRY.values() for issue_name in entries.keys()])
-
-
-ISSUE_TYPE_DESCRIPTION_CONTEXT = {
-    f"{issue_name}_context": {"issue_name": issue_name}
-    for issue_name in fetch_all_registered_issue_names()
-}
-
-jinja_contexts = {
-    **ISSUE_TYPE_DESCRIPTION_CONTEXT,
-}
 
 # -- Variables Setting ---------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -149,7 +149,6 @@ if os.getenv("CI") or shutil.which("katex") is not None:
 
 gtagjs_ids = ["G-EV8RVEFX82"]
 
-
 # -- Variables Setting ---------------------------------------------------
 
 # Determine doc site URL (DOCS_SITE_URL)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,6 +54,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinxcontrib.katex",
     "sphinxcontrib.gtagjs",
+    "sphinx_jinja",
     "sphinx_autodoc_typehints",
     "sphinx.ext.doctest",
     "sphinxext.opengraph",
@@ -147,6 +148,28 @@ if os.getenv("CI") or shutil.which("katex") is not None:
 # -- Options for gtagjs extension -------------------------------------------
 
 gtagjs_ids = ["G-EV8RVEFX82"]
+
+# -- Options for sphinx_jinja extension -------------------------------------------
+
+
+def fetch_all_registered_issue_names():
+    """This helper function fetches all registered issue names from the issue manager registry, across all tasks.
+
+    This function is used to generate the context for the Jinja templates.
+    """
+    from cleanlab.datalab.internal.issue_manager_factory import REGISTRY
+
+    return set([issue_name for entries in REGISTRY.values() for issue_name in entries.keys()])
+
+
+ISSUE_TYPE_DESCRIPTION_CONTEXT = {
+    f"{issue_name}_context": {"issue_name": issue_name}
+    for issue_name in fetch_all_registered_issue_names()
+}
+
+jinja_contexts = {
+    **ISSUE_TYPE_DESCRIPTION_CONTEXT,
+}
 
 # -- Variables Setting ---------------------------------------------------
 


### PR DESCRIPTION
## Summary

Introduce a new `tip` admonition template to be utilized for each section within the guide. The template's appearance within the documentation resembles the following:

<img width="769" alt="image" src="https://github.com/cleanlab/cleanlab/assets/18127060/e58f27cb-c7c6-4e97-b50e-708b9f98052f">

## High-level technical changes
Within conf.py, extract and organize the names of all registered issue managers into individual `<ISSUE_NAME>_context` variables for Jinja templating purposes. Currently, each context solely retains the `issue name`:

For example:

- `label_context` contains `{"issue_name": "label"}` within its context.
- `outlier_context` contains `{"issue_name": "outlier"}` within its context.
- and so forth.

The intention is to enrich these contexts with additional valuable information (such as the required_args in `Datalab.find_issues()`). While this enhancement may seem minimal at present, it lays the groundwork for future work, including the potential execution of automated tests that cater to default issue types.


## Reviewer notes

Take a closer look at the new template in `docs/source/cleanlab/datalab/guide/_templates/issue_types_tip.rst`.
- Is a `tip` admonition the best way to go here? 
- Can the text be shorter? The template size should be minimal, as it is used in about 8 sections on the same page.