### PR TITLE
Downgrade Tensorflow to 2.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Overwrite tensorflow version on Windows
         run: |
           pip uninstall -y tensorflow
-          pip install tensorflow-cpu
+          pip install tensorflow-cpu<2.16
       - name: Test with coverage
         run: pytest --verbose --maxfail=3 --order-tests --cov=cleanlab/ --cov-config .coveragerc --cov-report=xml
         env:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ pytest-cov
 requests
 scipy
 skorch
-tensorflow<=2.15.0
+tensorflow<2.16
 torch
 torchvision
 typing-extensions>=4.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ pytest-cov
 requests
 scipy
 skorch
-tensorflow
+tensorflow~=2.15
 torch
 torchvision
 typing-extensions>=4.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ pytest-cov
 requests
 scipy
 skorch
-tensorflow<2.16
+tensorflow<=2.15.0
 torch
 torchvision
 typing-extensions>=4.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ pytest-cov
 requests
 scipy
 skorch
-tensorflow~=2.15
+tensorflow<2.16
 torch
 torchvision
 typing-extensions>=4.8.0


### PR DESCRIPTION
This is a temporary fix, as version 2.16 is breaking CI on Keras tests.

For context, version 2.16 had a recent release, that uses Keras 3 by default ( recent major release).

We can revert this change once we can work with Keras 3 in our tests.