### PR TITLE
Refine handling of `underperforming_group` issue type

### DIFF
--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -483,11 +483,10 @@ class IssueFinder:
         if drop_class_imbalance_check:
             issue_types_copy.pop("class_imbalance")
 
-        if (
-            self.task == Task.CLASSIFICATION
-            and "underperforming_group" in issue_types_copy
-            and pred_probs is None
-        ):
+        drop_underperforming_group_check = (
+            "underperforming_group" in issue_types_copy and pred_probs is None
+        )
+        if drop_underperforming_group_check:
             issue_types_copy.pop("underperforming_group")
 
         return issue_types_copy

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -59,6 +59,7 @@ _CLASSIFICATION_ARGS_DICT = {
     "outlier": ["pred_probs", "features", "knn_graph"],
     "near_duplicate": ["features", "knn_graph"],
     "non_iid": ["pred_probs", "features", "knn_graph"],
+    # The underperforming_group issue type require a pair of inputs: (pred_probs, <any_of_the_other_three>)
     "underperforming_group": ["pred_probs", "features", "knn_graph", "cluster_ids"],
     "data_valuation": ["features", "knn_graph"],
     "class_imbalance": [],
@@ -483,8 +484,14 @@ class IssueFinder:
         if drop_class_imbalance_check:
             issue_types_copy.pop("class_imbalance")
 
-        drop_underperforming_group_check = (
-            "underperforming_group" in issue_types_copy and pred_probs is None
+        required_pairs_for_underperforming_group = [
+            ("pred_probs", "features"),
+            ("pred_probs", "knn_graph"),
+            ("pred_probs", "cluster_ids"),
+        ]
+        drop_underperforming_group_check = "underperforming_group" in issue_types_copy and not any(
+            all(key in kwargs and kwargs.get(key) is not None for key in pair)
+            for pair in required_pairs_for_underperforming_group
         )
         if drop_underperforming_group_check:
             issue_types_copy.pop("underperforming_group")

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -59,7 +59,7 @@ _CLASSIFICATION_ARGS_DICT = {
     "outlier": ["pred_probs", "features", "knn_graph"],
     "near_duplicate": ["features", "knn_graph"],
     "non_iid": ["pred_probs", "features", "knn_graph"],
-    # The underperforming_group issue type require a pair of inputs: (pred_probs, <any_of_the_other_three>)
+    # The underperforming_group issue type requires a pair of inputs: (pred_probs, <any_of_the_other_three>)
     "underperforming_group": ["pred_probs", "features", "knn_graph", "cluster_ids"],
     "data_valuation": ["features", "knn_graph"],
     "class_imbalance": [],

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -41,14 +41,15 @@ from cleanlab.datalab.internal.issue_manager_factory import (
 )
 from cleanlab.datalab.internal.model_outputs import (
     MultiClassPredProbs,
-    RegressionPredictions,
     MultiLabelPredProbs,
+    RegressionPredictions,
 )
 from cleanlab.datalab.internal.task import Task
 
 if TYPE_CHECKING:  # pragma: no cover
-    import numpy.typing as npt
     from typing import Callable
+
+    import numpy.typing as npt
 
     from cleanlab.datalab.datalab import Datalab
 
@@ -481,5 +482,12 @@ class IssueFinder:
         )
         if drop_class_imbalance_check:
             issue_types_copy.pop("class_imbalance")
+
+        if (
+            self.task == Task.CLASSIFICATION
+            and "underperforming_group" in issue_types_copy
+            and pred_probs is None
+        ):
+            issue_types_copy.pop("underperforming_group")
 
         return issue_types_copy

--- a/tests/datalab/test_issue_finder.py
+++ b/tests/datalab/test_issue_finder.py
@@ -1,9 +1,8 @@
-import pytest
 import numpy as np
-
-from cleanlab.datalab.internal.issue_finder import IssueFinder
+import pytest
 
 from cleanlab import Datalab
+from cleanlab.datalab.internal.issue_finder import IssueFinder
 from cleanlab.datalab.internal.task import Task
 
 
@@ -46,6 +45,11 @@ class TestIssueFinder:
             available_issue_types = issue_finder.get_available_issue_types(issue_types=issue_types)
             fail_msg = f"Failed to get available issue types with issue_types={issue_types}"
             assert available_issue_types == issue_types, fail_msg
+
+        only_features_available = {"features": np.random.random((10, 2))}
+        available_issue_types = issue_finder.get_available_issue_types(**only_features_available)
+        fail_msg = "underperforming_group should not be available if 'pred_probs' is not provided"
+        assert "underperforming_group" not in available_issue_types
 
     def test_find_issues(self, issue_finder, lab):
         N = len(lab.data)

--- a/tests/datalab/test_issue_finder.py
+++ b/tests/datalab/test_issue_finder.py
@@ -24,6 +24,101 @@ class TestIssueFinder:
     def test_init(self, issue_finder):
         assert issue_finder.verbosity == 1
 
+    @pytest.mark.parametrize("key", ["pred_probs", "features", "knn_graph"])
+    def test_get_available_issue_types_no_kwargs(self, issue_finder, key):
+        expected_issue_types = {"class_imbalance": {}}
+        issue_types = issue_finder.get_available_issue_types(**{key: None})
+        assert (
+            issue_types == expected_issue_types
+        ), "Only class_imbalance issue type for classification requires no kwargs"
+
+    @pytest.mark.parametrize(
+        "issue_types",
+        [
+            {"label": {}},
+            {"label": {"some_arg": "some_value"}},
+            {"label": {"some_arg": "some_value"}, "outlier": {}},
+            {"label": {}, "outlier": {}, "some_issue_type": {"some_arg": "some_value"}},
+            {},
+        ],
+    )
+    def test_get_available_issue_types_with_issue_types(self, issue_finder, issue_types):
+        available_issue_types = issue_finder.get_available_issue_types(issue_types=issue_types)
+        assert (
+            available_issue_types == issue_types
+        ), f"Failed to get available issue types with issue_types={issue_types}"
+
+    @pytest.mark.parametrize(
+        "keys, should_contain_underperforming_group",
+        [
+            # Test cases where 'pred_probs' is not provided, should all give False
+            (["features"], False),
+            (["knn_graph"], False),
+            (["cluster_ids"], False),
+            (["features", "knn_graph"], False),
+            (["features", "cluster_ids"], False),
+            (["knn_graph", "cluster_ids"], False),
+            (["features", "knn_graph", "cluster_ids"], False),
+            # Test cases where 'pred_probs' is provided should all give True
+            (["pred_probs", "features"], True),
+            (["pred_probs", "knn_graph"], True),
+            (["pred_probs", "cluster_ids"], True),
+            (["pred_probs", "features", "knn_graph"], True),
+            (["pred_probs", "features", "cluster_ids"], True),
+            (["pred_probs", "knn_graph", "cluster_ids"], True),
+            (["pred_probs", "features", "knn_graph", "cluster_ids"], True),
+            # only if other required keys are provided
+            (["pred_probs"], False),
+        ],
+        ids=lambda v: (
+            f"keys={v} "
+            if isinstance(v, list)
+            else ("> available" if v is True else "> unavailable")
+        ),
+    )
+    # Some warnings about preferring cluster_ids over knn_graph, or knn_graph over features can be ignored
+    @pytest.mark.filterwarnings(r"ignore:.*will (likely )?prefer.*:UserWarning")
+    # No other warnings should be allowed
+    @pytest.mark.filterwarnings("error")
+    def test_underperforming_group_availability_issue_1065(
+        self, issue_finder, keys, should_contain_underperforming_group
+    ):
+        """
+        Tests the availability of the 'underperforming_group' issue type based on the presence of 'pred_probs' and other required keys in the supplied arguments.
+
+        This test addresses issue #1065, where the mapping that decides which issue types to run based on the supplied arguments is incorrect.
+        Specifically, the 'underperforming_group' check should only be executed if 'pred_probs' and another required key are included in the supplied arguments.
+        See: https://github.com/cleanlab/cleanlab/issues/1065.
+
+        Parameters
+        ----------
+        keys : list
+            A list of keys to be included in the kwargs.
+        should_contain_underperforming_group : bool
+            A flag indicating whether the 'underperforming_group' issue type should be present in the available issue types.
+
+        Scenarios
+        ---------
+        Various combinations of 'features', 'pred_probs', 'knn_graph', and 'cluster_ids' are tested.
+
+        Asserts
+        -------
+        Ensures 'underperforming_group' is in the available issue types if 'pred_probs' and another required key are provided.
+        Ensures 'underperforming_group' is not in the available issue types if the required conditions are not met.
+        """
+        mock_value = object()  # Mock value to simulate presence of the required keys
+        kwargs = {key: mock_value for key in keys}
+
+        available_issue_types = issue_finder.get_available_issue_types(**kwargs)
+        if should_contain_underperforming_group:
+            assert (
+                "underperforming_group" in available_issue_types
+            ), "underperforming_group should be available if 'pred_probs' and another required key are provided"
+        else:
+            assert (
+                "underperforming_group" not in available_issue_types
+            ), "underperforming_group should not be available if the required conditions are not met"
+
     def test_get_available_issue_types(self, issue_finder):
         expected_issue_types = {"class_imbalance": {}}
         # Test with no kwargs, no issue type expected to be returned
@@ -46,10 +141,20 @@ class TestIssueFinder:
             fail_msg = f"Failed to get available issue types with issue_types={issue_types}"
             assert available_issue_types == issue_types, fail_msg
 
+        ## Test availability of underperforming_group issue type
         only_features_available = {"features": np.random.random((10, 2))}
         available_issue_types = issue_finder.get_available_issue_types(**only_features_available)
         fail_msg = "underperforming_group should not be available if 'pred_probs' is not provided"
-        assert "underperforming_group" not in available_issue_types
+        assert "underperforming_group" not in available_issue_types, fail_msg
+        features_and_pred_probs_available = {
+            **only_features_available,
+            "pred_probs": np.random.random((10, 2)),
+        }
+        available_issue_types = issue_finder.get_available_issue_types(
+            **features_and_pred_probs_available
+        )
+        fail_msg = "underperforming_group should be available if 'pred_probs' is provided"
+        assert "underperforming_group" in available_issue_types, fail_msg
 
     def test_find_issues(self, issue_finder, lab):
         N = len(lab.data)


### PR DESCRIPTION
## Summary
Closes #1065

🎯 Purpose: Refine handling of `underperforming_group` issue type for classification tasks to ensure it is correctly included only when appropriate inputs are provided.


`UnderperformingGroupIssueManager` always requires `pred_probs`. When `features` are available but `pred_probs` is not, the `_CLASSIFICATION_ARGS_DICT` includes the underperforming_group as an available issue type. An additional check was added to remove this issue from the list like we do for `label`, `class_imbalance` and `outlier`. A new assertion was added to the existing test suite. An error is correctly raised in master and this PR fixes the issue.

The `underperforming_group` issue type should only be available when `pred_probs` and another required input (`features`, `knn_graph`, or `cluster_ids`) are provided. This enhancement ensures that the `_CLASSIFICATION_ARGS_DICT` accurately reflects this requirement. An additional check was added to exclude `underperforming_group` from the list of available issue types if these conditions are not met. This refinement aligns with how other issue types such as `label`, `class_imbalance`, and `outlier` are handled. A new assertion was added to the existing test suite to validate this behavior.



## Testing

🔍 Testing Done: Included a new assertion to verify the correct behavior of `underperforming_group` issue type availability based on input conditions.



## Links to Relevant Issues or Conversations

> 🔗 What Git or Slack items (Issues, threads, etc) that are specifically related to
> this work? Please link them here.

- Addresses #1065
- Related to #995
  - A comment was added to `_CLASSIFICATION_ARGS_DICT` to clarify how the mapping should work for `underperforming_group`.



## Reviewer Notes
- The new check for `underperforming_group` issue type and its integration with the `_CLASSIFICATION_ARGS_DICT`.
- The comprehensiveness and coverage of the updated test cases.


