### PR TITLE
Remove deprecated `multi_class` argument in LogisticRegression and skip test for sklearn 1.5.0 regression

### DIFF
--- a/cleanlab/classification.py
+++ b/cleanlab/classification.py
@@ -243,7 +243,7 @@ class CleanLearning(BaseEstimator):  # Inherits sklearn classifier
         self._default_clf = False
         if clf is None:
             # Use logistic regression if no classifier is provided.
-            clf = LogReg(multi_class="auto", solver="lbfgs")
+            clf = LogReg(solver="lbfgs")
             self._default_clf = True
 
         # Make sure the given classifier has the appropriate methods defined.

--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -896,7 +896,7 @@ def estimate_py_and_noise_matrices_from_probabilities(
 def estimate_confident_joint_and_cv_pred_proba(
     X,
     labels,
-    clf=LogReg(multi_class="auto", solver="lbfgs"),
+    clf=LogReg(solver="lbfgs"),
     *,
     cv_n_folds=5,
     thresholds=None,
@@ -1078,7 +1078,7 @@ def estimate_confident_joint_and_cv_pred_proba(
 def estimate_py_noise_matrices_and_cv_pred_proba(
     X,
     labels,
-    clf=LogReg(multi_class="auto", solver="lbfgs"),
+    clf=LogReg(solver="lbfgs"),
     *,
     cv_n_folds=5,
     thresholds=None,
@@ -1189,7 +1189,7 @@ def estimate_py_noise_matrices_and_cv_pred_proba(
 def estimate_cv_predicted_probabilities(
     X,
     labels,
-    clf=LogReg(multi_class="auto", solver="lbfgs"),
+    clf=LogReg(solver="lbfgs"),
     *,
     cv_n_folds=5,
     seed=None,
@@ -1255,7 +1255,7 @@ def estimate_cv_predicted_probabilities(
 def estimate_noise_matrices(
     X,
     labels,
-    clf=LogReg(multi_class="auto", solver="lbfgs"),
+    clf=LogReg(solver="lbfgs"),
     *,
     cv_n_folds=5,
     thresholds=None,

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -19,6 +19,7 @@ import sys
 from sklearn.linear_model import LogisticRegression
 from sklearn.base import BaseEstimator
 from sklearn.model_selection import GridSearchCV
+import sklearn
 import scipy
 import pytest
 import numpy as np
@@ -750,11 +751,11 @@ def test_1D_formats():
 # Check if the current Python version is 3.11
 is_python_311 = sys.version_info.major == 3 and sys.version_info.minor == 11
 
-# This warning should be ignore as in Python 3.11, the sre_constants module has been deprecated.
+# This warning should be ignored as in Python 3.11, the sre_constants module has been deprecated.
 # At the time of writing this, cleanlab supports Python 3.8-3.11. This warning is raised by
 # tensorflow <2.14.0, which imports sre_constants. This warning is not relevant to cleanlab.
-# Once Python 3.8 reaches EOL, we may remove this warning filter as we can set the tensorflow dev-dependency
-# to a version that does not raise this warning (2.14 or higher).
+# Once Python 3.8 reaches EOL, we may remove this warning filter as we can set the tensorflow
+# dev-dependency to a version that does not raise this warning (2.14 or higher).
 if is_python_311:
     sre_deprecation_pytestmark = pytest.mark.filterwarnings(
         "ignore:module 'sre_constants' is deprecated"
@@ -762,9 +763,17 @@ if is_python_311:
 else:
     sre_deprecation_pytestmark = pytest.mark.filterwarnings("default")
 
+# Check if the installed version of sklearn is 1.5.0.
+# The test_sklearn_gridsearchcv test fails due to a regression introduced in 1.5.0.
+# This issue will be fixed in sklearn version 1.5.1.
+uses_sklearn_1_5_0 = sklearn.__version__ == "1.5.0"
 
-@sre_deprecation_pytestmark  # Allow sre_constants deprecation error for Python 3.11
+
+@sre_deprecation_pytestmark  # Allow sre_constants deprecation warning for Python 3.11
 @pytest.mark.filterwarnings("error")  # All other warnings are treated as errors
+@pytest.mark.skipif(
+    uses_sklearn_1_5_0, reason="Test is skipped because sklearn 1.5.0 is installed"
+)  # TODO: Remove this line once sklearn 1.5.1 is released
 def test_sklearn_gridsearchcv():
     # hyper-parameters for grid search
     param_grid = {

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -772,7 +772,8 @@ uses_sklearn_1_5_0 = sklearn.__version__ == "1.5.0"
 @sre_deprecation_pytestmark  # Allow sre_constants deprecation warning for Python 3.11
 @pytest.mark.filterwarnings("error")  # All other warnings are treated as errors
 @pytest.mark.skipif(
-    uses_sklearn_1_5_0, reason="Test is skipped because sklearn 1.5.0 is installed"
+    uses_sklearn_1_5_0,
+    reason="Test is skipped because sklearn 1.5.0 is installed, which has a regression for GridSearchCV.",
 )  # TODO: Remove this line once sklearn 1.5.1 is released
 def test_sklearn_gridsearchcv():
     # hyper-parameters for grid search

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -155,9 +155,7 @@ DATA_FORMATS = {
 
 @pytest.mark.parametrize("data", list(DATA_FORMATS.values()))
 def test_cl(data):
-    cl = CleanLearning(
-        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED)
-    )
+    cl = CleanLearning(clf=LogisticRegression(solver="lbfgs", random_state=SEED))
     X_train_og = deepcopy(data["X_train"])
     cl.fit(data["X_train"], data["labels"])
     score = cl.score(data["X_test"], data["true_labels_test"])
@@ -214,7 +212,7 @@ def test_invalid_inputs():
         raise Exception("expected test to raise Exception")
     try:
         cl = CleanLearning(
-            clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED),
+            clf=LogisticRegression(solver="lbfgs", random_state=SEED),
             find_label_issues_kwargs={"return_indices_ranked_by": "self_confidence"},
         )
         cl.fit(
@@ -238,7 +236,7 @@ def test_aux_inputs():
         "min_examples_per_class": 2,
     }
     cl = CleanLearning(
-        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED),
+        clf=LogisticRegression(solver="lbfgs", random_state=SEED),
         find_label_issues_kwargs=find_label_issues_kwargs,
         verbose=1,
     )
@@ -274,21 +272,15 @@ def test_aux_inputs():
     assert cl.label_issues_df is None
 
     # Verbose off
-    cl = CleanLearning(
-        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED), verbose=0
-    )
+    cl = CleanLearning(clf=LogisticRegression(solver="lbfgs", random_state=SEED), verbose=0)
     cl.save_space()  # dummy call test
 
-    cl = CleanLearning(
-        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED), verbose=0
-    )
+    cl = CleanLearning(clf=LogisticRegression(solver="lbfgs", random_state=SEED), verbose=0)
     cl.find_label_issues(
         labels=data["true_labels_test"], pred_probs=pred_probs_test, save_space=True
     )
 
-    cl = CleanLearning(
-        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED), verbose=1
-    )
+    cl = CleanLearning(clf=LogisticRegression(solver="lbfgs", random_state=SEED), verbose=1)
 
     # Test with label_issues_mask input
     label_issues_mask = find_label_issues(
@@ -325,9 +317,7 @@ def test_aux_inputs():
     assert "label_quality" in label_issues_df.columns
 
     # Test with sample_weight input:
-    cl = CleanLearning(
-        clf=LogisticRegression(multi_class="auto", solver="lbfgs", random_state=SEED), verbose=1
-    )
+    cl = CleanLearning(clf=LogisticRegression(solver="lbfgs", random_state=SEED), verbose=1)
     cl.fit(
         data["X_test"],
         data["true_labels_test"],

--- a/tests/test_outlier.py
+++ b/tests/test_outlier.py
@@ -228,7 +228,7 @@ def test_class_public_func():
     labels = data["true_labels_test"]
 
     # Fit Logistic Regression model on X_train and estimate train pred_probs
-    logreg = LogReg(multi_class="auto", solver="lbfgs")
+    logreg = LogReg(solver="lbfgs")
     logreg.fit(data["X_train"], data["true_labels_train"])
     train_pred_probs = logreg.predict_proba(data["X_train"])
 
@@ -490,7 +490,7 @@ def test_ood_predictions_scores():
     y_with_ood = np.hstack([y, data["true_labels_train"][1]])
 
     # Fit Logistic Regression model on X_train and estimate pred_probs
-    logreg = LogReg(multi_class="auto", solver="lbfgs")
+    logreg = LogReg(solver="lbfgs")
     logreg.fit(data["X_train"], data["true_labels_train"])
     pred_probs = logreg.predict_proba(X_with_ood)
 


### PR DESCRIPTION
## Summary

This PR updates the code to remove the deprecated `multi_class` argument when instantiating a `LogisticRegression` object as a default classifier. Also, it conditionally skips the `test_sklearn_gridsearchcv` test for sklearn version 1.5.0 due to a known regression where GridSearchCV fails.
It also filters out the [deprecation warning for the `sre_constants` module in Python 3.11](https://docs.python.org/3/whatsnew/3.11.html#modules) during the same test.

### Details

- **Python 3.11 Compatibility:**
  - Added a conditional check for Python 3.11 to ignore the deprecation warning for the `sre_constants` module during testing, which is raised by TensorFlow versions earlier than 2.14.0.
  - Imported the `sys` module to check the Python version.
  - Applied `pytest.mark.filterwarnings("ignore:module 'sre_constants' is deprecated")` specifically for Python 3.11.
  - Ensured all other warnings are treated as errors in the relevant test to maintain code robustness.

- **sklearn Compatibility:**
  - Added a check to see if the installed version of sklearn is 1.5.0.
  - Conditionally skipped the `test_sklearn_gridsearchcv` test for sklearn 1.5.0 due to a regression in this version.
  - Updated comments to explain the reason for skipping the test and noted that the issue will be fixed in sklearn 1.5.1.

- **Code Simplification:**
  - Removed the deprecated `multi_class` argument from instances of `LogisticRegression` in `cleanlab/classification.py` and the related tests, as its default behavior will now always use multinomial for multi-class problems.
  - This change ensures the code is up-to-date with the latest sklearn practices and reduces complexity.


### Context

`cleanlab` currently supports Python 3.8-3.11. The `sre_constants` deprecation warning is not relevant to `cleanlab` and can be safely ignored. Once Python 3.8 reaches its end of life (EOL), we may update the TensorFlow dependency to version 2.14.0 or higher, which does not raise this warning.

The `multi_class` parameter in `LogisticRegression` was deprecated in sklearn 1.5.0 (will be removed in 1.7). 
The regression in this version affects the `GridSearchCV` functionality, and the issue will be resolved in sklearn 1.5.1.


### Impact

This change ensures a clean test suite without irrelevant warnings in Python 3.11 and maintains compatibility with the latest sklearn version practices, maintaining the quality and clarity of test outputs.


## Testing

- [x] Tested the changes locally using a [fork of scikit-learn](https://github.com/lesteve/scikit-learn/tree/43ac226bd6106d149e7214fe209254c9185e4786) that includes a necessary fix for a regression.
- [x] Ensured all tests pass without warnings in Python 3.11 (by depending on the scikit-learn fork).
- [ ] Will test on scikit-learn 1.5.1 once it is released.


## Links to Relevant Issues or Conversations

- This PR removes the `pytest.mark.skip` mark introduced in [PR #1123](https://github.com/cleanlab/cleanlab/pull/1123).
- This PR is tested on code in [scikit-learn PR #29078](https://github.com/scikit-learn/scikit-learn/pull/29078). Consider merging this PR once the upstream PR is released in scikit-learn 1.5.1.

## References

- [Docs for pytest.mark.filterwarnings](https://docs.pytest.org/en/7.1.x/how-to/capture-warnings.html#pytest-mark-filterwarnings).
- [scikit-learn PR #28703](https://github.com/scikit-learn/scikit-learn/pull/28703) deprecating `multi_class` in `LogisticRegression`.