### PR TITLE
All identical datasets tests

### DIFF
--- a/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
+++ b/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
@@ -10,7 +10,13 @@ class TestAllIdenticalExamplesDataset:
         N, K = request.param
         # Create the dataset with all identical examples
         X = np.full((N, K), fill_value=np.random.rand(K))
-        return {"X": X}
+
+        # All labels for identical points should be the same
+        y = ["a"] * N
+        # One of the labels is different, so it should be flagged with a label issue
+        y[-1] = "b"
+
+        return {"X": X, "y": y}
 
     @pytest.fixture
     def dataset_with_one_unique_example(self, request):
@@ -20,7 +26,13 @@ class TestAllIdenticalExamplesDataset:
 
         # Add one unique example to the dataset
         X = np.vstack([X, np.random.rand(K)])
-        return {"X": X}
+
+        # All labels for identical points should be the same, let's make them all 0, along with the unique example
+        y = ["a"] * (N + 1)
+        # One of the N points has a noisy label, it should be flagged with a label issue
+        y[-2] = "b"
+
+        return {"X": X, "y": y}
 
     @pytest.fixture
     def lab(self, dataset):
@@ -37,8 +49,9 @@ class TestAllIdenticalExamplesDataset:
         ids=lambda x: f"N={x[0]}, K={x[1]}",
     )
     def test_issue_detection(self, dataset):
-        lab = Datalab(data=dataset)
-        lab.find_issues(features=dataset["X"])
+        lab = Datalab(data=dataset, label_name="y")
+        pred_probs = np.full((len(dataset["y"]), 2), fill_value=[1.0, 0.0])
+        lab.find_issues(features=dataset["X"], pred_probs=pred_probs)
 
         outlier_issues = lab.get_issues("outlier")
         expected_outlier_issues = pd.DataFrame(
@@ -64,6 +77,15 @@ class TestAllIdenticalExamplesDataset:
             atol=5e-16,
         )
 
+        lab_issues = lab.get_issues("label")[["is_label_issue", "label_score"]]
+        expected_lab_issues = pd.DataFrame(
+            [{"is_label_issue": False, "label_score": 1.0}] * (len(lab_issues) - 1)
+            + [
+                {"is_label_issue": False, "label_score": 0.0}
+            ]  # The confident threshold for this examble is extremely low, but won't flag it as a label issue
+        )
+        pd.testing.assert_frame_equal(lab_issues, expected_lab_issues)
+
     @pytest.mark.parametrize(
         "dataset_with_one_unique_example",
         [((N, K)) for N in [11, 20, 50, 100, 150] for K in [2, 3, 5, 10, 20]],
@@ -72,8 +94,9 @@ class TestAllIdenticalExamplesDataset:
     )
     def test_issue_detection_with_one_unique_example(self, dataset_with_one_unique_example):
         dataset = dataset_with_one_unique_example
-        lab = Datalab(data=dataset)
-        lab.find_issues(features=dataset["X"])
+        lab = Datalab(data=dataset, label_name="y")
+        pred_probs = np.full((len(dataset["y"]), 2), fill_value=[1.0, 0.0])
+        lab.find_issues(features=dataset["X"], pred_probs=pred_probs)
 
         outlier_issues = lab.get_issues("outlier")
         expected_outlier_issues = pd.DataFrame(
@@ -105,3 +128,13 @@ class TestAllIdenticalExamplesDataset:
             ),
             expected_near_duplicate_issues,
         )
+
+        lab_issues = lab.get_issues("label")[["is_label_issue", "label_score"]]
+        expected_lab_issues = pd.DataFrame(
+            [{"is_label_issue": False, "label_score": 1.0}] * (len(lab_issues) - 2)
+            + [
+                {"is_label_issue": False, "label_score": 0.0}
+            ]  # The confident threshold for this examble is extremely low, but won't flag it as a label issue
+            + [{"is_label_issue": False, "label_score": 1.0}]
+        )
+        pd.testing.assert_frame_equal(lab_issues, expected_lab_issues)

--- a/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
+++ b/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
@@ -26,9 +26,9 @@ class TestAllIdenticalExamplesDataset:
 
     @pytest.fixture
     def dataset(self, request):
-        N, K = request.param
+        N, M = request.param
         # Create the dataset with all identical examples
-        X = np.full((N, K), fill_value=np.random.rand(K))
+        X = np.full((N, M), fill_value=np.random.rand(M))
 
         # All labels for identical points should be the same
         y = ["a"] * N
@@ -39,12 +39,12 @@ class TestAllIdenticalExamplesDataset:
 
     @pytest.fixture
     def dataset_with_one_unique_example(self, request):
-        N, K = request.param
+        N, M = request.param
         # Create the dataset with all identical examples
-        X = np.full((N, K), fill_value=np.random.rand(K))
+        X = np.full((N, M), fill_value=np.random.rand(M))
 
         # Add one unique example to the dataset
-        X = np.vstack([X, np.random.rand(K)])
+        X = np.vstack([X, np.random.rand(M)])
 
         # All labels for identical points should be the same, let's make them all 0, along with the unique example
         y = ["a"] * (N + 1)
@@ -55,9 +55,9 @@ class TestAllIdenticalExamplesDataset:
 
     @pytest.fixture
     def regression_dataset(self, request):
-        N, K = request.param
+        N, M = request.param
         # Create the dataset with all identical examples
-        X = np.full((N, K), fill_value=np.random.rand(K))
+        X = np.full((N, M), fill_value=np.random.rand(M))
 
         # All labels for identical points should be the same
         y = np.full(N, fill_value=np.random.rand())
@@ -68,9 +68,9 @@ class TestAllIdenticalExamplesDataset:
 
     @pytest.fixture
     def regression_dataset_with_one_unique_example(self, request):
-        N, K = request.param
+        N, M = request.param
         # Create the dataset with all identical examples
-        X = np.full((N, K), fill_value=np.random.rand(K))
+        X = np.full((N, M), fill_value=np.random.rand(M))
 
         # All labels for identical points should be the same
         y = np.full(N, fill_value=np.random.rand())
@@ -78,16 +78,16 @@ class TestAllIdenticalExamplesDataset:
         y[-1] += 10
 
         # Add one unique example to the dataset, but it has the same target as the majority of the dataset
-        X = np.vstack([X, np.random.rand(K)])
+        X = np.vstack([X, np.random.rand(M)])
         y = np.append(y, [y[0]])
 
         return {"X": X, "y": y}
 
     @pytest.mark.parametrize(
         "dataset",
-        [((N, K)) for N in [11, 20, 50, 100, 150] for K in [2, 3, 5, 10, 20]],
+        [((N, M)) for N in [11, 20, 50, 100, 150] for M in [2, 3, 5, 10, 20]],
         indirect=["dataset"],
-        ids=lambda x: f"N={x[0]}, K={x[1]}",
+        ids=lambda x: f"N={x[0]}, M={x[1]}",
     )
     def test_issue_detection(self, dataset):
         lab = Datalab(data=dataset, label_name="y")
@@ -129,9 +129,9 @@ class TestAllIdenticalExamplesDataset:
 
     @pytest.mark.parametrize(
         "dataset_with_one_unique_example",
-        [((N, K)) for N in [11, 20, 50, 100, 150] for K in [2, 3, 5, 10, 20]],
+        [((N, M)) for N in [11, 20, 50, 100, 150] for M in [2, 3, 5, 10, 20]],
         indirect=["dataset_with_one_unique_example"],
-        ids=lambda x: f"N={x[0]}, K={x[1]}",
+        ids=lambda x: f"N={x[0]}, M={x[1]}",
     )
     def test_issue_detection_with_one_unique_example(self, dataset_with_one_unique_example):
         dataset = dataset_with_one_unique_example
@@ -182,9 +182,9 @@ class TestAllIdenticalExamplesDataset:
 
     @pytest.mark.parametrize(
         "regression_dataset",
-        [((N, K)) for N in [11, 20, 50, 100] for K in [3, 4, 6, 8, 10]],
+        [((N, M)) for N in [11, 20, 50, 100] for M in [3, 4, 6, 8, 10]],
         indirect=["regression_dataset"],
-        ids=lambda x: f"N={x[0]}, K={x[1]}",
+        ids=lambda x: f"N={x[0]}, M={x[1]}",
     )
     def test_regression_issue_detection(self, regression_dataset):
         lab = Datalab(data=regression_dataset, label_name="y", task="regression")
@@ -227,9 +227,9 @@ class TestAllIdenticalExamplesDataset:
 
     @pytest.mark.parametrize(
         "regression_dataset_with_one_unique_example",
-        [((N, K)) for N in [11, 20, 50, 100] for K in [3, 4, 6, 8, 10]],
+        [((N, M)) for N in [11, 20, 50, 100] for M in [3, 4, 6, 8, 10]],
         indirect=["regression_dataset_with_one_unique_example"],
-        ids=lambda x: f"N={x[0]}, K={x[1]}",
+        ids=lambda x: f"N={x[0]}, M={x[1]}",
     )
     def test_regression_issue_detection_with_one_unique_example(
         self, regression_dataset_with_one_unique_example

--- a/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
+++ b/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
@@ -64,22 +64,6 @@ class TestAllIdenticalExamplesDataset:
 
         return {"X": X, "y": y}
 
-    @pytest.fixture
-    def lab(self, dataset):
-        return Datalab(data=dataset)
-
-    @pytest.fixture
-    def lab_with_one_unique_example(self, dataset_with_one_unique_example):
-        return Datalab(data=dataset_with_one_unique_example)
-
-    @pytest.fixture
-    def regression_lab(self, regression_dataset):
-        return Datalab(data=regression_dataset, task="regression")
-
-    @pytest.fixture
-    def regression_lab_with_one_unique_example(self, regression_dataset_with_one_unique_example):
-        return Datalab(data=regression_dataset_with_one_unique_example, task="regression")
-
     @pytest.mark.parametrize(
         "dataset",
         [((N, K)) for N in [11, 20, 50, 100, 150] for K in [2, 3, 5, 10, 20]],

--- a/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
+++ b/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
@@ -21,6 +21,10 @@ class TestAllIdenticalExamplesDataset:
       - outlier issues
       - near-duplicate issues
 
+    There are a few more issue types that are tested in some cases, but they are less prone to be affected by future changes in the codebase.
+    - underperforming group issues (for classification)
+    - class imbalance issues (for classification)
+
     These tests focus on the issue detection capabilities of Datalab, and not the quality of the predictions or the features.
     """
 

--- a/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
+++ b/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
@@ -5,6 +5,25 @@ from cleanlab import Datalab
 
 
 class TestAllIdenticalExamplesDataset:
+    """There are 4 types of datasets this class tests:
+
+    1. A dataset with all identical data points. They all have identical labels, EXCEPT THE LAST ONE.
+    2. A dataset with all identical data points, except for one extra/unique example. One of the identical examples has a noisy label. The unique example has the same label as the majority of the dataset.
+    3. A regression dataset with all identical data points. They all have identical targets, EXCEPT THE LAST ONE.
+    4. A regression dataset with all identical data points, except for one extra/unique example. One of the identical examples has a noisy target. The unique example has the same target as the majority of the dataset.
+
+    Each test goes through the same motions:
+
+    - Set up Datalab instance
+    - Find default issues from features and pred_probs/predictions
+    - Assert that the following issue dataframes look as expected for each dataset type.
+      - label issues
+      - outlier issues
+      - near-duplicate issues
+
+    These tests focus on the issue detection capabilities of Datalab, and not the quality of the predictions or the features.
+    """
+
     @pytest.fixture
     def dataset(self, request):
         N, K = request.param

--- a/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
+++ b/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
@@ -119,14 +119,14 @@ class TestAllIdenticalExamplesDataset:
             atol=5e-16,
         )
 
-        lab_issues = lab.get_issues("label")[["is_label_issue", "label_score"]]
-        expected_lab_issues = pd.DataFrame(
+        label_issues = lab.get_issues("label")[["is_label_issue", "label_score"]]
+        expected_label_issues = pd.DataFrame(
             [{"is_label_issue": False, "label_score": 1.0}] * (N - 1)
             + [
                 {"is_label_issue": False, "label_score": 0.0}
             ]  # The confident threshold for this examble is extremely low, but won't flag it as a label issue
         )
-        pd.testing.assert_frame_equal(lab_issues, expected_lab_issues)
+        pd.testing.assert_frame_equal(label_issues, expected_label_issues)
 
         underperforming_group_issues = lab.get_issues("underperforming_group")
         expected_underperforming_group_issues = pd.DataFrame(

--- a/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
+++ b/tests/datalab/datalab/end_to_end_tests/test_all_identical_examples.py
@@ -35,12 +35,50 @@ class TestAllIdenticalExamplesDataset:
         return {"X": X, "y": y}
 
     @pytest.fixture
+    def regression_dataset(self, request):
+        N, K = request.param
+        # Create the dataset with all identical examples
+        X = np.full((N, K), fill_value=np.random.rand(K))
+
+        # All labels for identical points should be the same
+        y = np.full(N, fill_value=np.random.rand())
+        # Flip one of the targets to introduce a label issue
+        y[-1] += 10
+
+        return {"X": X, "y": y}
+
+    @pytest.fixture
+    def regression_dataset_with_one_unique_example(self, request):
+        N, K = request.param
+        # Create the dataset with all identical examples
+        X = np.full((N, K), fill_value=np.random.rand(K))
+
+        # All labels for identical points should be the same
+        y = np.full(N, fill_value=np.random.rand())
+        # Flip one of the targets to introduce a label issue
+        y[-1] += 10
+
+        # Add one unique example to the dataset, but it has the same target as the majority of the dataset
+        X = np.vstack([X, np.random.rand(K)])
+        y = np.append(y, [y[0]])
+
+        return {"X": X, "y": y}
+
+    @pytest.fixture
     def lab(self, dataset):
         return Datalab(data=dataset)
 
     @pytest.fixture
     def lab_with_one_unique_example(self, dataset_with_one_unique_example):
         return Datalab(data=dataset_with_one_unique_example)
+
+    @pytest.fixture
+    def regression_lab(self, regression_dataset):
+        return Datalab(data=regression_dataset, task="regression")
+
+    @pytest.fixture
+    def regression_lab_with_one_unique_example(self, regression_dataset_with_one_unique_example):
+        return Datalab(data=regression_dataset_with_one_unique_example, task="regression")
 
     @pytest.mark.parametrize(
         "dataset",
@@ -138,3 +176,103 @@ class TestAllIdenticalExamplesDataset:
             + [{"is_label_issue": False, "label_score": 1.0}]
         )
         pd.testing.assert_frame_equal(lab_issues, expected_lab_issues)
+
+    @pytest.mark.parametrize(
+        "regression_dataset",
+        [((N, K)) for N in [11, 20, 50, 100] for K in [3, 4, 6, 8, 10]],
+        indirect=["regression_dataset"],
+        ids=lambda x: f"N={x[0]}, K={x[1]}",
+    )
+    def test_regression_issue_detection(self, regression_dataset):
+        lab = Datalab(data=regression_dataset, label_name="y", task="regression")
+        predictions = np.full(len(y := regression_dataset["y"]), fill_value=y[0])
+
+        lab.find_issues(pred_probs=predictions, features=regression_dataset["X"])
+
+        outlier_issues = lab.get_issues("outlier")
+        expected_outlier_issues = pd.DataFrame(
+            [{"is_outlier_issue": False, "outlier_score": 1.0}] * len(outlier_issues)
+        )
+        pd.testing.assert_frame_equal(outlier_issues, expected_outlier_issues)
+
+        near_duplicate_issues = lab.get_issues("near_duplicate")
+        expected_near_duplicate_issues = pd.DataFrame(
+            [
+                {
+                    "is_near_duplicate_issue": True,
+                    "near_duplicate_score": 0.0,
+                    "distance_to_nearest_neighbor": np.finfo(np.float64).epsneg,
+                }
+                for i in range(len(near_duplicate_issues))
+            ]
+        )
+        pd.testing.assert_frame_equal(
+            near_duplicate_issues.drop(columns="near_duplicate_sets"),
+            expected_near_duplicate_issues,
+            check_exact=False,
+            atol=5e-16,
+        )
+
+        label_issues = lab.get_issues("label")[["is_label_issue", "label_score"]]
+        expected_label_issues = pd.DataFrame(
+            [{"is_label_issue": False, "label_score": 1.0}] * (len(label_issues) - 1)
+            + [
+                {"is_label_issue": True, "label_score": 0.0}
+            ]  # Expect last example to be flagged as a label issue
+        )
+        pd.testing.assert_frame_equal(label_issues, expected_label_issues)
+
+    @pytest.mark.parametrize(
+        "regression_dataset_with_one_unique_example",
+        [((N, K)) for N in [11, 20, 50, 100] for K in [3, 4, 6, 8, 10]],
+        indirect=["regression_dataset_with_one_unique_example"],
+        ids=lambda x: f"N={x[0]}, K={x[1]}",
+    )
+    def test_regression_issue_detection_with_one_unique_example(
+        self, regression_dataset_with_one_unique_example
+    ):
+        dataset = regression_dataset_with_one_unique_example
+        lab = Datalab(data=dataset, label_name="y", task="regression")
+        predictions = np.full(len(y := dataset["y"]), fill_value=y[0])
+
+        lab.find_issues(pred_probs=predictions, features=dataset["X"])
+
+        outlier_issues = lab.get_issues("outlier")
+        expected_outlier_issues = pd.DataFrame(
+            [{"is_outlier_issue": False, "outlier_score": 1.0}] * (len(outlier_issues) - 1)
+            + [{"is_outlier_issue": True, "outlier_score": 0.0}]
+        )
+        pd.testing.assert_frame_equal(outlier_issues, expected_outlier_issues)
+
+        near_duplicate_issues = lab.get_issues("near_duplicate")
+        expected_near_duplicate_issues = pd.DataFrame(
+            [
+                {
+                    "is_near_duplicate_issue": True,
+                    "near_duplicate_score": 0.0,
+                }
+                for i in range(len(near_duplicate_issues) - 1)
+            ]
+            + [
+                {
+                    "is_near_duplicate_issue": False,
+                    "near_duplicate_score": 1.0,
+                }
+            ]
+        )
+        pd.testing.assert_frame_equal(
+            near_duplicate_issues.drop(
+                columns=["near_duplicate_sets", "distance_to_nearest_neighbor"]
+            ),
+            expected_near_duplicate_issues,
+        )
+
+        label_issues = lab.get_issues("label")[["is_label_issue", "label_score"]]
+        expected_label_issues = pd.DataFrame(
+            [{"is_label_issue": False, "label_score": 1.0}] * (len(label_issues) - 2)
+            + [
+                {"is_label_issue": True, "label_score": 0.0}
+            ]  # Expect second to last example to be flagged as a label issue
+            + [{"is_label_issue": False, "label_score": 1.0}]
+        )
+        pd.testing.assert_frame_equal(label_issues, expected_label_issues)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -249,14 +249,19 @@ def test_save_space():
 @pytest.mark.parametrize("method", ["residual", "outre"])
 def test_all_identical_examples(N, method):
 
+    # All examples have predictions identical to the given labels/targets
     labels = np.zeros(N)
     predictions = np.copy(labels)
 
+    # Except the last ~quarter of examples have labels that are further away from the predictions
     cutoff_index = N // 4
     predictions[-cutoff_index:] += 1
+
     scores = get_label_quality_scores(labels=labels, predictions=predictions, method=method)
     np.testing.assert_allclose(scores[:-cutoff_index], 1, atol=1e-04)
     if method == "outre":
+        # Assert that the scores for the last (bad) ~quarter of examples are close to 0
         np.testing.assert_allclose(scores[-cutoff_index:], 0, atol=1e-04)
     else:
+        # Residual method should give "imperfect" scores for the last ~quarter of examples, but not necessarily near 0
         assert np.all(scores[-cutoff_index:] < 1)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -243,3 +243,20 @@ def test_save_space():
 
     cl.save_space()
     assert cl.get_label_issues() is None
+
+
+@pytest.mark.parametrize("N", [10, 100, 1000])
+@pytest.mark.parametrize("method", ["residual", "outre"])
+def test_all_identical_examples(N, method):
+
+    labels = np.zeros(N)
+    predictions = np.copy(labels)
+
+    cutoff_index = N // 4
+    predictions[-cutoff_index:] += 1
+    scores = get_label_quality_scores(labels=labels, predictions=predictions, method=method)
+    np.testing.assert_allclose(scores[:-cutoff_index], 1, atol=1e-04)
+    if method == "outre":
+        np.testing.assert_allclose(scores[-cutoff_index:], 0, atol=1e-04)
+    else:
+        assert np.all(scores[-cutoff_index:] < 1)


### PR DESCRIPTION
Add further test cases for an all-identical dataset.

This PR covers:

- Ensure that label quality scores for regression datasets work reasonably for all identical labels/targets.
- Verify that label issue detection behaves reasonably in Datalab for regression and classification.

Resolves #1055 

---

What issue types are tested against these kinds of datasets:

- [x] Label issues
- [x] Outlier issues
- [x] Near duplicate issues
- [x] Underperforming group issues (never any examples flagged, since there's usually just one example with a label error)
- [x] Class Imbalance issues (Only works for >20 example datasets, as the imbalance cutoff is 0.1*(1/K)=0.5 for a 2-class dataset.
- [ ] Non-IID issues (hard to reproduce, not a priority)
- [ ] Null issues (not a priority, all examples are generated)