### PR TITLE
get rid of warnings in the datalab quickstart tutorial

### DIFF
--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -324,7 +324,7 @@
     "    noisy_labels_idx = generate_noisy_labels(y_train_idx, noise_matrix)\n",
     "    noisy_labels = np.array([list(BINS_MAP.keys())[i] for i in noisy_labels_idx])\n",
     "    # Assign few datapoints to rare class\n",
-    "    random_idx = np.random.randint(0, X_train.shape[0], 3)\n",
+    "    random_idx = np.random.randint(0, X_train.shape[0], 11)\n",
     "    noisy_labels[random_idx] = \"max\"\n",
     "    noisy_labels_idx[random_idx] = np.max(y_bin_idx) + 1\n",
     "    \n",


### PR DESCRIPTION
fixes #1053 

just increase the number of samples of the rare class, but it is still a relatively small number.

