### PR TITLE
Fix: TypeError ufunc 'isnan' not supported for the input types

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/null.py
+++ b/cleanlab/datalab/internal/issue_manager/null.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, List
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -34,12 +34,14 @@ class NullIssueManager(IssueManager):
     }
 
     @staticmethod
-    def _calculate_null_issues(features: npt.NDArray) -> tuple[ndarray, ndarray, Any]:
+    def _calculate_null_issues(
+        features: npt.NDArray[Any],
+    ) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.float64], npt.NDArray[np.bool_]]:
         """Tracks the number of null values in each row of a feature array,
         computes quality scores based on the fraction of null values in each row,
         and returns a boolean array indicating whether each row only has null values."""
         cols = features.shape[1]
-        null_tracker = np.isnan(features)
+        null_tracker = pd.isna(features)
         non_null_count = cols - null_tracker.sum(axis=1)
         scores = non_null_count / cols
         is_null_issue = non_null_count == 0

--- a/cleanlab/datalab/internal/issue_manager/null.py
+++ b/cleanlab/datalab/internal/issue_manager/null.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
-from numpy import ndarray
 
 from cleanlab.datalab.internal.issue_manager import IssueManager
 


### PR DESCRIPTION
## Summary
Addresses #1063

> 🎯 **Purpose**: Fix TypeError when inputs cannot be cast using numpy safe rule.
>

**[ ✏️ Write your summary here. ]**
To avoid the exception I changed `np.isnan` to `pd.isna` as suggested in #1063. In addition, I added a new test that asserts this behavior works correctly and improved the type hints of the modified function (mypy --strict now reports 2 fewer errors). When this test is run on the current master branch it raises a TypeError exception.

## Testing

> 🔍 Testing Done: Existing test suite and the new added test.

## Links to Relevant Issues or Conversations

> 🔗 What Git or Slack items (Issues, threads, etc) that are specifically related to
> this work? Please link them here.

#1063

## References


## Reviewer Notes
> 💡 Include any specific points for the reviewer to consider during their review.