### PR TITLE
Fix error handling in get_issues method with empty issue dataframes

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -513,6 +513,15 @@ class Datalab:
 
             Additional columns may be present in the DataFrame depending on the type of issue specified.
         """
+
+        # Validate issue_name
+        if issue_name is not None and issue_name not in self.list_possible_issue_types():
+            raise ValueError(
+                f"""Invalid issue_name: {issue_name}. Please specify a valid issue_name from the list of possible issue types.
+            Either, specify one of the following: {self.list_possible_issue_types()}
+            or set issue_name as None to get all issue types.
+            """
+            )
         return self.data_issues.get_issues(issue_name=issue_name)
 
     def get_issue_summary(self, issue_name: Optional[str] = None) -> pd.DataFrame:

--- a/cleanlab/datalab/internal/data_issues.py
+++ b/cleanlab/datalab/internal/data_issues.py
@@ -244,12 +244,14 @@ class DataIssues:
         """
         if self.issues.empty:
             raise ValueError(
-                "No issues available for retrieval. Please check the following before using `get_issues`\n"
-                "1. Ensure `find_issues` was executed. If not, please run it with the necessary parameters.\n"
-                "2. If `find_issues` was run but you're seeing this message, it may have encountered limitations preventing full analysis. "
-                "However, partial checks can still provide valuable insights.\n"
-                "Review `find_issues` output carefully for any specific actions needed "
-                "to facilitate a more comprehensive analysis before calling `get_issues`."
+                """No issues available for retrieval. Please check the following before using `get_issues`:
+                1. Ensure `find_issues` was executed. If not, please run it with the necessary parameters.
+                2. If `find_issues` was run but you're seeing this message,
+                    it may have encountered limitations preventing full analysis.
+                    However, partial checks can still provide valuable insights.
+            Review `find_issues` output carefully for any specific actions needed
+            to facilitate a more comprehensive analysis before calling `get_issues`.
+            """
             )
         if issue_name is None:
             return self.issues
@@ -257,10 +259,13 @@ class DataIssues:
         columns = [col for col in self.issues.columns if issue_name in col]
         if not columns:
             raise ValueError(
-                f"No columns found for issue type '{issue_name}'. Ensure the following:\n"
-                "1. `find_issues` has been executed. If it hasn't, please run it.\n"
-                "2. Check `find_issues` output to verify that the issue type '{issue_name}' was included in the checks. If it’s not listed, the issue type may not have been considered during the analysis.\n"
-                f"3. Review `find_issues` output for any errors or warnings that might indicate the check for '{issue_name}' failed to complete. This can provide insights into what adjustments may be necessary."
+                f"""No columns found for issue type '{issue_name}'. Ensure the following:
+                1. `find_issues` has been executed. If it hasn't, please run it.
+                2. Check `find_issues` output to verify that the issue type '{issue_name}' was included in the checks to
+                    ensure it was not excluded accidentally before the audit.
+                3. Review `find_issues` output for any errors or warnings that might indicate the check for '{issue_name}' issues failed to complete.
+                    This can provide better insights into what adjustments may be necessary.
+            """
             )
         specific_issues = self.issues[columns]
         info = self.get_info(issue_name=issue_name)

--- a/cleanlab/datalab/internal/data_issues.py
+++ b/cleanlab/datalab/internal/data_issues.py
@@ -242,12 +242,26 @@ class DataIssues:
 
             Additional columns may be present in the DataFrame depending on the type of issue specified.
         """
+        if self.issues.empty:
+            raise ValueError(
+                "No issues available for retrieval. Please check the following before using `get_issues`\n"
+                "1. Ensure `find_issues` was executed. If not, please run it with the necessary parameters.\n"
+                "2. If `find_issues` was run but you're seeing this message, it may have encountered limitations preventing full analysis. "
+                "However, partial checks can still provide valuable insights.\n"
+                "Review `find_issues` output carefully for any specific actions needed "
+                "to facilitate a more comprehensive analysis before calling `get_issues`."
+            )
         if issue_name is None:
             return self.issues
 
         columns = [col for col in self.issues.columns if issue_name in col]
         if not columns:
-            raise ValueError(f"No columns found for issue type '{issue_name}'.")
+            raise ValueError(
+                f"No columns found for issue type '{issue_name}'. Ensure the following:\n"
+                "1. `find_issues` has been executed. If it hasn't, please run it.\n"
+                "2. Check `find_issues` output to verify that the issue type '{issue_name}' was included in the checks. If it’s not listed, the issue type may not have been considered during the analysis.\n"
+                f"3. Review `find_issues` output for any errors or warnings that might indicate the check for '{issue_name}' failed to complete. This can provide insights into what adjustments may be necessary."
+            )
         specific_issues = self.issues[columns]
         info = self.get_info(issue_name=issue_name)
 

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -1747,3 +1747,12 @@ class TestDatalabGetIssuesMethod:
         assert not lab.issues.empty
         with pytest.raises(ValueError, match="No columns found for issue type 'label'."):
             lab.get_issues("label")
+
+    def test_invalid_issue_name(self, lab):
+        lab.find_issues(features=np.array(lab.data["X"]), issue_types={"null": {}})
+
+        assert not lab.issues.empty
+
+        invalid_issue_name = "nul"
+        with pytest.raises(ValueError, match=f"Invalid issue_name: {invalid_issue_name}."):
+            lab.get_issues(issue_name=invalid_issue_name)


### PR DESCRIPTION
## Summary

The objective of this PR is to improve user guidance and error message clarity when issue retrieval fails when calling `Datalab.get_issues()`

It addresses the need for users to understand why retrieving issues might fail, specifically focusing on scenarios where `Datalab.find_issues()` has not been executed or has not included the requested issue type in its checks.

**Changes**
- Updated the `DataIssue.get_issues()` method to provide detailed error messages for an empty issue set or when no columns match a specified issue type, guiding users toward resolution.
  - It's not easy at call time to find out what step the user should pick.
- Added test cases in TestDatalabGetIssuesMethod to validate these error messages under various scenarios. Tagged with issue number that this PR is intended to resolve.

## Links to Relevant Issues or Conversations

Fixes #986, enhancing error communication in the get_issues method.