### PR TITLE
Refactor add quick check before import tensorflow

### DIFF
--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -48,7 +48,7 @@ def assert_valid_inputs(
     allow_empty_X = True
     if pred_probs is None:
         allow_empty_X = False
-    if not isinstance(X, (list, np.ndarray, np.generic, pd.Series, pd.DataFrame)):
+    if X is None or not isinstance(X, (list, np.ndarray, np.generic, pd.Series, pd.DataFrame)):
         try:
             import tensorflow
 

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -18,12 +18,14 @@
 Checks to ensure valid inputs for various methods.
 """
 
-from cleanlab.typing import LabelLike, DatasetLike
-from cleanlab.internal.constants import FLOATING_POINT_COMPARISON
-from typing import Any, List, Optional, Union
 import warnings
+from typing import Any, List, Optional, Union
+
 import numpy as np
 import pandas as pd
+
+from cleanlab.internal.constants import FLOATING_POINT_COMPARISON
+from cleanlab.typing import DatasetLike, LabelLike
 
 
 def assert_valid_inputs(
@@ -46,13 +48,14 @@ def assert_valid_inputs(
     allow_empty_X = True
     if pred_probs is None:
         allow_empty_X = False
-    try:
-        import tensorflow
+    if not isinstance(X, (list, np.ndarray, np.generic, pd.Series, pd.DataFrame)):
+        try:
+            import tensorflow
 
-        if isinstance(X, tensorflow.data.Dataset):
-            allow_empty_X = True  # length of X may differ due to batch-size used in tf Dataset, so don't check it
-    except Exception:
-        pass
+            if isinstance(X, tensorflow.data.Dataset):
+                allow_empty_X = True  # length of X may differ due to batch-size used in tf Dataset, so don't check it
+        except Exception:
+            pass
 
     if not allow_empty_X:
         assert_nonempty_input(X)

--- a/cleanlab/internal/validation.py
+++ b/cleanlab/internal/validation.py
@@ -48,7 +48,7 @@ def assert_valid_inputs(
     allow_empty_X = True
     if pred_probs is None:
         allow_empty_X = False
-    if X is None or not isinstance(X, (list, np.ndarray, np.generic, pd.Series, pd.DataFrame)):
+    if X is not None and not isinstance(X, (list, np.ndarray, np.generic, pd.Series, pd.DataFrame)):
         try:
             import tensorflow
 


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Avoid tensorflow import when X is None / numpy / pandas / list data.
>

**[ ✏️ Write your summary here. ]** 
When the function `assert_valid_inputs` is called we default to import tensorflow to check if the provided data is a tensorflow dataset. However the first tensorflow import is slow and we could quickly check for other common inputs first. By adding this quick check we can skip the tensorflow import unless it is likely that the provided data is a tensorflow dataset. The performance impact of this check is ~40ns in my laptop when the data is actually a tensorflow dataset and it is about the same performance improvement when X is None / numpy / pandas / list and tensorflow was already imported before.

## Impact

> 🌐 Areas Affected: The `assert_valid_input` function is called by many modules, thus we would skip the tensorflow import for most workflows that do not need it.


## Testing

> 🔍 Testing Done: Existing test suite.


## References

> 📚 Include any extra information that may be helpful to reviewers of your
> Pull-Request here (e.g. relevant URLs or Wiki pages that could help give
> background information). 
>
> Share links, docs, or sources that facilitated your changes.
>
> If relevant, please include additional code snippets
> (and their outputs/return values) showing alternative ways to use your newly added methods.

## Reviewer Notes
> 💡 Include any specific points for the reviewer to consider during their review.

