### PR TITLE
Fix numerical instability with Euclidean distance metric

### DIFF
--- a/cleanlab/data_valuation.py
+++ b/cleanlab/data_valuation.py
@@ -19,10 +19,11 @@ Data Valuation helps us assess individual training data points' contributions to
 """
 
 
-from typing import Optional, cast
+from typing import Callable, Optional, Union, cast
 
 import numpy as np
 from scipy.sparse import csr_matrix
+from scipy.spatial.distance import euclidean
 from sklearn.neighbors import NearestNeighbors
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
@@ -45,7 +46,7 @@ def _knn_shapley_score(knn_graph: csr_matrix, labels: np.ndarray, k: int) -> np.
 
 
 def _process_knn_graph_from_features(
-    features: np.ndarray, metric: Optional[str], k: int = 10
+    features: np.ndarray, metric: Optional[Union[str, Callable]], k: int = 10
 ) -> csr_matrix:
     """Calculate the knn graph from the features if it is not provided in the kwargs."""
     if k > len(features):  # Ensure number of neighbors less than number of examples
@@ -53,7 +54,11 @@ def _process_knn_graph_from_features(
             f"Number of nearest neighbors k={k} cannot exceed the number of examples N={len(features)} passed into the estimator (knn)."
         )
     if metric == None:
-        metric = "cosine" if features.shape[1] > 3 else "euclidean"
+        metric = (
+            "cosine"
+            if features.shape[1] > 3
+            else "euclidean" if features.shape[0] > 100 else euclidean
+        )
     knn = NearestNeighbors(n_neighbors=k, metric=metric).fit(features)
     knn_graph = knn.kneighbors_graph(mode="distance")
     try:
@@ -68,7 +73,7 @@ def data_shapley_knn(
     *,
     features: Optional[np.ndarray] = None,
     knn_graph: Optional[csr_matrix] = None,
-    metric: Optional[str] = None,
+    metric: Optional[Union[str, Callable]] = None,
     k: int = 10,
 ) -> np.ndarray:
     """
@@ -94,10 +99,12 @@ def data_shapley_knn(
             If provided, this must be a 2D array with shape (num_examples, num_features).
     knn_graph :
         A precomputed sparse KNN graph. If not provided, it will be computed from the `features` using the specified `metric`.
-    metric : Optional[str], default=None
+    metric : Optional[str or Callable], default=None
         The distance metric for KNN graph construction.
         Supports metrics available in ``sklearn.neighbors.NearestNeighbors``
         Default metric is ``"cosine"`` for ``dim(features) > 3``, otherwise ``"euclidean"`` for lower-dimensional data.
+        The euclidean is computed with an efficient implementation from scikit-learn when the number of examples is greater than 100.
+        When the number of examples is 100 or fewer, a more numerically stable version of the euclidean distance from scipy is used.
     k :
         The number of neighbors to consider for the KNN graph and Data Shapley value computation.
         Must be less than the total number of data points.

--- a/cleanlab/datalab/internal/issue_manager/data_valuation.py
+++ b/cleanlab/datalab/internal/issue_manager/data_valuation.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     ClassVar,
     Dict,
     List,
@@ -30,6 +31,7 @@ import warnings
 import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
+from scipy.spatial.distance import euclidean
 from sklearn.exceptions import NotFittedError
 from sklearn.neighbors import NearestNeighbors
 from sklearn.utils.validation import check_is_fitted
@@ -101,7 +103,7 @@ class DataValuationIssueManager(IssueManager):
     def __init__(
         self,
         datalab: Datalab,
-        metric: Optional[str] = None,
+        metric: Optional[Union[str, Callable]] = None,
         threshold: Optional[float] = None,
         k: int = 10,
         **kwargs,
@@ -142,7 +144,11 @@ class DataValuationIssueManager(IssueManager):
                     "If a knn_graph is not provided, features must be provided to fit a new knn."
                 )
             if self.metric is None:
-                self.metric = "cosine" if features.shape[1] > 3 else "euclidean"
+                self.metric = (
+                    "cosine"
+                    if features.shape[1] > 3
+                    else "euclidean" if features.shape[0] > 100 else euclidean
+                )
             knn = NearestNeighbors(n_neighbors=self.k, metric=self.metric).fit(features)
 
             if self.metric and self.metric != knn.metric:

--- a/cleanlab/datalab/internal/issue_manager/duplicate.py
+++ b/cleanlab/datalab/internal/issue_manager/duplicate.py
@@ -15,12 +15,13 @@
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Union
 import warnings
 
 import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
+from scipy.spatial.distance import euclidean
 from sklearn.neighbors import NearestNeighbors
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
@@ -53,7 +54,7 @@ class NearDuplicateIssueManager(IssueManager):
     def __init__(
         self,
         datalab: Datalab,
-        metric: Optional[str] = None,
+        metric: Optional[Union[str, Callable]] = None,
         threshold: float = 0.13,
         k: int = 10,
         **_,
@@ -79,7 +80,11 @@ class NearDuplicateIssueManager(IssueManager):
                     "If a knn_graph is not provided, features must be provided to fit a new knn."
                 )
             if self.metric is None:
-                self.metric = "cosine" if features.shape[1] > 3 else "euclidean"
+                self.metric = (
+                    "cosine"
+                    if features.shape[1] > 3
+                    else "euclidean" if features.shape[0] > 100 else euclidean
+                )
             knn = NearestNeighbors(n_neighbors=self.k, metric=self.metric)
 
             if self.metric and self.metric != knn.metric:

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Optional, Union, cast
 import warnings
 import itertools
 
@@ -8,6 +8,7 @@ from scipy.stats import gaussian_kde
 import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
+from scipy.spatial.distance import euclidean
 from sklearn.neighbors import NearestNeighbors
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
@@ -106,7 +107,7 @@ class NonIIDIssueManager(IssueManager):
     def __init__(
         self,
         datalab: Datalab,
-        metric: Optional[str] = None,
+        metric: Optional[Union[str, Callable]] = None,
         k: int = 10,
         num_permutations: int = 25,
         seed: Optional[int] = 0,
@@ -203,7 +204,11 @@ class NonIIDIssueManager(IssueManager):
         features_to_use = self._determine_features(features, pred_probs)
 
         if self.metric is None:
-            self.metric = "cosine" if features_to_use.shape[1] > 3 else "euclidean"
+            self.metric = (
+                "cosine"
+                if features_to_use.shape[1] > 3
+                else "euclidean" if features_to_use.shape[0] > 100 else euclidean
+            )
 
         knn = NearestNeighbors(n_neighbors=self.k, metric=self.metric)
 

--- a/cleanlab/datalab/internal/issue_manager/underperforming_group.py
+++ b/cleanlab/datalab/internal/issue_manager/underperforming_group.py
@@ -15,13 +15,14 @@
 # along with cleanlab.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Union, Tuple
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Optional, Union, Tuple
 import warnings
 import inspect
 
 import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
+from scipy.spatial.distance import euclidean
 from sklearn.neighbors import NearestNeighbors
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
@@ -79,7 +80,7 @@ class UnderperformingGroupIssueManager(IssueManager):
     def __init__(
         self,
         datalab: Datalab,
-        metric: Optional[str] = None,
+        metric: Optional[Union[str, Callable]] = None,
         threshold: float = 0.1,
         k: int = 10,
         clustering_kwargs: Dict[str, Any] = {},
@@ -157,7 +158,11 @@ class UnderperformingGroupIssueManager(IssueManager):
                     "If a knn_graph is not provided, features must be provided to fit a new knn."
                 )
             if self.metric is None:
-                self.metric = "cosine" if features.shape[1] > 3 else "euclidean"
+                self.metric = (
+                    "cosine"
+                    if features.shape[1] > 3
+                    else "euclidean" if features.shape[0] > 100 else euclidean
+                )
             knn = NearestNeighbors(n_neighbors=self.k, metric=self.metric)
 
             if self.metric and self.metric != knn.metric:

--- a/cleanlab/outlier.py
+++ b/cleanlab/outlier.py
@@ -430,14 +430,15 @@ class OutOfDistribution:
                 )
             if k is None:
                 k = DEFAULT_K  # use default when knn and k are both None
-            if k > (N := len(features)):  # Ensure number of neighbors less than number of examples
+            N, M = features.shape
+            if k > N:  # Ensure number of neighbors less than number of examples
                 raise ValueError(
                     f"Number of nearest neighbors k={k} cannot exceed the number of examples N={len(features)} passed into the estimator (knn)."
                 )
 
             # strings are used for sklearn metrics, callables are scipy pairwise distance functions
             metric: Union[str, Callable]
-            if features.shape[1] > 3:  # use euclidean distance for lower dimensional spaces
+            if M > 3:  # use euclidean distance for lower dimensional spaces
                 metric = "cosine"
             elif N > 100:  # Use efficient implementation (numerically unstable in edge cases)
                 metric = "euclidean"

--- a/cleanlab/outlier.py
+++ b/cleanlab/outlier.py
@@ -61,9 +61,16 @@ class OutOfDistribution:
              You can also pass in a subclass of ``sklearn.neighbors.NearestNeighbors`` which allows you to use faster
              approximate neighbor libraries as long as you wrap them behind the same sklearn API.
              If you specify ``knn`` here, there is no need to later call ``fit()`` before calling ``score()``.
-             If ``knn = None``, then by default: ``knn = sklearn.neighbors.NearestNeighbors(n_neighbors=k, metric=dist_metric).fit(features)``
-             where ``dist_metric == "cosine"`` if ``dim(features) > 3`` or ``dist_metric == "euclidean"`` otherwise.
+             If ``knn is None``, then by default:
+             The knn object is instantiated as ``sklearn.neighbors.NearestNeighbors(n_neighbors=k, metric=dist_metric).fit(features)``.
+             - If ``dim(features) > 3``, the distance metric is set to "cosine".
+             - If ``dim(features) <= 3``, the distance metric is set to "euclidean".
+               The implementation of the euclidean distance metric depends on the number of examples in the features array:
+                - For more than 100 rows, it uses scikit-learn's "euclidean" metric. This is for efficiency reasons reasons.
+                - For 100 or fewer rows, it uses scipy's ``scipy.spatial.distance.euclidean`` metric. This is for numerical stability reasons.
              See: https://scikit-learn.org/stable/modules/neighbors.html
+             See: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.euclidean_distances.html
+             See: https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.euclidean.html
        *  k : int, default=None
              Optional number of neighbors to use when calculating outlier score (average distance to neighbors).
              If `k` is not provided, then by default ``k = knn.n_neighbors`` or ``k = 10`` if ``knn is None``.

--- a/docs/source/cleanlab/datalab/guide/issue_type_description.rst
+++ b/docs/source/cleanlab/datalab/guide/issue_type_description.rst
@@ -296,7 +296,7 @@ Duplicate Issue Parameters
 .. code-block:: python
 
     near_duplicate_kwargs = {
-    	"metric": # string representing the distance metric used in nearest neighbors search (passed as argument to `NearestNeighbors`), if necessary,
+    	"metric": # string or callable representing the distance metric used in nearest neighbors search (passed as argument to `NearestNeighbors`), if necessary,
     	"k": # integer representing the number of nearest neighbors for nearest neighbors search (passed as argument to `NearestNeighbors`), if necessary,
     	"threshold": # `threshold` argument to constructor of `NearDuplicateIssueManager()`. Non-negative floating value that determines the maximum distance between two examples to be considered outliers, relative to the median distance to the nearest neighbors,
     }
@@ -316,7 +316,7 @@ Non-IID Issue Parameters
 .. code-block:: python
 
     non_iid_kwargs = {
-    	"metric": # `metric` argument to constructor of `NonIIDIssueManager`. String for the distance metric used for nearest neighbors search if necessary. `metric` argument to constructor of `sklearn.neighbors.NearestNeighbors`,
+    	"metric": # `metric` argument to constructor of `NonIIDIssueManager`. String or callable for the distance metric used for nearest neighbors search if necessary. `metric` argument to constructor of `sklearn.neighbors.NearestNeighbors`,
     	"k": # `k` argument to constructor of `NonIIDIssueManager`. Integer representing the number of nearest neighbors for nearest neighbors search if necessary. `n_neighbors` argument to constructor of `sklearn.neighbors.NearestNeighbors`,
         "num_permutations": # `num_permutations` argument to constructor of `NonIIDIssueManager`,
         "seed": # seed for numpy's random number generator (used for permutation tests),
@@ -349,7 +349,7 @@ Underperforming Group Issue Parameters
     underperforming_group_kwargs = {
         # Constructor arguments for `UnderperformingGroupIssueManager`
         "threshold": # Non-negative floating value between 0 and 1 used for determinining group of points with low confidence.
-        "metric": # String for the distance metric used for nearest neighbors search if necessary. `metric` argument to constructor of `sklearn.neighbors.NearestNeighbors`.
+        "metric": # String or callable for the distance metric used for nearest neighbors search if necessary. `metric` argument to constructor of `sklearn.neighbors.NearestNeighbors`.
         "k": # Integer representing the number of nearest neighbors for constructing the nearest neighbour graph. `n_neighbors` argument to constructor of `sklearn.neighbors.NearestNeighbors`.
         "min_cluster_samples": # Non-negative integer value specifying the minimum number of examples required for a cluster to be considered as the underperforming group. Used in `UnderperformingGroupIssueManager.filter_cluster_ids`.
         "clustering_kwargs": # Key-value pairs representing arguments for the constructor of the clustering algorithm class (e.g. `sklearn.cluster.DBSCAN`).

--- a/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
+++ b/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
@@ -4,25 +4,23 @@ import pytest
 from cleanlab import Datalab
 
 
-SEED = 42
-
-
 class TestAllIdenticalExamplesDataset:
-    N = 20
-    K = 5
-
     @pytest.fixture
-    def dataset(self):
-        np.random.seed(SEED)
+    def dataset(self, request):
+        N, K = request.param
         # Create the dataset with all identical examples
-        X = np.full((self.N, self.K), fill_value=np.random.rand(self.K))
+        X = np.full((N, K), fill_value=np.random.rand(K))
         return {"X": X}
 
     @pytest.fixture
-    def dataset_with_one_unique_example(self, dataset):
+    def dataset_with_one_unique_example(self, request):
+        N, K = request.param
+        # Create the dataset with all identical examples
+        X = np.full((N, K), fill_value=np.random.rand(K))
+
         # Add one unique example to the dataset
-        dataset["X"] = np.vstack([dataset["X"], np.random.rand(self.K)])
-        return dataset
+        X = np.vstack([X, np.random.rand(K)])
+        return {"X": X}
 
     @pytest.fixture
     def lab(self, dataset):
@@ -32,13 +30,19 @@ class TestAllIdenticalExamplesDataset:
     def lab_with_one_unique_example(self, dataset_with_one_unique_example):
         return Datalab(data=dataset_with_one_unique_example)
 
-    def test_issue_detection(self, lab, dataset):
-
+    @pytest.mark.parametrize(
+        "dataset",
+        [((N, K)) for N in [11, 20, 50, 100, 150] for K in [2, 3, 5, 10, 20]],
+        indirect=["dataset"],
+        ids=lambda x: f"N={x[0]}, K={x[1]}",
+    )
+    def test_issue_detection(self, dataset):
+        lab = Datalab(data=dataset)
         lab.find_issues(features=dataset["X"])
 
         outlier_issues = lab.get_issues("outlier")
         expected_outlier_issues = pd.DataFrame(
-            [{"is_outlier_issue": False, "outlier_score": 1.0}] * self.N
+            [{"is_outlier_issue": False, "outlier_score": 1.0}] * len(outlier_issues)
         )
         pd.testing.assert_frame_equal(outlier_issues, expected_outlier_issues)
 
@@ -50,25 +54,30 @@ class TestAllIdenticalExamplesDataset:
                     "near_duplicate_score": 0.0,
                     "distance_to_nearest_neighbor": np.finfo(np.float64).epsneg,
                 }
-                for i in range(self.N)
+                for i in range(len(near_duplicate_issues))
             ]
         )
         pd.testing.assert_frame_equal(
             near_duplicate_issues.drop(columns="near_duplicate_sets"),
             expected_near_duplicate_issues,
+            check_exact=False,
+            atol=5e-16,
         )
 
-    def test_issue_detection_with_one_unique_example(
-        self, lab_with_one_unique_example, dataset_with_one_unique_example
-    ):
-        lab = lab_with_one_unique_example
+    @pytest.mark.parametrize(
+        "dataset_with_one_unique_example",
+        [((N, K)) for N in [11, 20, 50, 100, 150] for K in [2, 3, 5, 10, 20]],
+        indirect=["dataset_with_one_unique_example"],
+        ids=lambda x: f"N={x[0]}, K={x[1]}",
+    )
+    def test_issue_detection_with_one_unique_example(self, dataset_with_one_unique_example):
         dataset = dataset_with_one_unique_example
-
+        lab = Datalab(data=dataset)
         lab.find_issues(features=dataset["X"])
 
         outlier_issues = lab.get_issues("outlier")
         expected_outlier_issues = pd.DataFrame(
-            [{"is_outlier_issue": False, "outlier_score": 1.0}] * self.N
+            [{"is_outlier_issue": False, "outlier_score": 1.0}] * (len(outlier_issues) - 1)
             + [{"is_outlier_issue": True, "outlier_score": 0.0}]
         )
 
@@ -80,19 +89,19 @@ class TestAllIdenticalExamplesDataset:
                 {
                     "is_near_duplicate_issue": True,
                     "near_duplicate_score": 0.0,
-                    "distance_to_nearest_neighbor": np.finfo(np.float64).epsneg,
                 }
-                for i in range(self.N)
+                for i in range(len(near_duplicate_issues) - 1)
             ]
             + [
                 {
                     "is_near_duplicate_issue": False,
                     "near_duplicate_score": 1.0,
-                    "distance_to_nearest_neighbor": 3.212390e-01,
                 }
             ]
         )
         pd.testing.assert_frame_equal(
-            near_duplicate_issues.drop(columns="near_duplicate_sets"),
+            near_duplicate_issues.drop(
+                columns=["near_duplicate_sets", "distance_to_nearest_neighbor"]
+            ),
             expected_near_duplicate_issues,
         )

--- a/tests/test_outlier.py
+++ b/tests/test_outlier.py
@@ -280,7 +280,8 @@ def test_class_public_func():
     X_small = np.random.rand(20, 3)
     OOD_euclidean = OutOfDistribution()
     OOD_euclidean.fit(features=X_small)
-    assert OOD_euclidean.params["knn"].metric == "euclidean"
+    # The metric attribute is the pairwise distance function implemented in scipy, use __name__ to get the name of the function
+    assert OOD_euclidean.params["knn"].metric.__name__ == "euclidean"
     X_small_with_ood = np.vstack([X_small, [999999.0] * 3])
     euclidean_score = OOD_euclidean.score(features=X_small_with_ood)
     assert (np.max(euclidean_score) <= 1) and (np.min(euclidean_score) >= 0)

--- a/tests/test_outlier.py
+++ b/tests/test_outlier.py
@@ -674,7 +674,7 @@ def test_wrong_info_get_ood_predictions_scores():
 @example(K=1, fill_value=0.0)
 @settings(deadline=None)
 def test_scores_for_identical_examples(fill_value, K):
-    N = 20
+    N = 100
 
     features = np.full((N, K), fill_value=fill_value)
     ood = OutOfDistribution()
@@ -690,9 +690,9 @@ def test_scores_for_identical_examples(fill_value, K):
 
 
 @given(K=st.integers(min_value=2, max_value=100))
-@settings(deadline=None)
+@settings(max_examples=10000, deadline=None)
 def test_scores_for_identical_examples_across_rows(K):
-    N = 20
+    N = 100
     fill_value = np.random.random(K)
     features = np.full((N, K), fill_value=fill_value)
     ood = OutOfDistribution()
@@ -708,7 +708,7 @@ def test_scores_for_identical_examples_across_rows(K):
 
     if K < 4:
         # This little changes should not affect euclidean calculation
-        features += np.random.random(features.shape) * np.sqrt(np.finfo(np.float_).eps)
+        features += np.random.random(features.shape) * 1e-10
         ood = OutOfDistribution()
         scores = ood.fit_score(features=features, verbose=False)
         np.testing.assert_array_equal(


### PR DESCRIPTION
## Summary

The currently selected implementation for computing the pair-wise Euclidean distances between data points is computationally efficient but sacrifices numerical stability when dealing with nearly-identical data points.

```python
import numpy as np
from sklearn.metrics.pairwise import euclidean_distances

# Comparing 2d points
a = np.array([[100000001, 100000000]])
b = np.array([[100000000, 100000001]])

print("sklearn:", euclidean_distances(a, b)[0,0])  # Used under-the-hood by NearestNeighbors
print("correct:", np.sqrt(np.sum((a-b)**2)))
```

The same happens for small values. While the relative error is small, the absolute error can be arbitrarily large.

SciPy has an accurate implementation and is already supported by scikit-learn (often as a string argument, with the exception of the `"euclidean"`). Due to a name clash with the [scikit-learn implementation](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.euclidean_distances.html), passing the [callable](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.euclidean.html#scipy.spatial.distance.euclidean) directly to NearestNeighbors is done in this PR.

Some benchmarks I ran show that the SciPy metric is several orders of magnitude slower for larger inputs (y-axis is runtime, x-axis is the number of points to compare): 
![image](https://github.com/cleanlab/cleanlab/assets/18127060/3f3aae24-2953-4777-b439-d07555e37f3e).
For smaller datasets, it may be preferable to run the precise algorithm. Using the current scikit-learn implementation should generally be fine, as long as the norm of the data points isn't significantly greater than their mutual distances.

Code for reproducing this figure can be found in [this gist](https://gist.github.com/elisno/5b92fe0414f113089047b20bb447d65f).


## Impact

This PR affects all parts of the code-base that instantiate a NearestNeighbors object and select a default metric based on the dimensionality of the features. The results for the euclidean metrics will be more precise for smaller datasets, as it uses the numerically stable algorithm to find nearest neighbors.
For larger datasets, the computationally efficient algorithm implemented in scikit-learn is still used.



## Testing

> 🔍 Testing Done: Tests in tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py have been updated to use a larger dataset of 100 points (the cutoff between the accurate and the efficient implementations for computing the euclidean pairwise distances). The same is done in tests/test_outlier.py.


**Unaddressed Cases**

Testing the "all-identical" datasets with [scikit-learn's `"euclidean"` metric](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.euclidean_distances.html) has not been addressed.
It's not possible to guarantee an upper limit for the numerical errors it gets.

-

## Links to Relevant Issues or Conversations

- This issue resolves #1055 

## References

You may wish to run this test code to get a better sense of how the different metrics work with scikit-learn and cleanlab's `OutOfDistribution` class.

```python
# test_distance_computations.py

"""This test module provides various tests to validate the behavior of distance calculation functionalities in a numerical computing environment.
It utilizes a combination of libraries including numpy, scipy, scikit-learn, hypothesis for property-based testing, and cleanlab for handling outlier detection.

The module includes the following main components:

1. `calculate_distances`: A function to calculate the nearest neighbor distances using different metrics provided by the scikit-learn library.

2. `test_calculate_distances_for_2d_data`: A test to ensure that the distance calculations are accurate and stable for two-dimensional data using multiple distance metrics, emphasizing the handling of numerical instabilities in certain metrics.

3. `test_calculate_distances_for_high_dimensional_data`: Similar to the 2D test but adapted for high-dimensional data, testing the robustness and correctness of distance calculations across various metrics, particularly focusing on the potential for numerical instabilities.

4. `test_outlier_scores_based_on_features_for_high_dimensional_data`: Tests the functionality of outlier detection based on distances in a high-dimensional space, ensuring that the OutOfDistribution class from cleanlab operates as expected with various distance metrics.

Each test is constructed using the hypothesis library to generate a wide range of test cases, ensuring comprehensive coverage of potential issues with distance calculations and outlier detection functionalities.
"""


import numpy as np

from scipy.spatial.distance import euclidean
from sklearn.neighbors import NearestNeighbors

from hypothesis import given, settings
from hypothesis.extra.numpy import arrays
from hypothesis.strategies import floats, integers

from cleanlab.outlier import OutOfDistribution


def calculate_distances(X: np.ndarray, nn: NearestNeighbors) -> np.ndarray:
    # Query the nearest neighbors
    distances, _ = nn.kneighbors(X)
    return distances


@given(X=arrays(float, shape=(1, 2), elements=floats(0, 1_000_000_000, allow_nan=False, allow_infinity=False, allow_subnormal=False, exclude_min=True)))
@settings(max_examples=1000, deadline=None)
def test_calculate_distances_for_2d_data(X: np.ndarray):

    # Store distances for each metric
    distances_dict: dict[str, np.ndarray] = {}

    metrics = ["euclidean", "cosine", euclidean, "seuclidean"]
    metric_ids = ["euclidean", "cosine", "euclidean from scipy"]
    for (metric, id)  in zip(metrics, metric_ids):
        if id == "euclidean":
            # The "euclidean" metric from scikit-learn suffers from numerical instability when the distance
            # between points in X are small compared to their norms. This is because the distance is calculated
            # as dot(x,x) - 2 * dot(x, y) + dot(y, y). These individual terms can blow up to huge values that are
            # not numerically stable. The upside of this implementation is the computational efficiency and allows for precomputing either
            # the dot(x,x) or dot(y,y) terms.
            continue
        nn = NearestNeighbors(n_neighbors=1, metric=metric).fit(X)
        distances_dict[id] = calculate_distances(X, nn)

    # Collect {metric_id: distances} that are not close to zero
    distances_not_close_to_zero = {
        metric_id: distances[0, 0]
        for metric_id, distances in distances_dict.items() 
        if not np.allclose(distances, 0, atol=1e-17)
    }
    
    assert not distances_not_close_to_zero, f"Distances between identical data points are not close to zero for the following metrics: {distances_not_close_to_zero}"

@given(X=arrays(float, shape=integers(2, 1000), elements=floats(0, 1_000_000_000_000, allow_nan=False, allow_infinity=False, allow_subnormal=False, exclude_min=True)))
@settings(max_examples=1000, deadline=None)
def test_calculate_distances_for_high_dimensional_data(X: np.ndarray):

    X = X.reshape(1, -1)
    # Store distances for each metric
    distances_dict: dict[str, np.ndarray] = {}

    metrics = ["euclidean", "cosine", euclidean]
    metric_ids = ["euclidean", "cosine", "euclidean from scipy"]
    for (metric, id)  in zip(metrics, metric_ids):
        if id == "euclidean":
            # The "euclidean" metric from scikit-learn suffers from numerical instability when the distance
            # between points in X are small compared to their norms. This is because the distance is calculated
            # as dot(x,x) - 2 * dot(x, y) + dot(y, y). These individual terms can blow up to huge values that are
            # not numerically stable. The upside of this implementation is the computational efficiency and allows for precomputing either
            # the dot(x,x) or dot(y,y) terms.
            continue
        nn = NearestNeighbors(n_neighbors=1, metric=metric).fit(X)
        distances_dict[id] = calculate_distances(X, nn)

    # Collect {metric_id: distances} that are not close to zero
    distances_not_close_to_zero = {
        metric_id: distances[0, 0]
        for metric_id, distances in distances_dict.items() 
        if not np.allclose(distances, 0, atol=1e-15)
    }
    
    assert not distances_not_close_to_zero, f"Distances between identical data points are not close to zero for the following metrics: {distances_not_close_to_zero}"


# Now run the same checks through the OutOfDistribution class

@given(X=arrays(float, shape=integers(2, 1000), elements=floats(0, 1_000_000_000_000, allow_nan=False, allow_infinity=False, allow_subnormal=False, exclude_min=True)))
def test_outlier_scores_based_on_features_for_high_dimensional_data(X: np.ndarray):

    X = X.reshape(1, -1)
    X = np.repeat(X, 11, axis=0)
    # Store distances for each metric
    distances_dict: dict[str, np.ndarray] = {}

    metrics = ["euclidean", "cosine", euclidean]
    metric_ids = ["euclidean", "cosine", "euclidean from scipy"]
    for (metric, id)  in zip(metrics, metric_ids):
        if id == "euclidean":
            # The "euclidean" metric from scikit-learn suffers from numerical instability when the distance
            # between points in X are small compared to their norms. This is because the distance is calculated
            # as dot(x,x) - 2 * dot(x, y) + dot(y, y). These individual terms can blow up to huge values that are
            # not numerically stable. The upside of this implementation is the computational efficiency and allows for precomputing either
            # the dot(x,x) or dot(y,y) terms.
            continue
        nn = OutOfDistribution(params={"metric": metric, 
        distances_dict[id] = calculate_distances(X, nn)

    # Collect {metric_id: distances} that are not close to zero
    distances_not_close_to_zero = {
        metric_id: distances[0, 0]
        for metric_id, distances in distances_dict.items() 
        if not np.allclose(distances, 0, atol=1e-15)
    }
    
    assert not distances_not_close_to_zero, f"Distances between identical data points are not close to zero for the following metrics: {distances_not_close_to_zero}"
```
Try running it with something like:

```pytest test_distance_computations.py```