### PR TITLE
Refine type hint in _process_find_label_issues_kwargs method

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/label.py
+++ b/cleanlab/datalab/internal/issue_manager/label.py
@@ -103,7 +103,6 @@ class LabelIssueManager(IssueManager):
         ]
         return {k: v for k, v in kwargs.items() if k in accepted_kwargs and v is not None}
 
-
     def _reset(self) -> None:
         """Reset the attributes of this manager based on the available datalab info
         and the keyword arguments stored as instance attributes.

--- a/cleanlab/datalab/internal/issue_manager/label.py
+++ b/cleanlab/datalab/internal/issue_manager/label.py
@@ -86,6 +86,7 @@ class LabelIssueManager(IssueManager):
     def _process_find_label_issues_kwargs(**kwargs) -> Dict[str, Any]:
         """Searches for keyword arguments that are meant for the
         CleanLearning.find_label_issues method call
+
         Examples
         --------
         >>> from cleanlab.datalab.internal.issue_manager.label import LabelIssueManager

--- a/cleanlab/datalab/internal/issue_manager/label.py
+++ b/cleanlab/datalab/internal/issue_manager/label.py
@@ -83,7 +83,7 @@ class LabelIssueManager(IssueManager):
         self._reset()
 
     @staticmethod
-    def _process_find_label_issues_kwargs(**kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def _process_find_label_issues_kwargs(**kwargs) -> Dict[str, Any]:
         """Searches for keyword arguments that are meant for the
         CleanLearning.find_label_issues method call
     

--- a/cleanlab/datalab/internal/issue_manager/label.py
+++ b/cleanlab/datalab/internal/issue_manager/label.py
@@ -86,11 +86,10 @@ class LabelIssueManager(IssueManager):
     def _process_find_label_issues_kwargs(**kwargs) -> Dict[str, Any]:
         """Searches for keyword arguments that are meant for the
         CleanLearning.find_label_issues method call
-    
         Examples
         --------
         >>> from cleanlab.datalab.internal.issue_manager.label import LabelIssueManager
-        >>> LabelIssueManager._process_find_label_issues_kwargs(**{'thresholds': [0.1, 0.9]})
+        >>> LabelIssueManager._process_find_label_issues_kwargs(thresholds=[0.1, 0.9])
         {'thresholds': [0.1, 0.9]}
         """
         accepted_kwargs = [

--- a/cleanlab/datalab/internal/issue_manager/label.py
+++ b/cleanlab/datalab/internal/issue_manager/label.py
@@ -86,11 +86,11 @@ class LabelIssueManager(IssueManager):
     def _process_find_label_issues_kwargs(**kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """Searches for keyword arguments that are meant for the
         CleanLearning.find_label_issues method call
-
+    
         Examples
         --------
         >>> from cleanlab.datalab.internal.issue_manager.label import LabelIssueManager
-        >>> LabelIssueManager._process_find_label_issues_kwargs(thresholds=[0.1, 0.9])
+        >>> LabelIssueManager._process_find_label_issues_kwargs(**{'thresholds': [0.1, 0.9]})
         {'thresholds': [0.1, 0.9]}
         """
         accepted_kwargs = [
@@ -102,6 +102,7 @@ class LabelIssueManager(IssueManager):
             "validation_func",
         ]
         return {k: v for k, v in kwargs.items() if k in accepted_kwargs and v is not None}
+
 
     def _reset(self) -> None:
         """Reset the attributes of this manager based on the available datalab info


### PR DESCRIPTION
Remove unnecessary type hint from `_process_find_label_issues_kwargs` for cleaner code.

Removing the `Dict[str, Any]` type hint simplifies the function signature because `**kwargs` inherently accepts keyword arguments, making the explicit hint redundant.