### PR TITLE
user-facing cleanlab.datavaluation module

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/data_valuation.py
+++ b/cleanlab/datalab/internal/issue_manager/data_valuation.py
@@ -34,6 +34,7 @@ from sklearn.exceptions import NotFittedError
 from sklearn.neighbors import NearestNeighbors
 from sklearn.utils.validation import check_is_fitted
 
+from cleanlab.datavaluation import data_shapley_knn
 from cleanlab.datalab.internal.issue_manager import IssueManager
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -161,7 +162,7 @@ class DataValuationIssueManager(IssueManager):
         if labels is None:
             raise ValueError("labels must be provided to run data valuation")
 
-        scores = _knn_shapley_score(knn_graph, labels, self.k)
+        scores = data_shapley_knn(knn_graph, labels, self.k)
 
         self.issues = pd.DataFrame(
             {
@@ -231,19 +232,3 @@ class DataValuationIssueManager(IssueManager):
                 statistics_dict["statistics"]["knn_metric"] = self.metric
 
         return statistics_dict
-
-
-def _knn_shapley_score(knn_graph: csr_matrix, labels: np.ndarray, k: int) -> np.ndarray:
-    """Compute the Shapley values of data points based on a knn graph."""
-    N = labels.shape[0]
-    scores = np.zeros((N, N))
-    dist = knn_graph.indices.reshape(N, -1)
-
-    for y, s, dist_i in zip(labels, scores, dist):
-        idx = dist_i[::-1]
-        ans = labels[idx]
-        s[idx[k - 1]] = float(ans[k - 1] == y)
-        ans_matches = (ans == y).flatten()
-        for j in range(k - 2, -1, -1):
-            s[idx[j]] = s[idx[j + 1]] + float(int(ans_matches[j]) - int(ans_matches[j + 1]))
-    return 0.5 * (np.mean(scores / k, axis=0) + 1)

--- a/cleanlab/datavaluation.py
+++ b/cleanlab/datavaluation.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2017-2024  Cleanlab Inc.
+# This file is part of cleanlab.
+#
+# cleanlab is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cleanlab is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+from scipy.sparse import csr_matrix
+
+
+def data_shapley_knn(
+    knn_graph: csr_matrix,
+    labels: np.ndarray,
+    k: int = 10,
+) -> np.ndarray:
+    """Compute the Shapley values of data points based on a knn graph.
+    Based on KNN-Shapley value described in https://arxiv.org/abs/1911.07128
+    The larger the score, the more valuable the data point is, the more contribution it will make to the model's training.
+
+    Parameters
+    ----------
+    knn_graph : csr_matrix
+        A sparse matrix representing the knn graph.
+    labels: np.ndarray
+        The labels of the data points.
+    k: int
+        The number of nearest neighbors to consider.
+    """
+    N = labels.shape[0]
+    scores = np.zeros((N, N))
+    dist = knn_graph.indices.reshape(N, -1)
+
+    for y, s, dist_i in zip(labels, scores, dist):
+        idx = dist_i[::-1]
+        ans = labels[idx]
+        s[idx[k - 1]] = float(ans[k - 1] == y)
+        ans_matches = (ans == y).flatten()
+        for j in range(k - 2, -1, -1):
+            s[idx[j]] = s[idx[j + 1]] + float(int(ans_matches[j]) - int(ans_matches[j + 1]))
+    return 0.5 * (np.mean(scores / k, axis=0) + 1)

--- a/cleanlab/datavaluation.py
+++ b/cleanlab/datavaluation.py
@@ -14,28 +14,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
 
+
+from typing import Optional, Tuple
+
 import numpy as np
 from scipy.sparse import csr_matrix
+from sklearn.neighbors import NearestNeighbors
 
 
-def data_shapley_knn(
-    knn_graph: csr_matrix,
-    labels: np.ndarray,
-    k: int = 10,
-) -> np.ndarray:
-    """Compute the Shapley values of data points based on a knn graph.
-    Based on KNN-Shapley value described in https://arxiv.org/abs/1911.07128
-    The larger the score, the more valuable the data point is, the more contribution it will make to the model's training.
-
-    Parameters
-    ----------
-    knn_graph : csr_matrix
-        A sparse matrix representing the knn graph.
-    labels: np.ndarray
-        The labels of the data points.
-    k: int
-        The number of nearest neighbors to consider.
-    """
+def _knn_shapley_score(knn_graph: csr_matrix, labels: np.ndarray, k: int) -> np.ndarray:
+    """Compute the Shapley values of data points based on a knn graph."""
     N = labels.shape[0]
     scores = np.zeros((N, N))
     dist = knn_graph.indices.reshape(N, -1)
@@ -48,3 +36,56 @@ def data_shapley_knn(
         for j in range(k - 2, -1, -1):
             s[idx[j]] = s[idx[j + 1]] + float(int(ans_matches[j]) - int(ans_matches[j + 1]))
     return 0.5 * (np.mean(scores / k, axis=0) + 1)
+
+
+def _process_knn_graph_from_features(features, metric, k: int = 10) -> csr_matrix:
+    """Calculate the knn graph from the features if it is not provided in the kwargs."""
+    if k > len(features):  # Ensure number of neighbors less than number of examples
+        raise ValueError(
+            f"Number of nearest neighbors k={k} cannot exceed the number of examples N={len(features)} passed into the estimator (knn)."
+        )
+
+    if metric == None:
+        metric = "cosine" if features.shape[1] > 3 else "euclidean"
+
+    knn = NearestNeighbors(n_neighbors=k, metric=metric).fit(features)
+    knn_graph = knn.kneighbors_graph(mode="distance")
+    return knn_graph
+
+
+def data_shapley_knn(
+    labels: np.ndarray,
+    knn_graph: Optional[csr_matrix] = None,
+    features: Optional[np.ndarray] = None,
+    metric: Optional[str] = None,
+    k: int = 10,
+) -> Tuple[np.ndarray, int]:
+    """Compute the Shapley values of data points based on a knn graph.
+    Based on KNN-Shapley value described in https://arxiv.org/abs/1911.07128
+    The larger the score, the more valuable the data point is, the more contribution it will make to the model's training.
+
+    Parameters
+    ----------
+    features: np.ndarray
+    knn_graph : csr_matrix
+        A sparse matrix representing the knn graph.
+    labels: np.ndarray
+        The labels of the data points.
+    k: int
+        The number of nearest neighbors to consider.
+    """
+    if knn_graph is not None:
+        if k > (knn_graph.nnz // knn_graph.shape[0]):
+            if features is not None:
+                # if k is larger than the number of neighbors of provided knn_graph and features are provided, recompute the knn_graph
+                knn_graph = None
+            else:
+                k = knn_graph.nnz // knn_graph.shape[0]
+                Warning(
+                    f"k is larger than the number of neighbors in the knn graph. Using k={k} instead."
+                )
+    else:
+        if features is None:
+            raise ValueError("features must be provided if knn_graph is not provided.")
+        knn_graph = _process_knn_graph_from_features(features, metric, k)
+    return _knn_shapley_score(knn_graph, labels, k), k

--- a/tests/test_datavaluation.py
+++ b/tests/test_datavaluation.py
@@ -42,17 +42,17 @@ class TestDataValuation:
         return knn_graph
 
     def test_data_shapley_knn(self, labels, features):
-        shapley, _ = data_shapley_knn(labels, features=features, k=self.K)
+        shapley, _, _ = data_shapley_knn(labels, features=features, k=self.K)
         assert shapley.shape == (100,)
         assert np.all(shapley >= 0)
         assert np.all(shapley <= 1)
 
     def test_data_shapley_knn_with_knn_graph(self, labels, knn_graph):
-        shapley, _ = data_shapley_knn(labels, knn_graph=knn_graph, k=self.K)
+        shapley, _, _ = data_shapley_knn(labels, knn_graph=knn_graph, k=self.K)
         assert shapley.shape == (100,)
         assert np.all(shapley >= 0)
         assert np.all(shapley <= 1)
 
     def test_data_shapley_knn_with_large_k(self, labels, knn_graph):
-        _, k = data_shapley_knn(labels, knn_graph=knn_graph, k=self.K + 1)
+        _, k, _ = data_shapley_knn(labels, knn_graph=knn_graph, k=self.K + 1)
         assert k == self.K

--- a/tests/test_datavaluation.py
+++ b/tests/test_datavaluation.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2017-2024  Cleanlab Inc.
+# This file is part of cleanlab.
+#
+# cleanlab is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cleanlab is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+from scipy.sparse import csr_matrix
+
+from cleanlab.datavaluation import data_shapley_knn
+
+
+class TestDataValuation:
+    K = 3
+    N = 100
+
+    @pytest.fixture
+    def labels(self):
+        return np.random.randint(0, 2, self.N)
+
+    @pytest.fixture
+    def knn_graph(self):
+        knn_graph = csr_matrix(np.random.rand(self.N, self.N))
+        return knn_graph
+
+    def test_data_shapley_knn(self, knn_graph, labels):
+        shapley = data_shapley_knn(knn_graph, labels, k=self.K)
+        assert shapley.shape == (100,)
+        assert np.all(shapley >= 0)
+        assert np.all(shapley <= 1)


### PR DESCRIPTION
## Summary

Solve #973 

> 🎯 **Purpose**: Move the data valuation calculation function to `cleanlab.datavaluation` module and support `features` as input


# Necessary Imports:
`from cleanlab.datavaluation import data_shapley_knn`


## Impact

> 🌐 Areas Affected: `datalab.issue_manager.DataValuationIssueManager`.

**Unaddressed Cases**

One thing may need discussion: when both `knn_graph` and `features` are provided and the given `k` is larger than the `k` in `knn_graph`, the default behavior now is recomputing `knn_graph` using `features.


