### PR TITLE
Add kwargs to functions that call plt.show()

### DIFF
--- a/cleanlab/object_detection/summary.py
+++ b/cleanlab/object_detection/summary.py
@@ -388,7 +388,7 @@ def visualize(
         Optional figure size for plotting the image.
         Corresponds to ``matplotlib.figure.figsize``.
 
-    **kwargs:
+    kwargs:
         Additional keyword arguments to pass to `plt.show()` (matplotlib.pyplot.show).
     """
     try:

--- a/cleanlab/object_detection/summary.py
+++ b/cleanlab/object_detection/summary.py
@@ -348,9 +348,9 @@ def visualize(
     save_path: Optional[str] = None,
     **kwargs
 ) -> None:
-    """
-    Display the annotated bounding boxes (given labels) and predicted bounding boxes (model predictions) for a particular image.
+    """Display the annotated bounding boxes (given labels) and predicted bounding boxes (model predictions) for a particular image.
     Given labels are shown in red, model predictions in blue.
+
 
     Parameters
     ----------
@@ -361,10 +361,14 @@ def visualize(
         The given label for a single image in the format ``{'bboxes': np.ndarray((L,4)), 'labels': np.ndarray((L,))}`` where
         ``L`` is the number of bounding boxes for the `i`-th image and ``bboxes[j]`` is in the format ``[x1,y1,x2,y2]`` with given label ``labels[j]``.
 
+        Note: Here, ``(x1,y1)`` corresponds to the top-left and ``(x2,y2)`` corresponds to the bottom-right corner of the bounding box with respect to the image matrix [e.g. `XYXY in Keras <https://keras.io/api/keras_cv/bounding_box/formats/>`, `Detectron 2 <https://detectron2.readthedocs.io/en/latest/modules/utils.html#detectron2.utils.visualizer.Visualizer.draw_box>`].
+
     prediction:
         A prediction for a single image in the format ``np.ndarray((K,))`` and ``prediction[k]`` is of shape ``np.ndarray(N,5)``
         where ``M`` is the number of predicted bounding boxes for class ``k`` and the five columns correspond to ``[x,y,x,y,pred_prob]`` where
         ``[x1,y1,x2,y2]`` are the bounding box coordinates predicted by the model and ``pred_prob`` is the model's confidence in ``predictions[i]``.
+
+        Note: Here, ``(x1,y1)`` corresponds to the top-left and ``(x2,y2)`` corresponds to the bottom-right corner of the bounding box with respect to the image matrix [e.g. `XYXY in Keras <https://keras.io/api/keras_cv/bounding_box/formats/>`, `Detectron 2 <https://detectron2.readthedocs.io/en/latest/modules/utils.html#detectron2.utils.visualizer.Visualizer.draw_box>`]. The last column, pred_prob, represents the predicted probability that the bounding box contains an object of the class k.
 
     prediction_threshold:
         All model-predicted bounding boxes with confidence (`pred_prob`)
@@ -372,7 +376,7 @@ def visualize(
 
     overlay: bool
         If True, display a single image with given labels and predictions overlaid.
-        If False, display two images (side by side) with the left image showing  the model predictions and the right image showing the given label.
+        If False, display two images (side by side) with the left image showing  the model predictions and the right image showing the given label.
 
     class_names:
         Optional dictionary mapping one-hot-encoded class labels back to their original class names in the format ``{"integer-label": "original-class-name"}``.

--- a/cleanlab/object_detection/summary.py
+++ b/cleanlab/object_detection/summary.py
@@ -241,7 +241,7 @@ def get_sorted_bbox_count_idxs(labels, predictions):
 
 
 def plot_class_size_distributions(
-    labels, predictions, class_names=None, class_to_show=MAX_CLASS_TO_SHOW
+    labels, predictions, class_names=None, class_to_show=MAX_CLASS_TO_SHOW, **kwargs
 ):
     """
     Plots the size distributions for bounding boxes for each class.
@@ -265,6 +265,9 @@ def plot_class_size_distributions(
     class_to_show: optional
         The number of classes to show in the plots. Classes over `class_to_show` are hidden. If this argument is provided, then the classes are sorted by the number of instances in the dataset.
         Defaults to `MAX_CLASS_TO_SHOW` which is set to 10.
+
+    **kwargs:
+        Additional keyword arguments to pass to `plt.show()`.
     """
     try:
         import matplotlib.pyplot as plt
@@ -291,10 +294,10 @@ def plot_class_size_distributions(
             axs[i].set_ylabel("count")
             axs[i].set_title("annotated" if i == 0 else "predicted")
 
-        plt.show()
+        plt.show(**kwargs)
 
 
-def plot_class_distribution(labels, predictions, class_names=None):
+def plot_class_distribution(labels, predictions, class_names=None, **kwargs):
     """
     Plots the distribution of class labels associated with all annotated bounding boxes and predicted bounding boxes in the dataset.
 
@@ -312,6 +315,9 @@ def plot_class_distribution(labels, predictions, class_names=None):
 
     class_names: optional
         Optional dictionary mapping one-hot-encoded class labels back to their original class names in the format ``{"integer-label": "original-class-name"}``.
+
+    **kwargs:
+        Additional keyword arguments to pass to `plt.show()`.
     """
     try:
         import matplotlib.pyplot as plt
@@ -327,7 +333,7 @@ def plot_class_distribution(labels, predictions, class_names=None):
         axs[i].pie(d.values(), labels=d.keys(), autopct="%1.1f%%")
         axs[i].set_title("Annotated" if i == 0 else "Predicted")
 
-    plt.show()
+    plt.show(**kwargs)
 
 
 def visualize(
@@ -340,10 +346,11 @@ def visualize(
     class_names: Optional[Dict[Any, Any]] = None,
     figsize: Optional[Tuple[int, int]] = None,
     save_path: Optional[str] = None,
+    **kwargs
 ) -> None:
-    """Display the annotated bounding boxes (given labels) and predicted bounding boxes (model predictions) for a particular image.
+    """
+    Display the annotated bounding boxes (given labels) and predicted bounding boxes (model predictions) for a particular image.
     Given labels are shown in red, model predictions in blue.
-
 
     Parameters
     ----------
@@ -354,14 +361,10 @@ def visualize(
         The given label for a single image in the format ``{'bboxes': np.ndarray((L,4)), 'labels': np.ndarray((L,))}`` where
         ``L`` is the number of bounding boxes for the `i`-th image and ``bboxes[j]`` is in the format ``[x1,y1,x2,y2]`` with given label ``labels[j]``.
 
-        Note: Here, ``(x1,y1)`` corresponds to the top-left and ``(x2,y2)`` corresponds to the bottom-right corner of the bounding box with respect to the image matrix [e.g. `XYXY in Keras <https://keras.io/api/keras_cv/bounding_box/formats/>`, `Detectron 2 <https://detectron2.readthedocs.io/en/latest/modules/utils.html#detectron2.utils.visualizer.Visualizer.draw_box>`].
-
     prediction:
         A prediction for a single image in the format ``np.ndarray((K,))`` and ``prediction[k]`` is of shape ``np.ndarray(N,5)``
         where ``M`` is the number of predicted bounding boxes for class ``k`` and the five columns correspond to ``[x,y,x,y,pred_prob]`` where
         ``[x1,y1,x2,y2]`` are the bounding box coordinates predicted by the model and ``pred_prob`` is the model's confidence in ``predictions[i]``.
-
-        Note: Here, ``(x1,y1)`` corresponds to the top-left and ``(x2,y2)`` corresponds to the bottom-right corner of the bounding box with respect to the image matrix [e.g. `XYXY in Keras <https://keras.io/api/keras_cv/bounding_box/formats/>`, `Detectron 2 <https://detectron2.readthedocs.io/en/latest/modules/utils.html#detectron2.utils.visualizer.Visualizer.draw_box>`]. The last column, pred_prob, represents the predicted probability that the bounding box contains an object of the class k.
 
     prediction_threshold:
         All model-predicted bounding boxes with confidence (`pred_prob`)
@@ -369,7 +372,7 @@ def visualize(
 
     overlay: bool
         If True, display a single image with given labels and predictions overlaid.
-        If False, display two images (side by side) with the left image showing  the model predictions and the right image showing the given label.
+        If False, display two images (side by side) with the left image showing  the model predictions and the right image showing the given label.
 
     class_names:
         Optional dictionary mapping one-hot-encoded class labels back to their original class names in the format ``{"integer-label": "original-class-name"}``.
@@ -380,6 +383,9 @@ def visualize(
     figsize:
         Optional figure size for plotting the image.
         Corresponds to ``matplotlib.figure.figsize``.
+
+    **kwargs:
+        Additional keyword arguments to pass to `plt.show()`.
     """
     try:
         import matplotlib.pyplot as plt
@@ -451,7 +457,7 @@ def visualize(
             transparent=True,
             pad_inches=0.5,
         )
-    plt.show()
+    plt.show(**kwargs)
 
 
 def _get_per_class_confusion_matrix_dict_(

--- a/cleanlab/object_detection/summary.py
+++ b/cleanlab/object_detection/summary.py
@@ -316,7 +316,7 @@ def plot_class_distribution(labels, predictions, class_names=None, **kwargs):
     class_names: optional
         Optional dictionary mapping one-hot-encoded class labels back to their original class names in the format ``{"integer-label": "original-class-name"}``.
 
-    **kwargs:
+    kwargs:
         Additional keyword arguments to pass to `plt.show()`.
     """
     try:

--- a/cleanlab/object_detection/summary.py
+++ b/cleanlab/object_detection/summary.py
@@ -389,7 +389,7 @@ def visualize(
         Corresponds to ``matplotlib.figure.figsize``.
 
     **kwargs:
-        Additional keyword arguments to pass to `plt.show()`.
+        Additional keyword arguments to pass to `plt.show()` (matplotlib.pyplot.show).
     """
     try:
         import matplotlib.pyplot as plt

--- a/cleanlab/object_detection/summary.py
+++ b/cleanlab/object_detection/summary.py
@@ -266,7 +266,7 @@ def plot_class_size_distributions(
         The number of classes to show in the plots. Classes over `class_to_show` are hidden. If this argument is provided, then the classes are sorted by the number of instances in the dataset.
         Defaults to `MAX_CLASS_TO_SHOW` which is set to 10.
 
-    **kwargs:
+    kwargs:
         Additional keyword arguments to pass to `plt.show()`.
     """
     try:

--- a/cleanlab/object_detection/summary.py
+++ b/cleanlab/object_detection/summary.py
@@ -346,7 +346,7 @@ def visualize(
     class_names: Optional[Dict[Any, Any]] = None,
     figsize: Optional[Tuple[int, int]] = None,
     save_path: Optional[str] = None,
-    **kwargs
+    **kwargs,
 ) -> None:
     """Display the annotated bounding boxes (given labels) and predicted bounding boxes (model predictions) for a particular image.
     Given labels are shown in red, model predictions in blue.

--- a/cleanlab/object_detection/summary.py
+++ b/cleanlab/object_detection/summary.py
@@ -317,7 +317,7 @@ def plot_class_distribution(labels, predictions, class_names=None, **kwargs):
         Optional dictionary mapping one-hot-encoded class labels back to their original class names in the format ``{"integer-label": "original-class-name"}``.
 
     kwargs:
-        Additional keyword arguments to pass to `plt.show()`.
+        Additional keyword arguments to pass to `plt.show()` (matplotlib.pyplot.show).
     """
     try:
         import matplotlib.pyplot as plt

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -35,7 +35,7 @@ def display_issues(
     class_names: Optional[List[str]] = None,
     exclude: Optional[List[int]] = None,
     top: Optional[int] = None,
-    **kwargs  # Accepting additional kwargs for plt.show()
+    **kwargs,  # Accepting additional kwargs for plt.show()
 ) -> None:
     """
     Display semantic segmentation label issues, showing images with problematic pixels highlighted.

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -88,7 +88,7 @@ def display_issues(
     exclude:
         Optional list of label classes that can be ignored in the errors, each element must be 0, 1, ..., K-1
 
-    **kwargs
+    kwargs
         Additional keyword arguments to pass to `plt.show()`.
     """
     class_names, exclude, top = _get_summary_optional_params(class_names, exclude, top)

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -44,29 +44,52 @@ def display_issues(
 
     Parameters
     ----------
-    issues : np.ndarray
-        Boolean **mask** for the entire dataset where ``True`` represents a pixel label issue and ``False``
-        represents an example that is accurately labeled.
+    issues:
+      Boolean **mask** for the entire dataset
+      where ``True`` represents a pixel label issue and ``False`` represents an example that is
+      accurately labeled.
 
-    labels : Optional[np.ndarray]
-        Optional discrete array of noisy labels for a semantic segmentation dataset, in the shape ``(N,H,W,)``,
-        where each pixel must be an integer in 0, 1, ..., K-1.
+      Same format as output by :py:func:`segmentation.filter.find_label_issues <cleanlab.segmentation.filter.find_label_issues>`
+      or :py:func:`segmentation.rank.issues_from_scores <cleanlab.segmentation.rank.issues_from_scores>`.
 
-    pred_probs : Optional[np.ndarray]
-        Optional array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
+    labels:
+      Optional discrete array of noisy labels for a segmantic segmentation dataset, in the shape ``(N,H,W,)``,
+      where each pixel must be integer in 0, 1, ..., K-1.
+      If `labels` is provided, this function also displays given label of the pixel identified with issue.
+      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
 
-    class_names : Optional[List[str]]
-        Optional list of strings, where each string represents the name of a class in the semantic segmentation problem.
+    pred_probs:
+      Optional array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
+      If `pred_probs` is provided, this function also displays predicted label of the pixel identified with issue.
+      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
 
-    exclude : Optional[List[int]]
-        Optional list of label classes that can be ignored in the errors, each element must be 0, 1, ..., K-1.
+      Tip
+      ---
+      If your labels are one hot encoded you can `np.argmax(labels_one_hot, axis=1)` assuming that `labels_one_hot` is of dimension (N,K,H,W)
+      before entering in the function
 
-    top : Optional[int]
+    class_names:
+      Optional list of strings, where each string represents the name of a class in the semantic segmentation problem.
+      The order of the names should correspond to the numerical order of the classes. The list length should be
+      equal to the number of unique classes present in the labels.
+      If provided, this function will generate a legend
+      showing the color mapping of each class in the provided colormap.
+
+      Example:
+      If there are three classes in your labels, represented by 0, 1, 2, then class_names might look like this:
+
+      .. code-block:: python
+
+            class_names = ['background', 'person', 'dog']
+
+    top:
         Optional maximum number of issues to be printed. If not provided, a good default is used.
+
+    exclude:
+        Optional list of label classes that can be ignored in the errors, each element must be 0, 1, ..., K-1
 
     **kwargs
         Additional keyword arguments to pass to `plt.show()`.
-
     """
     class_names, exclude, top = _get_summary_optional_params(class_names, exclude, top)
     if labels is None and len(exclude) > 0:

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -35,6 +35,7 @@ def display_issues(
     class_names: Optional[List[str]] = None,
     exclude: Optional[List[int]] = None,
     top: Optional[int] = None,
+    **kwargs  # Accepting additional kwargs for plt.show()
 ) -> None:
     """
     Display semantic segmentation label issues, showing images with problematic pixels highlighted.
@@ -43,49 +44,28 @@ def display_issues(
 
     Parameters
     ----------
-    issues:
-      Boolean **mask** for the entire dataset
-      where ``True`` represents a pixel label issue and ``False`` represents an example that is
-      accurately labeled.
+    issues : np.ndarray
+        Boolean **mask** for the entire dataset where ``True`` represents a pixel label issue and ``False``
+        represents an example that is accurately labeled.
 
-      Same format as output by :py:func:`segmentation.filter.find_label_issues <cleanlab.segmentation.filter.find_label_issues>`
-      or :py:func:`segmentation.rank.issues_from_scores <cleanlab.segmentation.rank.issues_from_scores>`.
+    labels : Optional[np.ndarray]
+        Optional discrete array of noisy labels for a semantic segmentation dataset, in the shape ``(N,H,W,)``,
+        where each pixel must be an integer in 0, 1, ..., K-1.
 
-    labels:
-      Optional discrete array of noisy labels for a segmantic segmentation dataset, in the shape ``(N,H,W,)``,
-      where each pixel must be integer in 0, 1, ..., K-1.
-      If `labels` is provided, this function also displays given label of the pixel identified with issue.
-      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
+    pred_probs : Optional[np.ndarray]
+        Optional array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
 
-    pred_probs:
-      Optional array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
-      If `pred_probs` is provided, this function also displays predicted label of the pixel identified with issue.
-      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
+    class_names : Optional[List[str]]
+        Optional list of strings, where each string represents the name of a class in the semantic segmentation problem.
 
-      Tip
-      ---
-      If your labels are one hot encoded you can `np.argmax(labels_one_hot, axis=1)` assuming that `labels_one_hot` is of dimension (N,K,H,W)
-      before entering in the function
+    exclude : Optional[List[int]]
+        Optional list of label classes that can be ignored in the errors, each element must be 0, 1, ..., K-1.
 
-    class_names:
-      Optional list of strings, where each string represents the name of a class in the semantic segmentation problem.
-      The order of the names should correspond to the numerical order of the classes. The list length should be
-      equal to the number of unique classes present in the labels.
-      If provided, this function will generate a legend
-      showing the color mapping of each class in the provided colormap.
-
-      Example:
-      If there are three classes in your labels, represented by 0, 1, 2, then class_names might look like this:
-
-      .. code-block:: python
-
-            class_names = ['background', 'person', 'dog']
-
-    top:
+    top : Optional[int]
         Optional maximum number of issues to be printed. If not provided, a good default is used.
 
-    exclude:
-        Optional list of label classes that can be ignored in the errors, each element must be 0, 1, ..., K-1
+    **kwargs
+        Additional keyword arguments to pass to `plt.show()`.
 
     """
     class_names, exclude, top = _get_summary_optional_params(class_names, exclude, top)
@@ -100,7 +80,7 @@ def display_issues(
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
         from matplotlib.colors import ListedColormap
-    except:
+    except ImportError:
         raise ImportError('try "pip install matplotlib"')
 
     output_plots = (pred_probs is not None) + (labels is not None) + 1
@@ -128,7 +108,7 @@ def display_issues(
             handles=patches, loc="center", ncol=len(class_names), facecolor="white", fontsize=20
         )  # adjust fontsize for larger text
         plt.axis("off")
-        plt.show()
+        plt.show(**kwargs)  # Passing kwargs to plt.show()
 
     for i in correct_ordering:
         # Show images
@@ -158,7 +138,7 @@ def display_issues(
             mask = ~np.isin(labels[i], exclude)
         ax.imshow(issues[i] & mask, cmap=error_cmap, vmin=0, vmax=1)
         ax.set_title(f"Image {i}: Suggested Errors (in Red)")
-        plt.show()
+        plt.show(**kwargs)  # Passing kwargs to plt.show() again for the loop
 
     return None
 

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -44,57 +44,103 @@ def display_issues(
 
     Parameters
     ----------
-    issues:
-      Boolean **mask** for the entire dataset
-      where ``True`` represents a pixel label issue and ``False`` represents an example that is
-      accurately labeled.
+    issues : np.ndarray
+        Boolean **mask** for the entire dataset where ``True`` represents a pixel label issue and ``False``
+        represents an example that is accurately labeled.
 
-      Same format as output by :py:func:`segmentation.filter.find_label_issues <cleanlab.segmentation.filter.find_label_issues>`
-      or :py:func:`segmentation.rank.issues_from_scores <cleanlab.segmentation.rank.issues_from_scores>`.
+    labels : Optional[np.ndarray]
+        Optional discrete array of noisy labels for a semantic segmentation dataset, in the shape ``(N,H,W,)``,
+        where each pixel must be an integer in 0, 1, ..., K-1.
 
-    labels:
-      Optional discrete array of noisy labels for a segmantic segmentation dataset, in the shape ``(N,H,W,)``,
-      where each pixel must be integer in 0, 1, ..., K-1.
-      If `labels` is provided, this function also displays given label of the pixel identified with issue.
-      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
+    pred_probs : Optional[np.ndarray]
+        Optional array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
 
-    pred_probs:
-      Optional array of shape ``(N,K,H,W,)`` of model-predicted class probabilities.
-      If `pred_probs` is provided, this function also displays predicted label of the pixel identified with issue.
-      Refer to documentation for this argument in :py:func:`find_label_issues <cleanlab.segmentation.filter.find_label_issues>` for more information.
+    class_names : Optional[List[str]]
+        Optional list of strings, where each string represents the name of a class in the semantic segmentation problem.
 
-      Tip
-      ---
-      If your labels are one hot encoded you can `np.argmax(labels_one_hot, axis=1)` assuming that `labels_one_hot` is of dimension (N,K,H,W)
-      before entering in the function
+    exclude : Optional[List[int]]
+        Optional list of label classes that can be ignored in the errors, each element must be 0, 1, ..., K-1.
 
-    class_names:
-      Optional list of strings, where each string represents the name of a class in the semantic segmentation problem.
-      The order of the names should correspond to the numerical order of the classes. The list length should be
-      equal to the number of unique classes present in the labels.
-      If provided, this function will generate a legend
-      showing the color mapping of each class in the provided colormap.
-
-      Example:
-      If there are three classes in your labels, represented by 0, 1, 2, then class_names might look like this:
-
-      .. code-block:: python
-
-            class_names = ['background', 'person', 'dog']
-
-    top:
+    top : Optional[int]
         Optional maximum number of issues to be printed. If not provided, a good default is used.
 
-    exclude:
-        Optional list of label classes that can be ignored in the errors, each element must be 0, 1, ..., K-1
-
-    **kwargs:
+    **kwargs
         Additional keyword arguments to pass to `plt.show()`.
-    """
-    # The rest of the function implementation remains the same
-    # Including handling for plt.show() calls with **kwargs passed in
-    plt.show(**kwargs)
 
+    """
+    class_names, exclude, top = _get_summary_optional_params(class_names, exclude, top)
+    if labels is None and len(exclude) > 0:
+        raise ValueError("Provide labels to allow class exclusion")
+
+    top = min(top, len(issues))
+
+    correct_ordering = np.argsort(-np.sum(issues, axis=(1, 2)))[:top]
+
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib.patches as mpatches
+        from matplotlib.colors import ListedColormap
+    except ImportError:
+        raise ImportError('try "pip install matplotlib"')
+
+    output_plots = (pred_probs is not None) + (labels is not None) + 1
+
+    # Colormap for errors
+    error_cmap = ListedColormap(["none", "red"])
+    _, h, w = issues.shape
+    if output_plots > 1:
+        if pred_probs is not None:
+            _, num_classes, _, _ = pred_probs.shape
+            cmap = _generate_colormap(num_classes)
+        elif labels is not None:
+            num_classes = max(np.unique(labels)) + 1
+            cmap = _generate_colormap(num_classes)
+    else:
+        cmap = None
+
+    # Show a legend
+    if class_names is not None and cmap is not None:
+        patches = [
+            mpatches.Patch(color=cmap[i], label=class_names[i]) for i in range(len(class_names))
+        ]
+        legend = plt.figure()  # adjust figsize for larger legend
+        legend.legend(
+            handles=patches, loc="center", ncol=len(class_names), facecolor="white", fontsize=20
+        )  # adjust fontsize for larger text
+        plt.axis("off")
+        plt.show(**kwargs)
+
+    for i in correct_ordering:
+        # Show images
+        fig, axes = plt.subplots(1, output_plots, figsize=(5 * output_plots, 5))
+        plot_index = 0
+
+        # First image - Given truth labels
+        if labels is not None:
+            axes[plot_index].imshow(cmap[labels[i]])
+            axes[plot_index].set_title("Given Labels")
+            plot_index += 1
+
+        # Second image - Argmaxed pred_probs
+        if pred_probs is not None:
+            axes[plot_index].imshow(cmap[np.argmax(pred_probs[i], axis=0)])
+            axes[plot_index].set_title("Argmaxed Prediction Probabilities")
+            plot_index += 1
+
+        # Third image - Errors
+        if output_plots == 1:
+            ax = axes
+        else:
+            ax = axes[plot_index]
+
+        mask = np.full((h, w), True)
+        if labels is not None and len(exclude) != 0:
+            mask = ~np.isin(labels[i], exclude)
+        ax.imshow(issues[i] & mask, cmap=error_cmap, vmin=0, vmax=1)
+        ax.set_title(f"Image {i}: Suggested Errors (in Red)")
+        plt.show(**kwargs)
+
+    return None
 
 
 def common_label_issues(

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -89,7 +89,7 @@ def display_issues(
         Optional list of label classes that can be ignored in the errors, each element must be 0, 1, ..., K-1
 
     kwargs
-        Additional keyword arguments to pass to `plt.show()`.
+        Additional keyword arguments to pass to `plt.show()` (matplotlib.pyplot.show).
     """
     class_names, exclude, top = _get_summary_optional_params(class_names, exclude, top)
     if labels is None and len(exclude) > 0:


### PR DESCRIPTION
## Summary

This PR addresses the issue brought up [here](https://cleanlab-community.slack.com/archives/C031BGERG3Z/p1712153457987209) in which a user can't choose to set the `block` param of `plt.show()` to `False` when plotting. The goal is to allow a user to define `kwargs` for their use case in which they can plot however they'd like.

This addresses this [issue](https://github.com/cleanlab/cleanlab/issues/1080)


