### PR TITLE
Perf object detection

### DIFF
--- a/cleanlab/object_detection/filter.py
+++ b/cleanlab/object_detection/filter.py
@@ -273,13 +273,14 @@ def _calculate_ap_per_class(
     num_images = len(predictions)
     num_scale = 1
     num_classes = len(predictions[0])
-    if num_images > 1:
+    use_pool = num_images > 1 and num_procs > 1
+    if use_pool:
         num_procs = min(num_procs, num_images)
         pool = Pool(num_procs)
     ap_per_class_list = []
     for class_num in range(num_classes):
         pred_bboxes, lab_bboxes = _filter_by_class(labels, predictions, class_num)
-        if num_images > 1:
+        if use_pool:
             tpfp = pool.starmap(
                 _calculate_true_positives_false_positives,
                 zip(pred_bboxes, lab_bboxes, [iou_threshold for _ in range(num_images)]),
@@ -287,10 +288,11 @@ def _calculate_ap_per_class(
         else:
             tpfp = [
                 _calculate_true_positives_false_positives(
-                    pred_bboxes[0],
-                    lab_bboxes[0],
+                    pred,
+                    lab,
                     iou_threshold,
                 )
+                for pred, lab in zip(pred_bboxes, lab_bboxes)
             ]
         true_positives, false_positives = tuple(zip(*tpfp))
         num_gts = np.zeros(num_scale, dtype=int)
@@ -309,7 +311,7 @@ def _calculate_ap_per_class(
         precisions = precisions[0, :]
         ap = _calculate_average_precision(recalls, precisions)
         ap_per_class_list.append(ap)
-    if num_images > 1:
+    if use_pool:
         pool.close()
     return ap_per_class_list
 
@@ -351,25 +353,25 @@ def _calculate_true_positives_false_positives(
         else:
             return true_positives, false_positives
     ious = _get_overlap_matrix(pred_bboxes, lab_bboxes)
-    ious_max = ious.max(axis=1)
     ious_argmax = ious.argmax(axis=1)
     sorted_indices = np.argsort(-pred_bboxes[:, -1])
     is_covered = np.zeros(num_labels, dtype=bool)
-    for index in sorted_indices:
-        if ious_max[index] >= iou_threshold:
-            matching_label = ious_argmax[index]
-            if not is_covered[matching_label]:
-                is_covered[matching_label] = True
-                true_positives[0, index] = 1
-            else:
-                false_positives[0, index] = 1
+
+    mask = ious[sorted_indices, ious_argmax[sorted_indices]] >= iou_threshold
+    false_positives[0, sorted_indices[~mask]] = 1
+    matching_labels = ious_argmax[sorted_indices[mask]]
+    for index, matching_label in zip(sorted_indices[mask], matching_labels):
+        if not is_covered[matching_label]:
+            is_covered[matching_label] = True
+            true_positives[0, index] = 1
         else:
             false_positives[0, index] = 1
+
     if return_false_negative:
         false_negatives = np.zeros((num_scales, num_labels), dtype=np.float32)
-        for label_index in range(num_labels):
-            if not is_covered[label_index]:
-                false_negatives[0, label_index] = 1
+        labels_arange = np.arange(num_labels)
+        mask = ~is_covered[labels_arange]
+        false_negatives[0, labels_arange[mask]] = 1
         return true_positives, false_positives, false_negatives
     return true_positives, false_positives
 
@@ -387,10 +389,9 @@ def _calculate_average_precision(
     modified_recall = np.hstack((zeros_matrix, recall_values, ones_matrix))
     modified_precision = np.hstack((zeros_matrix, precision_values, zeros_matrix))
 
-    for i in range(modified_precision.shape[1] - 1, 0, -1):
-        modified_precision[:, i - 1] = np.maximum(
-            modified_precision[:, i - 1], modified_precision[:, i]
-        )
+    modified_precision[:, :-1] = np.flip(
+        np.maximum.accumulate(np.flip(modified_precision[:, :-1], axis=1), axis=1)
+    )
 
     for i in range(num_scales):
         index = np.where(modified_recall[i, 1:] != modified_recall[i, :-1])[0]

--- a/cleanlab/object_detection/filter.py
+++ b/cleanlab/object_detection/filter.py
@@ -24,15 +24,16 @@ import numpy as np
 
 from cleanlab.internal.constants import (
     ALPHA,
+    AP_SCALE_FACTOR,
+    BADLOC_THRESHOLD_FACTOR,
     HIGH_PROBABILITY_THRESHOLD,
     LOW_PROBABILITY_THRESHOLD,
     OVERLOOKED_THRESHOLD_FACTOR,
-    BADLOC_THRESHOLD_FACTOR,
     SWAP_THRESHOLD_FACTOR,
-    AP_SCALE_FACTOR,
 )
 from cleanlab.internal.object_detection_utils import assert_valid_inputs
 from cleanlab.object_detection.rank import (
+    _get_overlap_matrix,
     _get_valid_inputs_for_compute_scores,
     _separate_label,
     _separate_prediction,
@@ -41,7 +42,6 @@ from cleanlab.object_detection.rank import (
     compute_swap_box_scores,
     get_label_quality_scores,
     issues_from_scores,
-    _get_overlap_matrix,
 )
 
 

--- a/cleanlab/object_detection/rank.py
+++ b/cleanlab/object_detection/rank.py
@@ -323,20 +323,20 @@ def _get_overlap_matrix(bb1_list: np.ndarray, bb2_list: np.ndarray) -> np.ndarra
 
 def _get_iou(bb1: np.ndarray, bb2: np.ndarray) -> np.ndarray:
     """
-    Calculate the Intersection over Union (IoU) of one bounding box with an array of bounding_boxes.
+    Calculate the Intersection over Union (IoU) of an array of bounding box with an array of bounding_boxes.
     I've modified this to calculate overlap ratio in the line:
     iou = np.clip(intersection_area / (bb1_area + bb2_area - intersection_area), 0.0, 1.0)
 
     Parameters
     ----------
     bb1 : np.ndarray
-        Shape [x1, y1, x2, y2]
+        Shape [N1, 4] where bb2[i, :] must be an array of shape [x1, y1, x2, y2] corresponding to the bouding box i.
     bb2 : np.ndarray
-        Shape [N, 4] where bb2[i, :] must be an array of shape [x1, y1, x2, y2] corresponding to the bouding box i.
+        Shape [N2, 4] where bb2[j, :] must be an array of shape [x1, y1, x2, y2] corresponding to the bouding box j.
     Returns
     -------
     np.ndarray
-        in [0, 1]
+        values in [0, 1]
     """
     # determine the coordinates of the intersection rectangle
     x_left = np.maximum(bb1[:, 0][:, np.newaxis], bb2[:, 0][np.newaxis, :])

--- a/cleanlab/object_detection/rank.py
+++ b/cleanlab/object_detection/rank.py
@@ -346,8 +346,6 @@ def _get_iou(bb1: np.ndarray, bb2: np.ndarray) -> np.ndarray:
     x_right = np.minimum(bb1[2], bb2[:, 2])
     y_bottom = np.minimum(bb1[3], bb2[:, 3])
 
-    iou = np.empty(bb2.shape[0])
-
     # The intersection of two axis-aligned bounding boxes is always an
     # axis-aligned bounding box
     intersection_area = (x_right - x_left) * (y_bottom - y_top)

--- a/cleanlab/object_detection/rank.py
+++ b/cleanlab/object_detection/rank.py
@@ -384,22 +384,23 @@ def _has_overlap(bbox_list, labels):
     return np.array(results_overlap)
 
 
-def _euc_dis(box1: List[float], box2: List[float]) -> float:
+def _euc_dis(box1: np.ndarray, box2: np.ndarray) -> float:
     """Calculates the Euclidean distance between `box1` and `box2`."""
+    p2 = np.empty((box2.shape[0], 2))
     x1, y1 = (box1[0] + box1[2]) / 2, (box1[1] + box1[3]) / 2
-    x2, y2 = (box2[0] + box2[2]) / 2, (box2[1] + box2[3]) / 2
+    p2[:, 0] = (box2[:, 0] + box2[:, 2]) / 2
+    p2[:, 1] = (box2[:, 1] + box2[:, 3]) / 2
     p1 = np.array([x1, y1])
-    p2 = np.array([x2, y2])
-    val2 = np.exp(-np.linalg.norm(p1 - p2) * EUC_FACTOR)
-    return val2
+    return np.exp(-np.linalg.norm(p1 - p2, axis=1) * EUC_FACTOR)
 
 
 def _get_dist_matrix(bb1_list: np.ndarray, bb2_list: np.ndarray) -> np.ndarray:
     """Returns a distance matrix of distances from all of boxes in bb1_list to all of boxes in bb2_list."""
     wd = np.zeros(shape=(len(bb1_list), len(bb2_list)))
-    for i in range(len(bb1_list)):
-        for j in range(len(bb2_list)):
-            wd[i][j] = _euc_dis(bb1_list[i], bb2_list[j])
+    if not len(bb2_list):
+        return wd
+    for i, bb1 in enumerate(bb1_list):
+        wd[i] = _euc_dis(bb1, bb2_list)
     return wd
 
 


### PR DESCRIPTION
## Summary
This PR partially addresses #862 

> 🎯 **Purpose**: Improve performance of find_label_issues in object_detection/filter.py file.
>

**[ ✏️ Write your summary here. ]**
A significant improvement comes from vectorizing `_get_iou`, `_euc_dis` and `_calculate_average_precision`. I searched for all references to the deleted `_mod_coordinates` and `_get_overlap` but they are not used anywhere else in the code. I assumed it is ok to remove them because they are not part of the public api however let me know if you prefer to deprecate them or keep both versions.


For memory I used the memory-profiler library. The code I used for benchmarking is copied below. In addition I sorted the imports in the modified files.

**Code Setup**
```python
import random

import numpy as np

from cleanlab.object_detection.filter import find_label_issues

np.random.seed(0)
random.seed(0)

N = 5_000
SIZE = 256
MAX_L = 10
MAX_M = 100
K = 20

# Create input data
labels = []
predictions = []
for _ in range(N):
    x = random.randint(1, MAX_L)
    bboxes = np.empty((x, 4))
    bboxes[:, :2] = np.random.randint(0, SIZE // 2, size=(x, 2))
    bboxes[:, 2:] = np.random.randint(SIZE // 2, SIZE, size=(x, 2))
    img_labels = np.random.randint(K, size=x)
    label = {"bboxes": bboxes, "labels": img_labels}
    labels.append(label)

    y = random.randint(x, MAX_M)
    prediction = np.empty((K, y, 5))
    prediction[:, :, :2] = np.random.randint(0, SIZE // 2, size=(K, y, 2))
    prediction[:, :, 2:4] = np.random.randint(SIZE // 2, SIZE, size=(K, y, 2))
    prediction[:, :, 4] = np.random.random((K, y))
    predictions.append(prediction)
```

**Current version**
```python
%%timeit
%memit find_label_issues(labels, predictions)
# peak memory: 1317.51 MiB, increment: 820.18 MiB
# peak memory: 1317.58 MiB, increment: 0.07 MiB
# peak memory: 1317.60 MiB, increment: 0.02 MiB
# peak memory: 1317.86 MiB, increment: 0.28 MiB
# peak memory: 1319.04 MiB, increment: 1.18 MiB
# peak memory: 1319.09 MiB, increment: 0.07 MiB
# peak memory: 1319.09 MiB, increment: 0.02 MiB
# peak memory: 1319.11 MiB, increment: 0.02 MiB
# 8min 7s ± 30.2 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**This PR**
```python
%%timeit
%memit find_label_issues(labels, predictions)
# peak memory: 1291.41 MiB, increment: 792.09 MiB
# peak memory: 1291.82 MiB, increment: 1.19 MiB
# peak memory: 1291.87 MiB, increment: 0.05 MiB
# peak memory: 1292.05 MiB, increment: 0.18 MiB
# peak memory: 1292.07 MiB, increment: 0.00 MiB
# peak memory: 1292.07 MiB, increment: 0.00 MiB
# peak memory: 1292.07 MiB, increment: 0.00 MiB
# peak memory: 1292.07 MiB, increment: 0.00 MiB
# 29.2 s ± 574 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


## Testing

> 🔍 Testing Done: Existing test suite and output verification (explained below).


## References


## Reviewer Notes
> 💡 Include any specific points for the reviewer to consider during their review.

I was not sure about which input would be more realistic, I have tried different options but the improvements were similar, however let me know if you want me to test a specific combination of inputs, I tried to use the largest input dataset I could while still being able to run the master %%timeit in about an hour.

I have noticed that the `num_procs` argument in `_calculate_ap_per_class` is always set to the default value. Thus, i made a few changes there to ensure that the pool is only created when `num_procs` is higher than 1.

After each change I ran the tests and they were catching any minor mistake I made. However once they were passing I ensured with some random input that both versions (master and this PR) still produced the same exact output.