### PR TITLE
Improve docstrings in token_classification/summary.py

### DIFF
--- a/cleanlab/token_classification/summary.py
+++ b/cleanlab/token_classification/summary.py
@@ -90,9 +90,6 @@ def display_issues(
     ...     ["An", "sentence", "with", "a", "typo"],
     ... ]
     >>> display_issues(issues, tokens)
-    Classes will be printed in terms of their integer index since `class_names` was not provided.
-    Specify this argument to see the string names of each class.
-    <BLANKLINE>
     Sentence index: 2, Token index: 0
     Token: An
     ----
@@ -104,11 +101,11 @@ def display_issues(
     ----
     A ?weird sentence
     """
-    if not class_names:
+    if not class_names and (labels or pred_probs):
         print(
-            "Classes will be printed in terms of their integer index since `class_names` was not provided."
+            "Classes will be printed in terms of their integer index since `class_names` was not provided.\n"
+            "Specify this argument to see the string names of each class.\n"
         )
-        print("Specify this argument to see the string names of each class.\n")
 
     top = min(top, len(issues))
     shown = 0

--- a/cleanlab/token_classification/summary.py
+++ b/cleanlab/token_classification/summary.py
@@ -90,20 +90,25 @@ def display_issues(
     ...     ["An", "sentence", "with", "a", "typo"],
     ... ]
     >>> display_issues(issues, tokens)
-    Sentence 2, token 0:
+    Classes will be printed in terms of their integer index since `class_names` was not provided.
+    Specify this argument to see the string names of each class.
+    <BLANKLINE>
+    Sentence index: 2, Token index: 0
+    Token: An
     ----
     An sentence with a typo
-    ...
-    ...
-    Sentence 0, token 1:
+    <BLANKLINE>
+    <BLANKLINE>
+    Sentence index: 0, Token index: 1
+    Token: ?weird
     ----
     A ?weird sentence
     """
     if not class_names:
         print(
-            "Classes will be printed in terms of their integer index since `class_names` was not provided. "
+            "Classes will be printed in terms of their integer index since `class_names` was not provided."
         )
-        print("Specify this argument to see the string names of each class. \n")
+        print("Specify this argument to see the string names of each class.\n")
 
     top = min(top, len(issues))
     shown = 0
@@ -223,6 +228,10 @@ def common_label_issues(
     ...     ["An", "sentence", "with", "a", "typo"],
     ... ]
     >>> df = common_label_issues(issues, tokens)
+    Token '?weird' is potentially mislabeled 1 times throughout the dataset
+    <BLANKLINE>
+    Token 'An' is potentially mislabeled 1 times throughout the dataset
+    <BLANKLINE>
     >>> df
         token  num_label_issues
     0      An                 1


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Fix doctest issues in token_classification/summary.py
>

To ensure that the doctests are working correctly, I ran:
```python
python3 -m doctest cleanlab/token_classification/summary.py
```
It produces an error on the current version that has been addressed with this PR.

I have removed the extra space in the print messages because `print` produces a new line by default, thus this space is not useful and conflicts with doctests.


## Testing

> 🔍 Testing Done: Existing test suite and `python3 -m doctest cleanlab/token_classification/summary.py`.
>


## Links to Relevant Issues or Conversations
#1092