### PR TITLE
Temporarily Revert to macOS 12 in CI due to Incompatibility with Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-12
         python:
           - "3.8"
           - "3.9"


### PR DESCRIPTION
Due to a migration in our CI environment from `macos-latest` to macOS 14 runner images ([announced earlier this year](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/)), we've encountered a compatibility issue with Python 3.8 and 3.9. The new architecture of macOS 14 does not currently support these Python versions. While we expect future updates to resolve this, we will temporarily revert our CI to use macOS 12 to ensure continuity in our workflows.

Below are logs from a failed attempt to install Python 3.8 on macOS 14, demonstrating the issue:

<details><summary>CI Run Logs</summary>
<p>

```yaml
2024-04-23T13:21:58.5589880Z Current runner version: '2.315.0'
2024-04-23T13:21:58.5607110Z ##[group]Operating System
2024-04-23T13:21:58.5607640Z macOS
2024-04-23T13:21:58.5607910Z 14.4.1
2024-04-23T13:21:58.5608170Z 23E224
2024-04-23T13:21:58.5608510Z ##[endgroup]
2024-04-23T13:21:58.5608820Z ##[group]Runner Image
2024-04-23T13:21:58.5609160Z Image: macos-14-arm64
2024-04-23T13:21:58.5609490Z Version: 20240415.6
2024-04-23T13:21:58.5610310Z Included Software: https://github.com/actions/runner-images/blob/macos-14-arm64/20240415.6/images/macos/macos-14-arm64-Readme.md
2024-04-23T13:21:58.5611330Z Image Release: https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240415.6

...

2024-04-23T13:22:02.0700330Z ##[group]Run actions/setup-python@v4
2024-04-23T13:22:02.0700650Z with:
2024-04-23T13:22:02.0700820Z   python-version: 3.8
2024-04-23T13:22:02.0701030Z   check-latest: false
2024-04-23T13:22:02.0701430Z   token: ***
2024-04-23T13:22:02.0701620Z   update-environment: true
2024-04-23T13:22:02.0701860Z   allow-prereleases: false
2024-04-23T13:22:02.0702130Z ##[endgroup]
2024-04-23T13:22:02.2314830Z ##[group]Installed versions
2024-04-23T13:22:02.2372100Z Version 3.8 was not found in the local cache
2024-04-23T13:22:03.1293730Z ##[error]The version '3.8' with architecture 'arm64' was not found for macOS 14.4.1.
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
``` 

</p>
</details> 