### PR TITLE
Perf segmentation filter

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -28,43 +28,40 @@ These are estimated from a classification dataset. This module considers two typ
 * multi-label classification where each example can be labeled as belonging to multiple classes (e.g. ``labels = [[1,2],[1],[0],[],...]``)
 """
 
-from sklearn.linear_model import LogisticRegression as LogReg
-from sklearn.model_selection import StratifiedKFold
-from sklearn.metrics import confusion_matrix
-import sklearn.base
-import numpy as np
 import warnings
-from typing import Tuple, Union, Optional
+from typing import Optional, Tuple, Union
 
-from cleanlab.typing import LabelLike
-from cleanlab.internal.multilabel_utils import stack_complement, get_onehot_num_classes
+import numpy as np
+import sklearn.base
+from sklearn.linear_model import LogisticRegression as LogReg
+from sklearn.metrics import confusion_matrix
+from sklearn.model_selection import StratifiedKFold
+
 from cleanlab.internal.constants import (
-    TINY_VALUE,
     CONFIDENT_THRESHOLDS_LOWER_BOUND,
     FLOATING_POINT_COMPARISON,
-)
-
-from cleanlab.internal.util import (
-    value_counts_fill_missing_classes,
-    clip_values,
-    clip_noise_rates,
-    round_preserving_row_totals,
-    append_extra_datapoint,
-    train_val_split,
-    get_num_classes,
-    get_unique_classes,
-    is_torch_dataset,
-    is_tensorflow_dataset,
+    TINY_VALUE,
 )
 from cleanlab.internal.latent_algebra import (
     compute_inv_noise_matrix,
-    compute_py,
     compute_noise_matrix_from_inverse,
+    compute_py,
 )
-from cleanlab.internal.validation import (
-    assert_valid_inputs,
-    labels_to_array,
+from cleanlab.internal.multilabel_utils import get_onehot_num_classes, stack_complement
+from cleanlab.internal.util import (
+    append_extra_datapoint,
+    clip_noise_rates,
+    clip_values,
+    get_num_classes,
+    get_unique_classes,
+    is_tensorflow_dataset,
+    is_torch_dataset,
+    round_preserving_row_totals,
+    train_val_split,
+    value_counts_fill_missing_classes,
 )
+from cleanlab.internal.validation import assert_valid_inputs, labels_to_array
+from cleanlab.typing import LabelLike
 
 
 def num_label_issues(
@@ -1458,7 +1455,7 @@ def get_confident_thresholds(
         #  this approach is that there will be no standard value returned for missing classes.
         labels = labels_to_array(labels)
         all_classes = range(pred_probs.shape[1])
-        unique_classes = get_unique_classes(labels)
+        unique_classes = get_unique_classes(labels, multi_label=multi_label)
         BIG_VALUE = 2
         confident_thresholds = [
             np.mean(pred_probs[:, k][labels == k]) if k in unique_classes else BIG_VALUE

--- a/cleanlab/segmentation/filter.py
+++ b/cleanlab/segmentation/filter.py
@@ -19,11 +19,12 @@ Methods to find label issues in image semantic segmentation datasets, where each
 
 """
 
-from cleanlab.experimental.label_issues_batched import LabelInspector
-import numpy as np
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
-from cleanlab.internal.segmentation_utils import _get_valid_optional_params, _check_input
+import numpy as np
+
+from cleanlab.experimental.label_issues_batched import LabelInspector
+from cleanlab.internal.segmentation_utils import _check_input, _get_valid_optional_params
 
 
 def find_label_issues(
@@ -102,13 +103,11 @@ def find_label_issues(
                 f"Height {h} and width {w} not divisible by downsample value of {downsample}. Set kwarg downsample to 1 to avoid downsampling."
             )
         small_labels = np.round(
-            labels.reshape((num_image, h // factor, factor, w // factor, factor)).mean(4).mean(2)
+            labels.reshape((num_image, h // factor, factor, w // factor, factor)).mean((4, 2))
         )
-        small_pred_probs = (
-            pred_probs.reshape((num_image, num_classes, h // factor, factor, w // factor, factor))
-            .mean(5)
-            .mean(3)
-        )
+        small_pred_probs = pred_probs.reshape(
+            (num_image, num_classes, h // factor, factor, w // factor, factor)
+        ).mean((5, 3))
 
         # We want to make sure that pred_probs are renormalized
         row_sums = small_pred_probs.sum(axis=1)
@@ -191,27 +190,29 @@ def find_label_issues(
     # Upsample carefully maintaining indicies
     label_issues = np.full((num_image, h, w), False)
 
-    for num, ii, jj in zip(image_number, pixel_coor_i, pixel_coor_j):
-        # only want to call it an error if pred_probs doesnt match the label at that pixel
-        label_issues[num, ii, jj] = True
-        if downsample == 1:
-            # check if pred_probs matches the label at that pixel
-            if np.argmax(pred_probs[num, :, ii, jj]) == labels[num, ii, jj]:
-                label_issues[num, ii, jj] = False
+    # only want to call it an error if pred_probs doesnt match the label at those pixels
+    label_issues[image_number, pixel_coor_i, pixel_coor_j] = True
+    if downsample == 1:
+        # check if pred_probs matches the label at those pixels
+        pred_argmax = np.argmax(pred_probs[image_number, :, pixel_coor_i, pixel_coor_j], axis=1)
+        mask = pred_argmax == labels[image_number, pixel_coor_i, pixel_coor_j]
+        label_issues[image_number[mask], pixel_coor_i[mask], pixel_coor_j[mask]] = False
 
     if downsample != 1:
         label_issues = label_issues.repeat(downsample, axis=1).repeat(downsample, axis=2)
 
-        for num, ii, jj in zip(image_number, pixel_coor_i, pixel_coor_j):
-            # Upsample the coordinates
-            upsampled_ii = ii * downsample
-            upsampled_jj = jj * downsample
-            # Iterate over the upsampled region
-            for row in range(upsampled_ii, upsampled_ii + downsample):
-                for col in range(upsampled_jj, upsampled_jj + downsample):
-                    # Check if the predicted class (argmax) at the identified issue location matches the true label
-                    if np.argmax(pred_probs[num, :, row, col]) == labels[num, row, col]:
-                        # If they match, set the corresponding entry in the label_issues array to False
-                        label_issues[num, row, col] = False
+        # Upsample the coordinates
+        upsampled_ii = pixel_coor_i * downsample
+        upsampled_jj = pixel_coor_j * downsample
+        # Iterate over the upsampled region
+        for i in range(downsample):
+            for j in range(downsample):
+                rows = upsampled_ii + i
+                cols = upsampled_jj + j
+                pred_argmax = np.argmax(pred_probs[image_number, :, rows, cols], axis=1)
+                # Check if the predicted class (argmax) at the identified issue location matches the true label
+                mask = pred_argmax == labels[image_number, rows, cols]
+                # If they match, set the corresponding entries in the label_issues array to False
+                label_issues[image_number[mask], rows[mask], cols[mask]] = False
 
     return label_issues

--- a/cleanlab/segmentation/filter.py
+++ b/cleanlab/segmentation/filter.py
@@ -191,12 +191,16 @@ def find_label_issues(
     label_issues = np.full((num_image, h, w), False)
 
     # only want to call it an error if pred_probs doesnt match the label at those pixels
-    label_issues[image_number, pixel_coor_i, pixel_coor_j] = True
-    if downsample == 1:
-        # check if pred_probs matches the label at those pixels
-        pred_argmax = np.argmax(pred_probs[image_number, :, pixel_coor_i, pixel_coor_j], axis=1)
-        mask = pred_argmax == labels[image_number, pixel_coor_i, pixel_coor_j]
-        label_issues[image_number[mask], pixel_coor_i[mask], pixel_coor_j[mask]] = False
+    for i in range(0, image_number.shape[0], batch_size):
+        image_batch = image_number[i : i + batch_size]
+        batch_i = pixel_coor_i[i : i + batch_size]
+        batch_j = pixel_coor_j[i : i + batch_size]
+        label_issues[image_batch, batch_i, batch_j] = True
+        if downsample == 1:
+            # check if pred_probs matches the label at those pixels
+            pred_argmax = np.argmax(pred_probs[image_batch, :, batch_i, batch_j], axis=1)
+            mask = pred_argmax == labels[image_batch, batch_i, batch_j]
+            label_issues[image_batch[mask], batch_i[mask], batch_j[mask]] = False
 
     if downsample != 1:
         label_issues = label_issues.repeat(downsample, axis=1).repeat(downsample, axis=2)


### PR DESCRIPTION
## Summary
This PR partially addresses #862 

> 🎯 **Purpose**: Improve performance of find_label_issues in segmentation/filter.py file.
>

**[ ✏️ Write your summary here. ]**
After profiling, it seems that the loops was the slowest part. In addition, the inference in the get_unique_classes is very slow when multi_label is False because of the isinstance calls. The loops were converted to numpy operations. At the point we call that function we already know that multi_label is False, then we can pass this parameter to avoid inference. 

For memory I used the memory-profiler library. The code I used for benchmarking is copied below. In addition I sorted the imports in the modified files.

**Code Setup**
```python
import random

import numpy as np

from cleanlab.segmentation.filter import find_label_issues

SIZE = 1000
DATASET_EXP_SIZE = 2
np.random.seed(0)
%load_ext memory_profiler

# Copied from the test file with minor changes
def generate_three_image_dataset(bad_index):
    good_gt = np.zeros((SIZE, SIZE))
    good_gt[:SIZE // 2, :] = 1.0
    bad_gt = np.ones((SIZE, SIZE))
    bad_gt[:SIZE // 2, :] = 0.0
    good_pr = np.random.random((2, SIZE, SIZE))
    good_pr[0, :SIZE // 2, :] = good_pr[0, :SIZE // 2, :] / 10
    good_pr[1, SIZE // 2:, :] = good_pr[1, SIZE // 2:, :] / 10

    val = np.binary_repr([4, 2, 1][bad_index], width=3)
    error = [int(case) for case in val]

    labels = []
    pred = []
    for case in val:
        if case == "0":
            labels.append(good_gt)
            pred.append(good_pr)
        else:
            labels.append(bad_gt)
            pred.append(good_pr)

    labels = np.array(labels)
    pred_probs = np.array(pred)
    return labels, pred_probs, error

# Create input data
labels, pred_probs, error = generate_three_image_dataset(random.randint(0, 2))
for _ in range(DATASET_EXP_SIZE):
    labels = np.append(labels, labels, axis=0)
    pred_probs = np.append(pred_probs, pred_probs, axis=0)

labels, pred_probs = labels.astype(int), pred_probs.astype(float)
```


**Current version**

```python
%%timeit
%memit find_label_issues(labels, pred_probs, n_jobs=1, verbose=False)
# peak memory: 1219.42 mib, increment: 659.78 mib
# peak memory: 1220.45 mib, increment: 677.88 mib
# peak memory: 1220.45 mib, increment: 677.88 mib
# peak memory: 1220.65 mib, increment: 678.08 mib
# peak memory: 1220.65 mib, increment: 677.88 mib
# peak memory: 1220.65 mib, increment: 677.88 mib
# peak memory: 1220.64 mib, increment: 677.88 mib
# peak memory: 1220.65 mib, increment: 677.88 mib
# 8.03 s ± 249 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
```python
%%timeit
%memit find_label_issues(labels, pred_probs, downsample=4, n_jobs=1, verbose=False)
# peak memory: 607.32 MiB, increment: 64.55 MiB
# peak memory: 607.34 MiB, increment: 76.01 MiB
# peak memory: 607.34 MiB, increment: 76.01 MiB
# peak memory: 607.35 MiB, increment: 76.02 MiB
# peak memory: 607.34 MiB, increment: 76.01 MiB
# peak memory: 607.34 MiB, increment: 76.01 MiB
# peak memory: 607.36 MiB, increment: 76.03 MiB
# peak memory: 607.36 MiB, increment: 76.03 MiB
# 5.51 s ± 138 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
**This PR**
```python
%%timeit
%memit find_label_issues(labels, pred_probs, n_jobs=1, verbose=False)
# peak memory: 1240.52 MiB, increment: 674.35 MiB
# peak memory: 1223.41 MiB, increment: 681.34 MiB
# peak memory: 1236.62 MiB, increment: 694.56 MiB
# peak memory: 1246.82 MiB, increment: 704.75 MiB
# peak memory: 1227.48 MiB, increment: 685.22 MiB
# peak memory: 1230.82 MiB, increment: 688.56 MiB
# peak memory: 1227.61 MiB, increment: 685.36 MiB
# peak memory: 1221.61 MiB, increment: 679.35 MiB
# 3.4 s ± 27.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
```python
%%timeit
%memit find_label_issues(labels, pred_probs, downsample=4, n_jobs=1, verbose=False)
# peak memory: 622.23 MiB, increment: 79.96 MiB
# peak memory: 622.27 MiB, increment: 94.12 MiB
# peak memory: 622.40 MiB, increment: 94.24 MiB
# peak memory: 622.19 MiB, increment: 94.03 MiB
# peak memory: 622.41 MiB, increment: 94.25 MiB
# peak memory: 622.40 MiB, increment: 94.24 MiB
# peak memory: 622.40 MiB, increment: 94.24 MiB
# peak memory: 622.42 MiB, increment: 94.26 MiB
# 704 ms ± 12.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

## Testing

> 🔍 Testing Done: Existing tests.


## References


## Reviewer Notes
> 💡 Include any specific points for the reviewer to consider during their review.


