### PR TITLE
Enhance test coverage for setting Confident Joint in `CleanLearning`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "cleanlab"
 # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/
 dependencies = [
   "numpy>=1.22.0",
-  "scikit-learn>=1.1",
+  "scikit-learn>=1.1,<1.5",
   "tqdm>=4.53.0",
   "pandas>=1.4.0",
   "termcolor>=2.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "cleanlab"
 # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/
 dependencies = [
   "numpy>=1.22.0",
-  "scikit-learn>=1.1,<1.5",
+  "scikit-learn>=1.1",
   "tqdm>=4.53.0",
   "pandas>=1.4.0",
   "termcolor>=2.4.0",

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -757,6 +757,7 @@ def test_1D_formats():
     cl.score(X, labels)
 
 
+@pytest.mark.skip
 def test_sklearn_gridsearchcv():
     # hyper-parameters for grid search
     param_grid = {
@@ -769,6 +770,10 @@ def test_sklearn_gridsearchcv():
         ],
         "converge_latent_estimates": [True, False],
     }
+
+    # make params_grid a list of dicts
+    # from itertools import product
+    # param_grid = [dict(zip(param_grid, v)) for v in product(*param_grid.values())]
 
     clf = LogisticRegression(random_state=0, solver="lbfgs", multi_class="auto")
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -934,3 +934,61 @@ def test_find_issues_low_memory():
         low_memory=True, find_label_issues_kwargs=find_label_issues_kwargs, seed=SEED
     ).find_label_issues(X=X, labels=labels, noise_matrix=DATA["noise_matrix"])
     assert issues_df.equals(issues_df_lm)
+
+
+def test_confident_joint_setting_in_find_label_issues_kwargs():
+    """
+    This test ensures that the 'confident_joint' is correctly set in the
+    'find_label_issues_kwargs' of the 'CleanLearning' class when calling find_label_issues().
+
+    This test was added to cover the lines of code that were previously
+    missed due to the removal of another test.
+    """
+    # Load training data and labels
+    X = DATA["X_train"]
+    labels = DATA["labels"]
+
+    # Estimate predicted probabilities using cross-validation
+    pred_probs = estimate_cv_predicted_probabilities(X=X, labels=labels, seed=SEED)
+
+    # Initialize CleanLearning instance
+    cl = CleanLearning()
+
+    # Test that the confident joint is not set initially
+    cj = cl.find_label_issues_kwargs.get("confident_joint")
+    assert cj is None, "Initial confident_joint should be None"
+
+    # Call find_label_issues to set the confident joint
+    cl.find_label_issues(labels=labels, pred_probs=pred_probs)
+    cj = cl.find_label_issues_kwargs.get("confident_joint")
+
+    # Compute expected confident joint
+    expected_cj = compute_confident_joint(labels=labels, pred_probs=pred_probs)
+
+    # Assert that the confident joint is set correctly
+    np.testing.assert_array_equal(
+        cj, expected_cj, "Confident joint not set correctly after find_label_issues"
+    )
+
+    # Pass a precomputed confident_joint to the CleanLearning instance
+    cj_as_input = np.random.rand(3, 3)
+    cl = CleanLearning(
+        find_label_issues_kwargs={
+            "confident_joint": cj_as_input,
+        }
+    )
+
+    # Ensure the precomputed confident joint is used
+    cj = cl.find_label_issues_kwargs.get("confident_joint")
+    np.testing.assert_array_equal(
+        cj, cj_as_input, "Confident joint not set correctly when passed as input"
+    )
+
+    # Calling find_label_issues should not change the precomputed confident_joint
+    cl.find_label_issues(labels=labels, pred_probs=pred_probs)
+    cj = cl.find_label_issues_kwargs.get("confident_joint")
+    np.testing.assert_array_equal(
+        cj,
+        cj_as_input,
+        "Confident joint should not change after find_label_issues call when precomputed joint is provided",
+    )

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -771,10 +771,6 @@ def test_sklearn_gridsearchcv():
         "converge_latent_estimates": [True, False],
     }
 
-    # make params_grid a list of dicts
-    # from itertools import product
-    # param_grid = [dict(zip(param_grid, v)) for v in product(*param_grid.values())]
-
     clf = LogisticRegression(random_state=0, solver="lbfgs", multi_class="auto")
 
     cv = GridSearchCV(


### PR DESCRIPTION
Related to a CI failure mentioned in https://github.com/cleanlab/cleanlab/pull/1119#issuecomment-2123470141.

The skipped test can be added again once scikit-learn releases 1.5.1 (due to a regression in the recently released 1.5.0)