### PR TITLE
remove sklearn install from tutorial

### DIFF
--- a/docs/source/tutorials/clean_learning/tabular.ipynb
+++ b/docs/source/tutorials/clean_learning/tabular.ipynb
@@ -101,7 +101,6 @@
     "You can use `pip` to install all packages required for this tutorial as follows:\n",
     "\n",
     "```ipython3\n",
-    "!pip install sklearn\n",
     "!pip install cleanlab\n",
     "# Make sure to install the version corresponding to this tutorial\n",
     "# E.g. if viewing master branch documentation:\n",

--- a/docs/source/tutorials/clean_learning/text.ipynb
+++ b/docs/source/tutorials/clean_learning/text.ipynb
@@ -102,7 +102,7 @@
     "You can use `pip` to install all packages required for this tutorial as follows:\n",
     "\n",
     "```ipython3\n",
-    "!pip install sklearn sentence-transformers\n",
+    "!pip install sentence-transformers\n",
     "!pip install cleanlab\n",
     "# Make sure to install the version corresponding to this tutorial\n",
     "# E.g. if viewing master branch documentation:\n",

--- a/docs/source/tutorials/datalab/audio.ipynb
+++ b/docs/source/tutorials/datalab/audio.ipynb
@@ -65,7 +65,7 @@
     "You can use `pip` to install all packages required for this tutorial as follows:\n",
     "\n",
     "```ipython3\n",
-    "!pip install tensorflow==2.12.1 sklearn tensorflow_io==0.32.0 huggingface_hub==0.17.0 speechbrain==0.5.13 \n",
+    "!pip install tensorflow==2.12.1 tensorflow_io==0.32.0 huggingface_hub==0.17.0 speechbrain==0.5.13 \n",
     "!pip install \"cleanlab[datalab]\"\n",
     "# Make sure to install the version corresponding to this tutorial\n",
     "# E.g. if viewing master branch documentation:\n",

--- a/docs/source/tutorials/datalab/tabular.ipynb
+++ b/docs/source/tutorials/datalab/tabular.ipynb
@@ -61,7 +61,6 @@
     "You can use `pip` to install all packages required for this tutorial as follows:\n",
     "\n",
     "```ipython3\n",
-    "!pip install sklearn datasets\n",
     "!pip install \"cleanlab[datalab]\"\n",
     "# Make sure to install the version corresponding to this tutorial\n",
     "# E.g. if viewing master branch documentation:\n",

--- a/docs/source/tutorials/datalab/text.ipynb
+++ b/docs/source/tutorials/datalab/text.ipynb
@@ -62,7 +62,7 @@
     "You can use `pip` to install all packages required for this tutorial as follows:\n",
     "\n",
     "```ipython3\n",
-    "!pip install sklearn sentence-transformers\n",
+    "!pip install sentence-transformers\n",
     "!pip install \"cleanlab[datalab]\"\n",
     "# Make sure to install the version corresponding to this tutorial\n",
     "# E.g. if viewing master branch documentation:\n",

--- a/docs/source/tutorials/indepth_overview.ipynb
+++ b/docs/source/tutorials/indepth_overview.ipynb
@@ -40,7 +40,7 @@
     "You can use pip to install all packages required for this tutorial as follows:\n",
     "\n",
     "```\n",
-    "!pip install sklearn matplotlib \n",
+    "!pip install matplotlib \n",
     "!pip install cleanlab[datalab]\n",
     "# Make sure to install the version corresponding to this tutorial\n",
     "# E.g. if viewing master branch documentation:\n",

--- a/docs/source/tutorials/multiannotator.ipynb
+++ b/docs/source/tutorials/multiannotator.ipynb
@@ -74,7 +74,6 @@
     "You can use `pip` to install all packages required for this tutorial as follows:\n",
     "\n",
     "```ipython3\n",
-    "!pip install sklearn\n",
     "!pip install cleanlab\n",
     "\n",
     "# Make sure to install the version corresponding to this tutorial\n",

--- a/docs/source/tutorials/outliers.ipynb
+++ b/docs/source/tutorials/outliers.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Detect Outliers with Cleanlab and PyTorch Image Models (timm)\n",
     "\n",
-    "This quickstart tutorial shows how to detect outliers (out-of-distribution examples) in image data, using the [cifar10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset as an example. You can easily replace the image dataset + neural network used here with any other Pytorch dataset + neural network (e.g. to instead detect outliers in text data with minimal code changes). \n",
+    "This quick tutorial shows how to detect outliers (out-of-distribution examples) in image data, using the [cifar10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset as an example. You can easily replace the image dataset + neural network used here with any other Pytorch dataset + neural network (e.g. to instead detect outliers in text data with minimal code changes). \n",
     "\n",
     "**Overview of what we'll do in this tutorial:**\n",
     "\n",
@@ -94,7 +94,7 @@
     "You can use `pip` to install all packages required for this tutorial as follows:\n",
     "\n",
     "```ipython3\n",
-    "!pip install matplotlib sklearn torch torchvision timm\n",
+    "!pip install matplotlib torch torchvision timm\n",
     "!pip install cleanlab\n",
     "...\n",
     "# Make sure to install the version corresponding to this tutorial\n",

--- a/docs/source/tutorials/regression.ipynb
+++ b/docs/source/tutorials/regression.ipynb
@@ -88,7 +88,7 @@
     "You can use `pip` to install all packages required for this tutorial as follows:\n",
     "\n",
     "```ipython3\n",
-    "!pip install scikit-learn matplotlib>=3.6.0\n",
+    "!pip install matplotlib\n",
     "!pip install cleanlab[datalab]\n",
     "# Make sure to install the version corresponding to this tutorial\n",
     "# E.g. if viewing master branch documentation:\n",
@@ -106,7 +106,6 @@
    "outputs": [],
    "source": [
     "# Package installation (hidden on docs website).\n",
-    "# Package versions we used: scikit-learn\n",
     "\n",
     "dependencies = [\"cleanlab\", \"matplotlib>=3.6.0\", \"datasets\"]\n",
     "\n",


### PR DESCRIPTION
it's already a cleanlab dependency, and now `pip install sklearn` leads to unhappy messages:

![Screen Shot 2024-04-08 at 5 41 05 PM](https://github.com/cleanlab/cleanlab/assets/1390638/55f54cee-4c59-4676-bc6a-9c54a352a090)
