### PR TITLE
Optimize value_counts function for performance improvement with missing classes

### DIFF
--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -19,7 +19,7 @@ Ancillary helper methods used internally throughout this package; mostly related
 """
 
 import warnings
-from typing import Any, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -139,9 +139,7 @@ def clip_values(x, low=0.0, high=1.0, new_sum=None) -> np.ndarray:
     return x
 
 
-def value_counts(
-    x, *, num_classes: Optional[int] = None, multi_label=False
-) -> np.ndarray[Any, np.dtype[np.int_]]:
+def value_counts(x, *, num_classes: Optional[int] = None, multi_label=False) -> np.ndarray:
     """Returns an np.ndarray of shape (K, 1), with the
     value counts for every unique item in the labels list/array,
     where K is the number of unique entries in labels.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from collections import namedtuple
 
 from cleanlab.internal import util
 import numpy as np
@@ -60,6 +61,28 @@ def test_pu_f1():
 def test_value_counts_str():
     r = util.value_counts(["a", "b", "a"])
     assert all(np.array([2, 1]) - r < 1e-4)
+
+
+TestCase = namedtuple("TestCase", ["labels", "id"])
+
+value_counts_missing_classes_test_cases = [
+    TestCase([0, 1, 0, 2], "integers"),
+    TestCase(["a", "b", "a", "c"], "strings"),
+    TestCase([[0], [0, 1], [2]], "multilabel_integers"),
+    TestCase([["c"], ["a", "b"], ["a"]], "multilabel_strings"),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    value_counts_missing_classes_test_cases,
+    ids=lambda x: str(x.id),
+)
+def test_value_counts_fill_missing_classes(test_case):
+    labels = test_case.labels
+    is_multi_label = isinstance(labels[0], list)
+    r = util.value_counts_fill_missing_classes(labels, num_classes=4, multi_label=is_multi_label)
+    assert np.array_equal(r, [2, 1, 1, 0])
 
 
 def test_pu_remove_noise():


### PR DESCRIPTION
## Summary
This PR partially addresses #862 

> 🎯 **Purpose**: Improve performance of internal value_counts function
>

**[ ✏️ Write your summary here. ]**
While working on _token_classification_ I noticed when I worked with batches the _value_counts_ function was around the top 30 when profiling. By preallocating the array and given that np.unique returns a sorted array, we can avoid the creation of multiple lists before converting them into an array which is orders of magnitude faster. With this PR almost all the time is spent in the np.unique function. The improvement is only noticeable when all the classes are not present (mostly batches with a relative high number of classes).

For memory I used the memory-profiler library. The code I used for benchmarking is copied below. In addition I sorted the imports in the modified files.

**Code Setup**
```python
import numpy as np

from cleanlab.internal.util import value_counts

np.random.seed(0)
%load_ext memory_profiler

# Simulate a batch_size of 10_000 and a total of 250_000 classes
x = np.random.randint(250_000, size=10_000)

# Simulate a large dataset with most classes present.
y = np.random.randint(249_950, size=500_000_000)
```
Note: when calling value_counts on x I measured memory only once after the timeit function. Otherwise it would print too many statements.
**Current version**
```python
%timeit value_counts(x, num_classes=250_000)
%memit value_counts(x, num_classes=250_000)
# 48.1 ms ± 1.24 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
# peak memory: 4103.93 MiB, increment: 4.66 MiB
```
```python
%%timeit 
%memit value_counts(y, num_classes=250_000)
# peak memory: 8465.91 MiB, increment: 4385.38 MiB
# peak memory: 8472.33 MiB, increment: 4391.65 MiB
# peak memory: 8372.47 MiB, increment: 4291.54 MiB
# peak memory: 8570.36 MiB, increment: 4489.45 MiB
# peak memory: 8372.46 MiB, increment: 4291.54 MiB
# peak memory: 8582.37 MiB, increment: 4501.44 MiB
# peak memory: 8692.37 MiB, increment: 4611.44 MiB
# peak memory: 8760.37 MiB, increment: 4679.44 MiB
# 1min 5s ± 971 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**This PR**
```python
%timeit value_counts(x, num_classes=250_000)
%memit value_counts(x, num_classes=250_000)
# 16.9 ms ± 402 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# peak memory: 4093.53 MiB, increment: 0.00 MiB
```
```python
%%timeit 
%memit value_counts(y, num_classes=250_000)
# peak memory: 8777.02 MiB, increment: 4712.53 MiB
# peak memory: 8587.01 MiB, increment: 4524.52 MiB
# peak memory: 8433.01 MiB, increment: 4370.52 MiB
# peak memory: 8355.69 MiB, increment: 4293.21 MiB
# peak memory: 8404.86 MiB, increment: 4342.38 MiB
# peak memory: 8789.01 MiB, increment: 4726.52 MiB
# peak memory: 8769.01 MiB, increment: 4706.52 MiB
# peak memory: 8355.70 MiB, increment: 4293.21 MiB
# 28.7 s ± 322 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

## Testing

> 🔍 Testing Done: Existing tests.


## References


## Reviewer Notes
> 💡 Include any specific points for the reviewer to consider during their review.
