### PR TITLE
Add workflow for automated releases to PyPI

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -1,0 +1,256 @@
+name: Release Build Publish
+
+on:
+    release:
+      types: [ published ]
+
+jobs:
+  extract_project_name:
+    runs-on: ubuntu-latest
+    outputs:
+      cleanlab_package_name: ${{ steps.extract_name.outputs.value }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: TOML Reader
+        uses: SebRollen/toml-action@v1.2.0
+        id: extract_name
+        with:
+          file: "pyproject.toml"
+          field: "project.name"
+
+  store_published_version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compare.outputs.version }}
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install package
+        run: pip install .
+
+      - name: Compare the published version with the package version
+        id: compare
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          # TAG_NAME must be in the form "v1.2.3[...]", error if it doesn't match
+            if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+                echo "Tag name '$TAG_NAME' does not match the expected pattern 'vX.Y.Z'"
+                exit 1
+            fi
+          # Strip the 'v' prefix from the tag, and store the version in an output variable
+          VERSION=${TAG_NAME:1} # Strip the 'v' prefix from the tag
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          # Check that the package version matches the tag version
+          PACKAGE_VERSION=$(python -c "import cleanlab; print(cleanlab.__version__)")
+          if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+            echo "Package version $PACKAGE_VERSION does not match tag $VERSION"
+            exit 1
+          fi
+
+  build:
+    needs: [store_published_version, extract_project_name]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Remove tests directory
+        run: |
+          # Remove the tests directory from the package
+          TEST_DIR=$(find . -type d -name "tests")
+          if [ -n "$TEST_DIR" ]; then
+            rm -rf $TEST_DIR
+          else
+            echo "No tests directory found! This is unexpected."
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: pip install --upgrade setuptools wheel twine
+
+      - name: Perform some tests on the metadata of the package
+        run: |
+          python setup.py check --metadata --strict
+
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Test package
+        run: |
+          twine check dist/*
+
+      - name: Verify contents of the tar.gz
+        env:
+          CLEANLAB_PACKAGE_NAME: ${{ needs.extract_project_name.outputs.cleanlab_package_name }}
+        run: |
+          # Extract the tar.gz to a temporary directory
+          TMPDIR=$(mktemp -d)
+          tar -xzf dist/*.tar.gz -C $TMPDIR
+          PACKAGE_DIR=$TMPDIR/$(ls $TMPDIR) # Assuming there's only one directory extracted
+
+          # Define expected files and directories
+          EXPECTED_FILES="LICENSE PKG-INFO MANIFEST.in DEVELOPMENT.md CONTRIBUTING.md CODE_OF_CONDUCT.md README.md pyproject.toml setup.cfg setup.py"
+          EXPECTED_DIRS="cleanlab $CLEANLAB_PACKAGE_NAME.egg-info"
+
+          # Collect actual top-level files and directories
+          ACTUAL_CONTENTS=$(ls $PACKAGE_DIR)
+          ACTUAL_FILES=$(find $PACKAGE_DIR -maxdepth 1 -type f -exec basename {} \;)
+          ACTUAL_DIRS=$(find $PACKAGE_DIR -maxdepth 1 -type d -exec basename {} \; | sed "1d") # Remove the package directory itself from the list
+
+          # Function to check for unexpected or missing files and directories
+          check_contents() {
+            local missing=0
+            # Check for expected files
+            for expected_file in $EXPECTED_FILES; do
+              echo $ACTUAL_FILES | grep -qw $expected_file || { echo "Missing expected file: $expected_file"; missing=1; }
+            done
+            
+            # Check for expected directories
+            for expected_dir in $EXPECTED_DIRS; do
+              echo $ACTUAL_DIRS | grep -qw $expected_dir || { echo "Missing expected directory: $expected_dir"; missing=1; }
+            done
+
+            # Check for unexpected files and directories
+            for actual in $ACTUAL_CONTENTS; do
+              echo $EXPECTED_FILES $EXPECTED_DIRS | grep -qw $actual || { echo "Unexpected item in package: $actual"; missing=1; }
+            done
+
+            # Exit if anything unexpected or missing
+            if [ $missing -ne 0 ]; then
+              echo "Package content verification failed."
+              exit 1
+            fi
+          }
+
+          # Execute checks
+          check_contents
+
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: dist/*
+
+  publish-testpypi:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+        id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verify-metadata: true
+
+  verify-version:
+    needs: [publish-testpypi, store_published_version, extract_project_name]
+    runs-on: ubuntu-latest
+    environment: testpypi
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install package from TestPyPI
+        env:
+          CLEANLAB_PACKAGE_NAME: ${{ needs.extract_project_name.outputs.cleanlab_package_name }}
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ $CLEANLAB_PACKAGE_NAME
+
+      - name: Verify the published version
+        env:
+          VERSION: ${{ needs.store_published_version.outputs.version }}
+        run: |
+          TEST_IMPORT_VERSION=$(python -c "import cleanlab; print(cleanlab.__version__)")
+          if [ "$TEST_IMPORT_VERSION" != "$VERSION" ]; then
+            echo "Imported version $TEST_IMPORT_VERSION does not match tag $VERSION"
+            exit 1
+          fi
+
+  test-basic-import:
+    needs: [verify-version, extract_project_name]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install package from TestPyPI
+        env:
+          CLEANLAB_PACKAGE_NAME: ${{ needs.extract_project_name.outputs.cleanlab_package_name }}
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ $CLEANLAB_PACKAGE_NAME
+
+      - name: Test importing package
+        run: |
+          python -c "import cleanlab
+          from cleanlab.outlier import OutOfDistribution
+          ood = OutOfDistribution()
+          print(ood)"
+
+  test-extras-import:
+    needs: [verify-version, extract_project_name]
+    runs-on: ubuntu-latest
+ 
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install package with extras
+        env:
+          CLEANLAB_PACKAGE_NAME: ${{ needs.extract_project_name.outputs.cleanlab_package_name }}
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ $CLEANLAB_PACKAGE_NAME[all]
+
+      - name: Test importing package with extras
+        run: |
+          python -c "import cleanlab
+          from cleanlab import Datalab
+          lab = Datalab({'a': [1, 2, 3, 4, 5], 'b': ['a', 'b', 'c', 'b', 'a']})
+          print(lab)"
+
+  publish-pypi:
+    needs: [test-basic-import, test-extras-import]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+        id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06
+        with:
+          verify-metadata: true

--- a/cleanlab/experimental/mnist_pytorch.py
+++ b/cleanlab/experimental/mnist_pytorch.py
@@ -304,7 +304,7 @@ class CNN(BaseEstimator):  # Inherits sklearn classifier
             # else range(self.train_size)),
             sampler=SubsetRandomSampler(train_idx),
             batch_size=self.batch_size,
-            **self.loader_kwargs
+            **self.loader_kwargs,
         )
 
         optimizer = optim.SGD(self.model.parameters(), lr=self.lr, momentum=self.momentum)
@@ -361,7 +361,7 @@ class CNN(BaseEstimator):  # Inherits sklearn classifier
         loader = torch.utils.data.DataLoader(
             dataset=dataset,
             batch_size=self.batch_size if loader == "train" else self.test_batch_size,
-            **self.loader_kwargs
+            **self.loader_kwargs,
         )
 
         # sets model.train(False) inactivating dropout and batch-norm layers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,81 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cleanlab"
+# List run-time dependencies here.  These will be installed by pip when
+# your project is installed. For an analysis of "install_requires" vs pip's
+# requirements files see:
+# https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/
+dependencies = [
+  "numpy>=1.22.0",
+  "scikit-learn>=1.1",
+  "tqdm>=4.53.0",
+  "pandas>=1.4.0",
+  "termcolor>=2.4.0",
+]
+description = "The standard package for data-centric AI, machine learning with label errors, and automatically finding and fixing dataset issues in Python."
+readme = "README.md"
+authors = [
+  {name = "Cleanlab Inc.", email = "team@cleanlab.ai"}
+]
+# See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Education",
+  "Intended Audience :: Science/Research",
+  "Intended Audience :: Information Technology",
+  "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+  "Natural Language :: English",
+  # We believe this package works will these versions, but we do not guarantee it!
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python",
+  "Topic :: Software Development",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Scientific/Engineering :: Mathematics",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+requires-python = ">=3.8"
+# What does your project relate to?
+keywords = [
+  "machine_learning",
+  "data_cleaning",
+  "confident_learning",
+  "classification",
+  "weak_supervision",
+  "learning_with_noisy_labels",
+  "unsupervised_learning",
+  "datacentric_ai",
+  "datacentric",
+]
+license = {file = "LICENSE"}
+dynamic = [
+  "version",
+  "optional-dependencies",
+]
+
+[project.urls]
+Homepage = "https://cleanlab.ai"
+Documentation = "https://docs.cleanlab.ai"
+"Bug Tracker" =  "https://github.com/cleanlab/cleanlab/issues"
+"Source Code" = "https://github.com/cleanlab/cleanlab"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["cleanlab*", "cleanlab.*"]
+exclude = ["tests*", "tests.*", "*.tests", "*.tests.*", "*.tests*"]
+
 [tool.black]
 line-length = 100
 exclude = '''

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 from setuptools.command.egg_info import egg_info
 
 # To use a consistent encoding
 from codecs import open
-from os import path
 
 
 class egg_info_ex(egg_info):
@@ -18,12 +17,6 @@ class egg_info_ex(egg_info):
 
         egg_info.run(self)
 
-
-here = path.abspath(path.dirname(__file__))
-
-# Get the long description from the README file
-with open(path.join(here, "README.md"), encoding="utf-8") as f:
-    long_description = f.read()
 
 # Get version number and store it in __version__
 exec(open("cleanlab/version.py").read())
@@ -44,68 +37,7 @@ EXTRAS_REQUIRE = {
 EXTRAS_REQUIRE["all"] = list(set(sum(EXTRAS_REQUIRE.values(), [])))
 
 setup(
-    name="cleanlab",
     version=__version__,
-    license="AGPLv3+",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    description="The standard package for data-centric AI, machine learning with label errors, "
-    "and automatically finding and fixing dataset issues in Python.",
-    url="https://cleanlab.ai",
-    project_urls={
-        "Documentation": "https://docs.cleanlab.ai",
-        "Bug Tracker": "https://github.com/cleanlab/cleanlab/issues",
-        "Source Code": "https://github.com/cleanlab/cleanlab",
-    },
-    author="Cleanlab Inc.",
-    author_email="team@cleanlab.ai",
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "Intended Audience :: Information Technology",
-        "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
-        "Natural Language :: English",
-        # We believe this package works will these versions, but we do not guarantee it!
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python",
-        "Topic :: Software Development",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Scientific/Engineering :: Mathematics",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        "Topic :: Software Development :: Libraries",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ],
-    python_requires=">=3.8",
-    # What does your project relate to?
-    keywords="machine_learning data_cleaning confident_learning classification weak_supervision "
-    "learning_with_noisy_labels unsupervised_learning datacentric_ai, datacentric",
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=find_packages(exclude=[]),
-    # Include cleanlab license file.
-    include_package_data=True,
-    package_data={
-        "": ["LICENSE"],
-    },
-    license_files=("LICENSE",),
     cmdclass={"egg_info": egg_info_ex},
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/
-    install_requires=[
-        "numpy>=1.22.0",
-        "scikit-learn>=1.1",
-        "tqdm>=4.53.0",
-        "pandas>=1.4.0",
-        "termcolor>=2.4.0",
-    ],
     extras_require=EXTRAS_REQUIRE,
 )


### PR DESCRIPTION
## Summary

Trigger a PyPI release process when publishing a release on GitHub.

### Main changes

- Port most of the setup.py configuration to `pyproject.toml` 
  - Using this opportunity to move most of the package metadata to a more standardized format, where possible. The setup.py file is by no means rendered obsolete, but greatly simplified.
- Add a section to DEVELOPMENT.md on how to setup up a testing PyPI project (also on TestPyPI) to allow further development of the release process, without affecting the real `cleanlab` project [on PyPI](https://pypi.org/project/cleanlab/).
  - It lists the prerequisite steps for getting started with a personal PyPI project for testing purposes.
- A new workflow file in `.github/workflows`, called `release-build-publish.yml`, which builds, tests and distributes the package in an automated fashion.


**Screenshot of the new workflow, running on a fork of cleanlab/cleanlab.**
![image](https://github.com/cleanlab/cleanlab/assets/18127060/110d23cd-3bd6-46bd-96a6-e05577fb9755)

## Notes

Most of the setup for testing the release process involves configuring environments on the repository on GitHub and configuring PyPI accounts. The only actual changes necessary in the source code are the `project.name` found in the updated pyproject.toml file and regularity bumping the __version__ number in cleanlab/version.py to successfully publish a new version to PyPI.

