### PR TITLE
Perf: compute_soft_cross_entropy

### DIFF
--- a/cleanlab/internal/multiannotator_utils.py
+++ b/cleanlab/internal/multiannotator_utils.py
@@ -18,14 +18,16 @@
 Helper methods used internally in cleanlab.multiannotator
 """
 
-from cleanlab.typing import LabelLike
-from typing import Optional, Tuple
 import warnings
+from typing import Optional, Tuple
+
 import numpy as np
 import pandas as pd
-from cleanlab.internal.validation import assert_valid_class_labels
+
 from cleanlab.internal.numerics import softmax
 from cleanlab.internal.util import get_num_classes, value_counts
+from cleanlab.internal.validation import assert_valid_class_labels
+from cleanlab.typing import LabelLike
 
 SMALL_CONST = 1e-30
 
@@ -274,12 +276,15 @@ def compute_soft_cross_entropy(
     """Compute soft cross entropy between the annotators' empirical label distribution and model pred_probs"""
     num_classes = get_num_classes(pred_probs=pred_probs)
 
-    empirical_label_distribution = np.full((len(labels_multiannotator), num_classes), np.NaN)
-    for i, labels in enumerate(labels_multiannotator):
-        labels_subset = labels[~np.isnan(labels)]
-        empirical_label_distribution[i, :] = value_counts(
-            labels_subset, num_classes=num_classes
-        ) / len(labels_subset)
+    empirical_label_distribution = np.zeros((len(labels_multiannotator), num_classes), dtype=float)
+    length = np.zeros(len(labels_multiannotator), dtype=float)
+    for i in range(labels_multiannotator.shape[1]):
+        mask = ~np.isnan(labels_multiannotator[:, i])
+        empirical_label_distribution[mask, labels_multiannotator[mask, i].astype(int)] += 1
+        length += mask
+
+    for k in range(num_classes):
+        empirical_label_distribution[:, k] /= length
 
     clipped_pred_probs = np.clip(pred_probs, a_min=SMALL_CONST, a_max=None)
     soft_cross_entropy = -np.sum(


### PR DESCRIPTION
## Summary
This PR partially addresses #862 

> 🎯 **Purpose**: Improve performance of find_best_temp_scaler
>

**[ ✏️ Write your summary here. ]**
I was profiling _get_label_quality_multiannotator_ and it seems that _find_best_temp_scaler_ took a long time when _calibrate_probs_ was True. Almost all of the time was spent running _compute_soft_cross_entropy_. The idea is to skip the _value_counts_ function and instead rely on less expensive numpy operations as much as possible.

For memory I used the memory-profiler library. The code I used for benchmarking is copied below. In addition I sorted the imports in the modified files.

**Code Setup**
```python
import numpy as np

from cleanlab.internal.multiannotator_utils import find_best_temp_scaler

np.random.seed(0)
%load_ext memory_profiler

M = 5
N = 100_000
K = 20
labels = np.random.randint(K, size=(N, M))
pred_probs = np.random.random((N, K))
pred_probs /= pred_probs.sum(axis=1, keepdims=True)

labels_with_some_nans = labels.astype(np.float64)
labels_with_some_nans[:labels_with_some_nans.shape[0] // 2, np.random.randint(M, size=(M))] = np.nan 
```

**Current version**
```python
%%timeit
%memit find_best_temp_scaler(labels_with_some_nans, pred_probs)
# peak memory: 707.00 MiB, increment: 77.20 MiB
# peak memory: 708.11 MiB, increment: 78.07 MiB
# peak memory: 708.11 MiB, increment: 78.07 MiB
# peak memory: 708.11 MiB, increment: 78.07 MiB
# peak memory: 708.11 MiB, increment: 78.07 MiB
# peak memory: 708.12 MiB, increment: 78.08 MiB
# peak memory: 708.12 MiB, increment: 78.07 MiB
# peak memory: 708.12 MiB, increment: 78.07 MiB
# 21.5 s ± 479 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
```python
%%timeit
%memit find_best_temp_scaler(labels, pred_probs)
# peak memory: 708.32 MiB, increment: 78.27 MiB
# peak memory: 708.32 MiB, increment: 78.07 MiB
# peak memory: 708.32 MiB, increment: 78.07 MiB
# peak memory: 708.32 MiB, increment: 78.07 MiB
# peak memory: 708.32 MiB, increment: 78.07 MiB
# peak memory: 708.32 MiB, increment: 78.07 MiB
# peak memory: 708.32 MiB, increment: 78.07 MiB
# peak memory: 708.32 MiB, increment: 78.07 MiB
# 21.2 s ± 338 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**This PR**
```python
%%timeit
%memit find_best_temp_scaler(labels_with_some_nans, pred_probs)
# peak memory: 368.92 MiB, increment: 73.48 MiB
# peak memory: 370.00 MiB, increment: 93.27 MiB
# peak memory: 370.07 MiB, increment: 93.28 MiB
# peak memory: 370.25 MiB, increment: 93.46 MiB
# peak memory: 370.26 MiB, increment: 93.27 MiB
# peak memory: 370.20 MiB, increment: 93.21 MiB
# peak memory: 370.19 MiB, increment: 93.20 MiB
# peak memory: 370.26 MiB, increment: 93.27 MiB
# 716 ms ± 7.81 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
```python
%%timeit
%memit find_best_temp_scaler(labels, pred_probs)
# peak memory: 370.46 MiB, increment: 93.33 MiB
# peak memory: 370.47 MiB, increment: 93.27 MiB
# peak memory: 370.47 MiB, increment: 93.27 MiB
# peak memory: 370.47 MiB, increment: 93.27 MiB
# peak memory: 370.41 MiB, increment: 93.21 MiB
# peak memory: 370.47 MiB, increment: 93.27 MiB
# peak memory: 370.47 MiB, increment: 93.27 MiB
# peak memory: 370.41 MiB, increment: 93.21 MiB
# 756 ms ± 12.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

## Testing

> 🔍 Testing Done: Existing tests.


## References


## Reviewer Notes
> 💡 Include any specific points for the reviewer to consider during their review.
