### PR TITLE
Optimize internal multilabel score

### DIFF
--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -599,17 +599,10 @@ def multilabel_py(y: np.ndarray) -> np.ndarray:
            [0.8, 0.2]])
     """
 
-    def compute_class_py(y_slice: np.ndarray) -> np.ndarray:
-        # Should only consider a single class at a time
-        assert y_slice.ndim == 1
-        unique_values, counts = np.unique(y_slice, axis=0, return_counts=True)
-        N = y_slice.shape[0]
-        if len(unique_values) == 1:
-            # Should be 0 and 1, pad with 0 probability if either is missing.
-            counts = np.array([0, N] if unique_values[0] == 1 else [N, 0])
-        return counts / N
-
-    py = np.apply_along_axis(compute_class_py, axis=1, arr=y.T)
+    N, _ = y.shape
+    fraction_0 = np.sum(y == 0, axis=0) / N
+    fraction_1 = 1 - fraction_0
+    py = np.column_stack((fraction_0, fraction_1))
     return py
 
 

--- a/cleanlab/internal/multilabel_scorer.py
+++ b/cleanlab/internal/multilabel_scorer.py
@@ -22,13 +22,14 @@ from typing import Callable, Dict, Optional, Union
 
 import numpy as np
 from sklearn.model_selection import cross_val_predict
-from cleanlab.internal.multilabel_utils import _is_multilabel, stack_complement
+
 from cleanlab.internal.label_quality_utils import _subtract_confident_thresholds
+from cleanlab.internal.multilabel_utils import _is_multilabel, stack_complement
 from cleanlab.internal.numerics import softmax
 from cleanlab.rank import (
-    get_self_confidence_for_each_label,
-    get_normalized_margin_for_each_label,
     get_confidence_weighted_entropy_for_each_label,
+    get_normalized_margin_for_each_label,
+    get_self_confidence_for_each_label,
 )
 
 
@@ -616,9 +617,7 @@ def multilabel_py(y: np.ndarray) -> np.ndarray:
 
 
 def _get_split_generator(labels, cv):
-    unique_labels = np.unique(labels, axis=0)
-    label_to_index = {tuple(label): i for i, label in enumerate(unique_labels)}
-    multilabel_ids = np.array([label_to_index[tuple(label)] for label in labels])
+    _, multilabel_ids = np.unique(labels, axis=0, return_inverse=True)
     split_generator = cv.split(X=multilabel_ids, y=multilabel_ids)
     return split_generator
 


### PR DESCRIPTION
## Summary
This PR partially addresses #862 

> 🎯 **Purpose**: Improve performance of internal multilabel_py and _get_split_generator functions.
>

**[ ✏️ Write your summary here. ]**
The significant improvement comes from using numpy operations where possible.

For memory I used the memory-profiler library. The code I used for benchmarking is copied below. In addition I sorted the imports in the modified files.

**Code Setup**
```python
import numpy as np
from sklearn.model_selection import ShuffleSplit

from cleanlab.internal.multilabel_scorer import _get_split_generator, multilabel_py

np.random.seed(0)

N = 1_000_000
K = 20
labels = np.random.randint(K, size=(N, K))
cv = ShuffleSplit(n_splits=5, test_size=0.2, random_state=0)

# We will use a larger input for multilabel_py function
N = 10_000_000
y = np.random.randint(2, size=(N, K))
```

**Current version**
```python
%%timeit
%memit _get_split_generator(labels, cv)
# peak memory: 1457.49 MiB, increment: 1036.85 MiB
# peak memory: 1483.90 MiB, increment: 1058.73 MiB
# peak memory: 1484.05 MiB, increment: 1034.66 MiB
# peak memory: 1484.31 MiB, increment: 1034.92 MiB
# peak memory: 1484.32 MiB, increment: 1034.67 MiB
# peak memory: 1484.30 MiB, increment: 1034.66 MiB
# peak memory: 1484.32 MiB, increment: 1034.68 MiB
# peak memory: 1484.31 MiB, increment: 1034.67 MiB
# 5 s ± 304 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
```python
%%timeit 
%memit multilabel_py(y)
# peak memory: 2091.26 MiB, increment: 121.00 MiB
# peak memory: 2087.01 MiB, increment: 152.54 MiB
# peak memory: 2102.09 MiB, increment: 167.62 MiB
# peak memory: 2087.30 MiB, increment: 152.83 MiB
# peak memory: 2106.12 MiB, increment: 171.39 MiB
# peak memory: 2106.13 MiB, increment: 171.41 MiB
# peak memory: 2106.05 MiB, increment: 171.32 MiB
# peak memory: 2106.13 MiB, increment: 171.41 MiB
# 1min 27s ± 651 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**This PR**
```python
%%timeit
%memit _get_split_generator(labels, cv)
# peak memory: 830.01 MiB, increment: 385.66 MiB
# peak memory: 766.49 MiB, increment: 350.77 MiB
# peak memory: 726.51 MiB, increment: 319.19 MiB
# peak memory: 722.98 MiB, increment: 315.66 MiB
# peak memory: 732.79 MiB, increment: 325.22 MiB
# peak memory: 872.84 MiB, increment: 465.27 MiB
# peak memory: 812.81 MiB, increment: 405.24 MiB
# peak memory: 732.82 MiB, increment: 325.25 MiB
# 2.11 s ± 67.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
```python
%%timeit 
%memit multilabel_py(y)
# peak memory: 2119.58 MiB, increment: 165.53 MiB
# peak memory: 2119.68 MiB, increment: 190.74 MiB
# peak memory: 2119.68 MiB, increment: 190.74 MiB
# peak memory: 2119.84 MiB, increment: 190.91 MiB
# peak memory: 2119.84 MiB, increment: 190.71 MiB
# peak memory: 2119.84 MiB, increment: 190.71 MiB
# peak memory: 2119.87 MiB, increment: 190.74 MiB
# peak memory: 2119.87 MiB, increment: 190.74 MiB
# 497 ms ± 37.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


## Testing

> 🔍 Testing Done: Existing test suite and I also verified that the outputs were the same after refactoring.


## References


## Reviewer Notes
> 💡 Include any specific points for the reviewer to consider during their review.
