### PR TITLE
Remove unsqueeze call in image tutorial

### DIFF
--- a/docs/source/tutorials/datalab/image.ipynb
+++ b/docs/source/tutorials/datalab/image.ipynb
@@ -57,7 +57,7 @@
     "You can use `pip` to install all packages required for this tutorial as follows:\n",
     "\n",
     "```ipython3\n",
-    "!pip install matplotlib torch torchvision datasets\n",
+    "!pip install matplotlib torch torchvision datasets>=2.19.0\n",
     "!pip install \"cleanlab[image]\"\n",
     "# We install cleanlab with extra dependencies for image data\n",
     "# Make sure to install the version corresponding to this tutorial\n",

--- a/docs/source/tutorials/datalab/image.ipynb
+++ b/docs/source/tutorials/datalab/image.ipynb
@@ -173,7 +173,7 @@
     "\n",
     "# Apply transformations\n",
     "def normalize(example):\n",
-    "    example[\"image\"] = (example[\"image\"] / 255.0).unsqueeze(0)\n",
+    "    example[\"image\"] = (example[\"image\"] / 255.0)\n",
     "    return example\n",
     "\n",
     "\n",

--- a/docs/source/tutorials/datalab/image.ipynb
+++ b/docs/source/tutorials/datalab/image.ipynb
@@ -173,7 +173,7 @@
     "\n",
     "# Apply transformations\n",
     "def normalize(example):\n",
-    "    example[\"image\"] = (example[\"image\"] / 255.0)\n",
+    "    example[\"image\"] = (example[\"image\"] / 255.0)  # each pixel value was originally between 0 and 255 \n",
     "    return example\n",
     "\n",
     "\n",


### PR DESCRIPTION
With the latest release of the datasets library (2.19.0), the torch formatter now handles PIL objects of 2d arrays (e.g. grayscale images) differently.

Now when calling `Dataset.with_format("torch")`, every image tensor now has shape (1, H, W) for grayscale images. Previously, this was done by the `unsqueeze(0)` call in the subsequent step in the preprocessing pipeline, but calling `unsqueeze` is redundant for 2d image datasets (stored as PIL objects).

You can verify this by running:

```python
from datasets import load_dataset

dataset = load_dataset("fashion_mnist", split="train")
transformed_dataset = dataset.with_format("torch")
transformed_dataset[:2]["image"].shape
#torch.Size([2, 1, 28, 28])
```

Previously, this would have returned

```
#torch.Size([2, 28, 28])
```

which required the call to `unsqueeze`.
