### PR TITLE
Remove unnecessary warnings during KNN graph correction

### DIFF
--- a/tests/internal/neighbor/test_neighbor.py
+++ b/tests/internal/neighbor/test_neighbor.py
@@ -437,20 +437,6 @@ def test_knn_graph_duplicate_handling(base_point, num_duplicates, extra_points, 
     )
 
 
-def test_warnings():
-    features = np.array([[0, 0], [0, 0], [0, 0], [1, 1]])
-    distances = np.array([[0, np.sqrt(2)], [0, 0], [0, 0], [np.sqrt(2)] * 2])
-    indices = np.array([[1, 3], [0, 2], [0, 1], [0, 1]])
-
-    with pytest.warns(UserWarning) as w:
-        correct_knn_distances_and_indices(features, distances, indices, enable_warning=True)
-        assert len(w) == 1
-        assert issubclass(w[-1].category, UserWarning)
-        assert ("There were some slots available for an exact duplicate that were missed.") in str(
-            w[-1].message
-        )
-
-
 def test_construct_knn_then_correct_knn_graph_does_the_same_work():
     features = np.random.rand(1000, 2)
     features[10:20] = features[10]  # Make the 10th to 20th rows identical


### PR DESCRIPTION
## Summary

This PR is a direct follow-up to
- #1119

It removes the unnecessary warning check for missing exact duplicates in the KNN graph correction process. The check ran separately from the correction algorithm and could slow down the process, while warning that a KNN graph was corrected.

## Key Changes

- Removed the _warn_missing_exact_duplicates function and the enable_warning parameter.
- Updated the correct_knn_distances_and_indices function to exclude the optional warning check.
- Deleted the corresponding test case for the warning.

## Rationale
The separate check for missing exact duplicates is redundant in most use cases since the output is already corrected. By removing this check, we simplify the code and enhance the user experience with fewer unnecessary warnings and better performance.

Additionally, this warning would only trigger when constructing the KNN graph from scratch along with a correction step. The check is unnecessary and can be safely removed.

## Impact

- Improved performance in KNN graph correction.
- Simplified codebase with reduced unnecessary checks.