### PR TITLE
Tubular Tutorial: Dynamically handle displaying exact duplicate sets

### DIFF
--- a/docs/source/tutorials/datalab/tabular.ipynb
+++ b/docs/source/tutorials/datalab/tabular.ipynb
@@ -427,15 +427,6 @@
     "indices_to_display = [lowest_scoring_duplicate] + duplicate_results.loc[lowest_scoring_duplicate, \"near_duplicate_sets\"].tolist()\n",
     "\n",
     "# Display the relevant rows from the original dataset\n",
-    "X_raw.iloc[indices_to_display]\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "X_raw.iloc[indices_to_display]"
    ]
   },
@@ -443,7 +434,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These examples are exact duplicates! Perhaps the same information was accidentally recorded multiple times in this data.\n"
+    "These examples are exact duplicates! Perhaps the same information was accidentally recorded multiple times in this data."
    ]
   },
   {
@@ -535,7 +526,7 @@
     "\n",
     "# Repeat the test for the next set of indices\n",
     "if not are_rows_identical(X_raw.iloc[next_indices_to_display]):\n",
-    "    raise Exception(\"Not all rows are identical! These examples should belong to the same EXACT duplicate set\")\n"
+    "    raise Exception(\"Not all rows are identical! These examples should belong to the same EXACT duplicate set\")"
    ]
   }
  ],

--- a/docs/source/tutorials/datalab/tabular.ipynb
+++ b/docs/source/tutorials/datalab/tabular.ipynb
@@ -402,7 +402,7 @@
    "outputs": [],
    "source": [
     "duplicate_results = lab.get_issues(\"near_duplicate\")\n",
-    "duplicate_results.sort_index(ascending=False).sort_values(\"near_duplicate_score\", kind=\"mergesort\").head()"
+    "duplicate_results.sort_values(\"near_duplicate_score\").head()"
    ]
   },
   {
@@ -411,7 +411,7 @@
    "source": [
     "The results above show which examples cleanlab considers nearly duplicated (rows where `is_near_duplicate_issue == True`). Here, we see some examples that cleanlab has flagged as being nearly duplicated. Let's view these examples to see how similar they are\n",
     "\n",
-    "Using student 690 as an example, let's compare it against the example cleanlab has identified in the `near_duplicate_sets` (student 246)."
+    "Using the one of the lowest-scoring examples, let's compare it against the identified near-duplicate sets."
    ]
   },
   {
@@ -420,21 +420,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_raw.iloc[[690, 246]]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "These examples are exact duplicates! Perhaps the same information was accidentally recorded twice in this data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Similarly, let's take a look at example 185 and the identified near duplicate, example 582:"
+    "# Identify the row with the lowest near_duplicate_score\n",
+    "lowest_scoring_duplicate = duplicate_results[\"near_duplicate_score\"].idxmin()\n",
+    "\n",
+    "# Extract the indices of the lowest scoring duplicate and its near duplicate sets\n",
+    "indices_to_display = [lowest_scoring_duplicate] + duplicate_results.loc[lowest_scoring_duplicate, \"near_duplicate_sets\"].tolist()\n",
+    "\n",
+    "# Display the relevant rows from the original dataset\n",
+    "X_raw.iloc[indices_to_display]\n"
    ]
   },
   {
@@ -443,14 +436,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_raw.iloc[[185, 582]]"
+    "X_raw.iloc[indices_to_display]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We identified another exact duplicate in our dataset! Including near/exact duplicates in a dataset may have unintended effects on models; be wary about splitting them across training/test sets. Learn more about handling near duplicates detected in a dataset from [the FAQ](../faq.html#How-to-handle-near-duplicate-data-identified-by-cleanlab?)."
+    "These examples are exact duplicates! Perhaps the same information was accidentally recorded multiple times in this data.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly, let's take a look at another example and the identified near-duplicate sets:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Identify the next row not in the previous near duplicate set\n",
+    "second_lowest_scoring_duplicate = duplicate_results[\"near_duplicate_score\"].drop(indices_to_display).idxmin()\n",
+    "\n",
+    "# Extract the indices of the second lowest scoring duplicate and its near duplicate sets\n",
+    "next_indices_to_display = [second_lowest_scoring_duplicate] + duplicate_results.loc[second_lowest_scoring_duplicate, \"near_duplicate_sets\"].tolist()\n",
+    "\n",
+    "# Display the relevant rows from the original dataset\n",
+    "X_raw.iloc[next_indices_to_display]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We identified another set of exact duplicates in our dataset! Including near/exact duplicates in a dataset may have unintended effects on models; be wary about splitting them across training/test sets. Learn more about handling near duplicates detected in a dataset from [the FAQ](../faq.html#How-to-handle-near-duplicate-data-identified-by-cleanlab?)."
    ]
   },
   {
@@ -499,7 +522,20 @@
     "    raise Exception(\"These examples are not in the same near duplicate set\")\n",
     "    \n",
     "if not duplicate_results.iloc[185][\"near_duplicate_sets\"] == 582:\n",
-    "    raise Exception(\"These examples are not in the same near duplicate set\")"
+    "    raise Exception(\"These examples are not in the same near duplicate set\")\n",
+    "\n",
+    "# Function to check if all rows are identical\n",
+    "def are_rows_identical(df):\n",
+    "    first_row = df.iloc[0]\n",
+    "    return all(df.iloc[i].equals(first_row) for i in range(1, len(df)))\n",
+    "\n",
+    "# Test to ensure all displayed rows are identical\n",
+    "if not are_rows_identical(X_raw.iloc[indices_to_display]):\n",
+    "    raise Exception(\"Not all rows are identical! These examples should belong to the same EXACT duplicate set\")\n",
+    "\n",
+    "# Repeat the test for the next set of indices\n",
+    "if not are_rows_identical(X_raw.iloc[next_indices_to_display]):\n",
+    "    raise Exception(\"Not all rows are identical! These examples should belong to the same EXACT duplicate set\")\n"
    ]
   }
  ],
@@ -522,7 +558,75 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.8.5"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "3b5405a8fced4ed6a15ff76049074dc2": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_692cb2ce951b403b853205316720434e",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "Near Duplicate Set 1:\n"
+        },
+        {
+         "data": {
+          "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>exam_1</th>\n      <th>exam_2</th>\n      <th>exam_3</th>\n      <th>notes</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>1</th>\n      <td>81.0</td>\n      <td>64.0</td>\n      <td>80.0</td>\n      <td>great participation +10</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>81.0</td>\n      <td>64.0</td>\n      <td>80.0</td>\n      <td>great participation +10</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>81.0</td>\n      <td>64.0</td>\n      <td>80.0</td>\n      <td>great participation +10</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>81.0</td>\n      <td>64.0</td>\n      <td>80.0</td>\n      <td>great participation +10</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>81.0</td>\n      <td>64.0</td>\n      <td>80.0</td>\n      <td>great participation +10</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+          "text/plain": "    exam_1  exam_2  exam_3                    notes\n1     81.0    64.0    80.0  great participation +10\n2     81.0    64.0    80.0  great participation +10\n12    81.0    64.0    80.0  great participation +10\n6     81.0    64.0    80.0  great participation +10\n9     81.0    64.0    80.0  great participation +10"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        },
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "Next Set: [27, 187]\n"
+        }
+       ]
+      }
+     },
+     "692cb2ce951b403b853205316720434e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "81ec42494c864c5e850326ccaf18c3fa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntSliderModel",
+      "state": {
+       "continuous_update": false,
+       "description": "Set Index:",
+       "layout": "IPY_MODEL_a59cbf0d08e14fb2a3d80e0e676768e4",
+       "max": 6,
+       "style": "IPY_MODEL_dbe96d71d43e40158a84487e1561e05b"
+      }
+     },
+     "a59cbf0d08e14fb2a3d80e0e676768e4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dbe96d71d43e40158a84487e1561e05b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/datalab/tabular.ipynb
+++ b/docs/source/tutorials/datalab/tabular.ipynb
@@ -402,16 +402,16 @@
    "outputs": [],
    "source": [
     "duplicate_results = lab.get_issues(\"near_duplicate\")\n",
-    "duplicate_results.sort_values(\"near_duplicate_score\").head()"
+    "duplicate_results.sort_index(ascending=False).sort_values(\"near_duplicate_score\", kind=\"mergesort\").head()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The results above show which examples cleanlab considers nearly duplicated (rows where `is_near_duplicate_issue == True`). Here, we see some examples that cleanlab has flagged as being nearly duplicated. Let's view these examples to see how similar they are, starting with the top one.\n",
+    "The results above show which examples cleanlab considers nearly duplicated (rows where `is_near_duplicate_issue == True`). Here, we see some examples that cleanlab has flagged as being nearly duplicated. Let's view these examples to see how similar they are\n",
     "\n",
-    "We compare this example (student 690) against the example cleanlab has identified in the `near_duplicate_sets` (student 246)."
+    "Using student 690 as an example, let's compare it against the example cleanlab has identified in the `near_duplicate_sets` (student 246)."
    ]
   },
   {

--- a/docs/source/tutorials/datalab/tabular.ipynb
+++ b/docs/source/tutorials/datalab/tabular.ipynb
@@ -558,75 +558,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
-  },
-  "widgets": {
-   "application/vnd.jupyter.widget-state+json": {
-    "state": {
-     "3b5405a8fced4ed6a15ff76049074dc2": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "layout": "IPY_MODEL_692cb2ce951b403b853205316720434e",
-       "outputs": [
-        {
-         "name": "stdout",
-         "output_type": "stream",
-         "text": "Near Duplicate Set 1:\n"
-        },
-        {
-         "data": {
-          "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>exam_1</th>\n      <th>exam_2</th>\n      <th>exam_3</th>\n      <th>notes</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>1</th>\n      <td>81.0</td>\n      <td>64.0</td>\n      <td>80.0</td>\n      <td>great participation +10</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>81.0</td>\n      <td>64.0</td>\n      <td>80.0</td>\n      <td>great participation +10</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>81.0</td>\n      <td>64.0</td>\n      <td>80.0</td>\n      <td>great participation +10</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>81.0</td>\n      <td>64.0</td>\n      <td>80.0</td>\n      <td>great participation +10</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>81.0</td>\n      <td>64.0</td>\n      <td>80.0</td>\n      <td>great participation +10</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-          "text/plain": "    exam_1  exam_2  exam_3                    notes\n1     81.0    64.0    80.0  great participation +10\n2     81.0    64.0    80.0  great participation +10\n12    81.0    64.0    80.0  great participation +10\n6     81.0    64.0    80.0  great participation +10\n9     81.0    64.0    80.0  great participation +10"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        },
-        {
-         "name": "stdout",
-         "output_type": "stream",
-         "text": "Next Set: [27, 187]\n"
-        }
-       ]
-      }
-     },
-     "692cb2ce951b403b853205316720434e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "81ec42494c864c5e850326ccaf18c3fa": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "IntSliderModel",
-      "state": {
-       "continuous_update": false,
-       "description": "Set Index:",
-       "layout": "IPY_MODEL_a59cbf0d08e14fb2a3d80e0e676768e4",
-       "max": 6,
-       "style": "IPY_MODEL_dbe96d71d43e40158a84487e1561e05b"
-      }
-     },
-     "a59cbf0d08e14fb2a3d80e0e676768e4": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "dbe96d71d43e40158a84487e1561e05b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "SliderStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     }
-    },
-    "version_major": 2,
-    "version_minor": 0
-   }
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Describe the objective of your changes in this Pull-Request.

This simple change improves the tutorial by making sure the referenced row (Student 690) actually is displayed in the tutorial! Otherwise can lead to a very confusing result, for example, when I ran the tutorial:

![image](https://github.com/cleanlab/cleanlab/assets/3402261/5c69dd47-5a75-4cf3-b693-82d3edfbcf7d)

A quick change to sort fixes this. Using `mergesort` is important because it's the only stable sort method to keep the duplicate-score-sorting working - see https://stackoverflow.com/questions/33699555/pandas-sorting-by-value-and-then-by-index

Here's the results. Student 690 isn't the first row, so I also updated the copy

![image](https://github.com/cleanlab/cleanlab/assets/3402261/75002116-2329-4b8d-a617-0422da51114f)



