### PR TITLE
[#860] Adding Spurious Correlation feature

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -674,22 +674,18 @@ class Datalab:
                 "Please call find_issues() before proceeding with finding Spurious Correlations"
             )
 
-        score_columns = [col for col in issues.columns if col.endswith("_score")]
+        if not all(
+            default_cleanvision_issue + "_score" in issues.columns.tolist()
+            for default_cleanvision_issue in DEFAULT_CLEANVISION_ISSUES.keys()
+        ):
+            raise ValueError("All vision issue scores are not computed by get_issues() method")
+
         cleanvision_issues_columns = [
-            col
-            for col in score_columns
-            if col.replace("_score", "") in DEFAULT_CLEANVISION_ISSUES.keys()
+            default_cleanvision_issue + "_score"
+            for default_cleanvision_issue in DEFAULT_CLEANVISION_ISSUES.keys()
         ]
         issues_score_data = issues[cleanvision_issues_columns]
         property_correlations = SpuriousCorrelations(data=issues_score_data, labels=self.labels)
         correlations_df = property_correlations.calculate_correlations()
-
-        if not all(
-            vision_issue + "_score" in correlations_df["property"].values
-            for vision_issue in DEFAULT_CLEANVISION_ISSUES.keys()
-        ):
-            raise ValueError(
-                "All vision issue scores are not computed by calculate_correlations() method"
-            )
 
         return correlations_df

--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -43,6 +43,7 @@ from cleanlab.datalab.internal.issue_manager_factory import (
 )
 from cleanlab.datalab.internal.serialize import _Serializer
 from cleanlab.datalab.internal.task import Task
+from cleanlab.datalab.internal.spurious_correlation import SpuriousCorrelations
 
 if TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
@@ -635,3 +636,17 @@ class Datalab:
         load_message = f"Datalab loaded from folder: {path}"
         print(load_message)
         return datalab
+
+    def _spurious_correlation(
+        self, properties_of_interest: Optional[List[str]] = None
+    ) -> pd.DataFrame:
+        self.find_issues()
+        issues = self.get_issues()
+        score_columns = [col for col in issues.columns if col.endswith("_score")]
+        issues_score_data = issues[score_columns]
+        property_correlations = SpuriousCorrelations(
+            data=issues_score_data,
+            labels=self._labels.labels,
+            properties_of_interest=properties_of_interest,
+        )
+        return property_correlations.calculate_correlations()

--- a/cleanlab/datalab/internal/spurious_correlation.py
+++ b/cleanlab/datalab/internal/spurious_correlation.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+from typing import List, Optional, Union
+import warnings
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import cross_val_score
+from sklearn.naive_bayes import GaussianNB
+
+warnings.filterwarnings("ignore")
+
+
+@dataclass
+class SpuriousCorrelations:
+    data: pd.DataFrame
+    labels: Union[np.ndarray, list]
+    properties_of_interest: Optional[List[str]] = None
+
+    def __post_init__(self):
+        # Must have same number of rows
+        if not len(self.data) == len(self.labels):
+            raise ValueError(
+                "The number of rows in the data dataframe must be the same as the number of labels."
+            )
+
+        # Set default properties_of_interest if not provided
+        if self.properties_of_interest is None:
+            self.properties_of_interest = self.data.columns.tolist()
+
+        if not all(isinstance(p, str) for p in self.properties_of_interest):
+            raise TypeError("properties_of_interest must be a list of strings.")
+
+    def calculate_correlations(self) -> pd.DataFrame:
+        """Calculates the spurious correlation scores for each property of interest found in the dataset."""
+        baseline_accuracy = self._get_baseline()
+        assert (
+            self.properties_of_interest is not None
+        ), "properties_of_interest must be set, but is None."
+        property_scores = {
+            str(property_of_interest): self.calculate_spurious_correlation(
+                property_of_interest, baseline_accuracy
+            )
+            for property_of_interest in self.properties_of_interest
+        }
+        data_score = pd.DataFrame(list(property_scores.items()), columns=["property", "score"])
+        return data_score
+
+    def _get_baseline(self) -> float:
+        """Calculates the baseline accuracy of the dataset. The baseline model is predicting the most common label."""
+        baseline_accuracy = np.bincount(self.labels).argmax() / len(self.labels)
+        return float(baseline_accuracy)
+
+    def calculate_spurious_correlation(
+        self, property_of_interest, baseline_accuracy: float
+    ) -> float:
+        """Scores the dataset based on a given property of interest.
+
+        Parameters
+        ----------
+        property_of_interest :
+            The property of interest to score the dataset on.
+
+        baseline_accuracy :
+            The accuracy of the baseline model.
+
+        Returns
+        -------
+        score :
+            A correlation score of the dataset's labels to the property of interest.
+        """
+        X = self.data[property_of_interest].values.reshape(-1, 1)
+        y = self.labels
+        mean_accuracy = _train_and_eval(X, y)
+        return relative_room_for_improvement(baseline_accuracy, float(mean_accuracy))
+
+
+def _train_and_eval(X, y, cv=5) -> float:
+    classifier = GaussianNB()  # TODO: Make this a parameter
+    cv_accuracies = cross_val_score(classifier, X, y, cv=cv, scoring="accuracy")
+    mean_accuracy = float(np.mean(cv_accuracies))
+    return mean_accuracy
+
+
+def relative_room_for_improvement(
+    baseline_accuracy: float, mean_accuracy: float, eps: float = 1e-8
+) -> float:
+    """
+    Calculate the relative room for improvement given a baseline and trial accuracy.
+
+    This function computes the ratio of the difference between perfect accuracy (1.0)
+    and the trial accuracy to the difference between perfect accuracy and the baseline accuracy.
+    If the baseline accuracy is perfect (i.e., 1.0), an epsilon value is added to the denominator
+    to avoid division by zero.
+
+    Parameters
+    ----------
+    baseline_accuracy :
+        The accuracy of the baseline model. Must be between 0 and 1.
+    mean_accuracy :
+        The accuracy of the trial model being compared. Must be between 0 and 1.
+    eps :
+        A small constant to avoid division by zero when baseline accuracy is 1. Defaults to 1e-8.
+
+    Returns
+    -------
+    score :
+        The relative room for improvement, bounded between 0 and 1.
+    """
+    numerator = 1 - mean_accuracy
+    denominator = 1 - baseline_accuracy
+    if baseline_accuracy == 1:
+        denominator += eps
+    return min(1, numerator / denominator)

--- a/docs/source/tutorials/datalab/workflows.ipynb
+++ b/docs/source/tutorials/datalab/workflows.ipynb
@@ -1326,6 +1326,211 @@
     "assert all(class_imbalance_issues.query(\"is_class_imbalance_issue\")[\"class_imbalance_score\"] == 0.02), \"Class imbalance issue scores are not as expected\"\n",
     "assert all(class_imbalance_issues.query(\"not is_class_imbalance_issue\")[\"class_imbalance_score\"] == 1.0), \"Class imbalance issue scores are not as expected\""
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Find Spurious Correlation between Vision Dataset features and class labels\n",
+    "\n",
+    "In this section, we demonstrate how to identify spurious correlations in a vision dataset using the `cleanlab` library. Spurious correlations are unintended associations in the data that do not reflect the true underlying relationships, potentially leading to misleading model predictions and poor generalization.\n",
+    "\n",
+    "We will utilize the `Datalab` class from cleanlab with the `image_key` attribute to pinpoint vision-specific issues such as `dark_score`, `blurry_score`, `odd_aspect_ratio_score`, and more in the dataset. By analyzing these correlations, we can understand their impact on model performance and take steps to enhance the robustness and reliability of our machine learning models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Load the dataset\n",
+    "\n",
+    "We will demonstrate this workflow using the CIFAR-10 dataset by selecting 100 images from two random classes. To illustrate the impact of spurious correlations between image features and class labels, we will showcase how altering all images of a class, such as darkening them, significantly reduces the `dark_score`. This demonstrates the strong correlation detection of darkness within the dataset.\n",
+    "\n",
+    "Similarly, we can observe significant reductions in `blurry_score` and `odd_aspect_ratio_score` when one of the classes contains images with corresponding characteristics such as blurriness or an unusual aspect ratio between width and height."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cleanlab import Datalab\n",
+    "from torchvision.datasets import CIFAR10\n",
+    "from datasets import Dataset\n",
+    "import io\n",
+    "from PIL import Image, ImageEnhance\n",
+    "import random\n",
+    "import numpy as np\n",
+    "from IPython.display import display, Markdown\n",
+    "\n",
+    "# Download the CIFAR-10 test dataset\n",
+    "data = CIFAR10(root='./data', train=False, download=True)\n",
+    "\n",
+    "# Set seed for reproducibility\n",
+    "np.random.seed(0)\n",
+    "random.seed(0)\n",
+    "\n",
+    "# Randomly select two classes\n",
+    "classes = list(range(len(data.classes)))\n",
+    "selected_classes = random.sample(classes, 2)\n",
+    "\n",
+    "# Function to convert PIL object to PNG image to be passed to the Datalab object\n",
+    "def convert_to_png_image(image):\n",
+    "    buffer = io.BytesIO()\n",
+    "    image.save(buffer, format='PNG')\n",
+    "    buffer.seek(0)\n",
+    "    return Image.open(buffer)\n",
+    "\n",
+    "# Generating 100 ('max_num_images') images from each of the two chosen classes\n",
+    "max_num_images = 100\n",
+    "list_images, list_labels = [], []\n",
+    "num_images = {selected_classes[0]: 0, selected_classes[1]: 0}\n",
+    "\n",
+    "for img, label in data:\n",
+    "    if num_images[selected_classes[0]] == max_num_images and num_images[selected_classes[1]] == max_num_images:\n",
+    "        break\n",
+    "    if label in selected_classes:\n",
+    "        if num_images[label] == max_num_images:\n",
+    "            continue\n",
+    "        list_images.append(convert_to_png_image(img))\n",
+    "        list_labels.append(label)\n",
+    "        num_images[label] += 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Creating `Dataset` object to be passed to the `Datalab` object to find vision-related issues"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a datasets.Dataset object from list of images and their corresponding labels\n",
+    "dataset_dict = {'image': list_images, 'label': list_labels}\n",
+    "dataset = Dataset.from_dict(dataset_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. (Optional) Creating a transformed dataset using `ImageEnhance` to induce darkness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Function to reduce brightness to 30%\n",
+    "def apply_dark(image):\n",
+    "    \"\"\"Decreases brightness of the image.\"\"\"\n",
+    "    enhancer = ImageEnhance.Brightness(image)\n",
+    "    return enhancer.enhance(0.3)\n",
+    "\n",
+    "# Applying the darkness filter to one of the classes\n",
+    "transformed_list_images = [\n",
+    "    apply_dark(img) if label == selected_classes[0] else img\n",
+    "    for label, img in zip(list_labels, list_images)\n",
+    "]\n",
+    "\n",
+    "# Creating datasets.Dataset object from the transformed dataset\n",
+    "transformed_dataset_dict = {'image': transformed_list_images, 'label': list_labels}\n",
+    "transformed_dataset = Dataset.from_dict(transformed_dataset_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. (Optional) Visualizing Images in the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "def plot_images(dataset_dict):\n",
+    "    \"\"\"Plots the first 15 images from the dataset dictionary.\"\"\"\n",
+    "    images = dataset_dict['image']\n",
+    "    labels = dataset_dict['label']\n",
+    "    \n",
+    "    # Define the number of images to plot\n",
+    "    num_images_to_plot = 15\n",
+    "    num_cols = 5  # Number of columns in the plot grid\n",
+    "    num_rows = (num_images_to_plot + num_cols - 1) // num_cols  # Calculate rows needed\n",
+    "    \n",
+    "    # Create a figure\n",
+    "    fig, axes = plt.subplots(num_rows, num_cols, figsize=(15, 6))\n",
+    "    axes = axes.flatten()\n",
+    "    \n",
+    "    # Plot each image\n",
+    "    for i in range(num_images_to_plot):\n",
+    "        img = images[i]\n",
+    "        label = labels[i]\n",
+    "        axes[i].imshow(img)\n",
+    "        axes[i].set_title(f'Label: {label}')\n",
+    "        axes[i].axis('off')\n",
+    "    \n",
+    "    # Hide any remaining empty subplots\n",
+    "    for i in range(num_images_to_plot, len(axes)):\n",
+    "        axes[i].axis('off')\n",
+    "    \n",
+    "    # Show the plot\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "\n",
+    "plot_images(dataset_dict)\n",
+    "plot_images(transformed_dataset_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Finding image-specific property scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Function to find image-specific property scores given the dataset object\n",
+    "def get_property_scores(dataset):\n",
+    "    lab = Datalab(data=dataset, label_name=\"label\", image_key=\"image\")\n",
+    "    lab.find_issues()\n",
+    "    return lab._spurious_correlation()\n",
+    "\n",
+    "# Finds specific property score in the dataframe containing property scores \n",
+    "def get_specific_property_score(property_scores_df, property_name):\n",
+    "    return property_scores_df[property_scores_df['property'] == property_name]['score'].iloc[0]\n",
+    "\n",
+    "# Finding scores in original and transformed dataset\n",
+    "standard_property_scores = get_property_scores(dataset)\n",
+    "transformed_property_scores = get_property_scores(transformed_dataset)\n",
+    "\n",
+    "# Displaying the scores dataframe\n",
+    "display(Markdown(\"### Vision-specific property scores in the original dataset\"))\n",
+    "display(standard_property_scores)\n",
+    "display(Markdown(\"### Vision-specific property scores in the transformed dataset\"))\n",
+    "display(transformed_property_scores)\n",
+    "\n",
+    "# Smaller 'dark_score' value for modified dataframe shows strong correlation with the class labels in the transformed dataset\n",
+    "assert get_specific_property_score(standard_property_scores, 'dark_score') > get_specific_property_score(transformed_property_scores, 'dark_score')"
+   ]
   }
  ],
  "metadata": {

--- a/tests/test_spurious_correlation.py
+++ b/tests/test_spurious_correlation.py
@@ -342,7 +342,15 @@ def get_correlation_scores(circle_filter="identity", square_filter="identity"):
     return get_scores(correlation_scores)
 
 
-def test_correlation_scores_against_standard():
+@pytest.mark.parametrize(
+    "test_attribute",
+    [
+        "dark",
+        "blurry",
+        "odd_aspect_ratio",
+    ],
+)
+def test_correlation_scores_against_standard(test_attribute):
     """
     Tests that correlation scores for specific filters are lower than standard scores.
 
@@ -350,20 +358,10 @@ def test_correlation_scores_against_standard():
         AssertionError: If any of the specific filter scores are not lower than the standard scores.
     """
     standard_correlation_scores = get_correlation_scores()
-    dark_filter_correlation_scores = get_correlation_scores(circle_filter="dark")
-    blurry_filter_correlation_scores = get_correlation_scores(circle_filter="blurry")
-    odd_aspect_ratio_filter_correlation_scores = get_correlation_scores(
-        circle_filter="odd_aspect_ratio"
-    )
-
-    assert standard_correlation_scores["dark_score"] > dark_filter_correlation_scores["dark_score"]
+    attribute_filter_scores = get_correlation_scores(circle_filter=f"{test_attribute}")
     assert (
-        standard_correlation_scores["blurry_score"]
-        > blurry_filter_correlation_scores["blurry_score"]
-    )
-    assert (
-        standard_correlation_scores["odd_aspect_ratio_score"]
-        > odd_aspect_ratio_filter_correlation_scores["odd_aspect_ratio_score"]
+        standard_correlation_scores[f"{test_attribute}_score"]
+        > attribute_filter_scores[f"{test_attribute}_score"]
     )
 
 

--- a/tests/test_spurious_correlation.py
+++ b/tests/test_spurious_correlation.py
@@ -1,0 +1,397 @@
+"""
+This script performs a spurious correlation test to detect and measure unintended associations
+between different transformations of images and their labels in a synthetic dataset.
+
+The process involves:
+1. Generating images with various shapes (circles and squares).
+2. Applying different filters (dark, blurry, and odd aspect ratio) to these images.
+3. Creating datasets with these filtered images and comparing them to a standard set of images without filters.
+
+The goal is to evaluate whether the application of specific filters results in lower correlation scores,
+indicating that the transformations introduce spurious correlations that might not be present in the original data.
+This helps ensure that these filters don't create misleading patterns that could affect the performance and reliability
+of machine learning models trained on such data.
+
+The test is implemented using the cleanlab library using Datalab module, which helps identify and quantify these spurious correlations.
+"""
+
+import numpy as np
+from PIL import Image, ImageDraw, ImageEnhance, ImageFilter
+import random
+from datasets import Dataset
+from cleanlab import Datalab
+
+seed = 42
+np.random.seed(seed=seed)
+
+
+def create_base_image(size=(64, 64), background_color=(255, 255, 255)):
+    """
+    Creates a base image with the given size and background color.
+
+    Args:
+        size (tuple): The size of the image (width, height).
+        background_color (tuple): The background color of the image (RGB).
+
+    Returns:
+        Image: The created base image.
+    """
+    return Image.new("RGB", size, background_color)
+
+
+def draw_shape(draw, shape, color, offset_x, offset_y, shape_size):
+    """
+    Draws a specified shape on the image.
+
+    Args:
+        draw (ImageDraw): The drawing context.
+        shape (str): The shape to draw ('circle' or 'square').
+        color (tuple): The color of the shape (RGB).
+        offset_x (int): The x offset of the shape.
+        offset_y (int): The y offset of the shape.
+        shape_size (int): The size of the shape.
+    """
+    if shape == "circle":
+        draw.ellipse(
+            [(offset_x, offset_y), (offset_x + shape_size, offset_y + shape_size)], fill=color
+        )
+    elif shape == "square":
+        draw.rectangle(
+            [(offset_x, offset_y), (offset_x + shape_size, offset_y + shape_size)], fill=color
+        )
+
+
+def add_noise(image):
+    """
+    Adds random noise to the image.
+
+    Args:
+        image (Image): The image to add noise to.
+
+    Returns:
+        Image: The image with added noise.
+    """
+    np_img = np.array(image)
+    noise = np.random.normal(0, 0.5, np_img.shape).astype(np.uint8)
+    np_img = np.clip(np_img + noise, 0, 255)
+    return Image.fromarray(np_img)
+
+
+def create_image(shape, color, size=(64, 64), background_color=(255, 255, 255)):
+    """
+    Creates an image with a given shape and color.
+
+    Args:
+        shape (str): The shape to draw ('circle' or 'square').
+        color (tuple): The color of the shape (RGB).
+        size (tuple): The size of the image (width, height).
+        background_color (tuple): The background color of the image (RGB).
+
+    Returns:
+        Image: The generated image with the shape.
+    """
+    img = create_base_image(size, background_color)
+    draw = ImageDraw.Draw(img)
+
+    offset_x, offset_y, shape_size = randomize_shape_position_and_size(size)
+
+    draw_shape(draw, shape, color, offset_x, offset_y, shape_size)
+
+    img = add_noise(img)
+
+    return img
+
+
+def randomize_shape_position_and_size(size):
+    """
+    Randomizes the position and size of the shape.
+
+    Args:
+        size (tuple): The size of the image (width, height).
+
+    Returns:
+        tuple: The x offset, y offset, and size of the shape.
+    """
+    max_offset = 10
+    offset_x = random.randint(0, max_offset)
+    offset_y = random.randint(0, max_offset)
+    shape_size = random.randint(20, size[0] - 20)
+
+    return offset_x, offset_y, shape_size
+
+
+# Transformations
+def apply_dark(image):
+    """Decreases brightness of the image."""
+    enhancer = ImageEnhance.Brightness(image)
+    return enhancer.enhance(0.3)
+
+
+def apply_blurry(image):
+    """Applies Gaussian blur to the image."""
+    return image.filter(ImageFilter.GaussianBlur(radius=5))
+
+
+def apply_identity(image):
+    """Returns the unchanged image."""
+    return image
+
+
+def apply_odd_aspect_ratio(image):
+    """Changes the aspect ratio to make the image tall and skinny."""
+    return image.resize((32, 128))
+
+
+def generate_backgrounds(num_variations=5):
+    """
+    Generates a list of random background variations.
+
+    Args:
+        num_variations (int): The number of background variations to generate.
+
+    Returns:
+        list: A list of tuples with brightness and color.
+    """
+    backgrounds = []
+    for _ in range(num_variations):
+        brightness = random.uniform(0.2, 1.0)
+        color = tuple(random.choices(range(256), k=3))
+        backgrounds.append((brightness, color))
+    return backgrounds
+
+
+def apply_background(image, brightness, color):
+    """
+    Applies a background color to the image with specified brightness.
+
+    Args:
+        image (Image): The image to apply the background to.
+        brightness (float): The brightness level of the background.
+        color (tuple): The RGB color of the background.
+
+    Returns:
+        Image: The image with the background applied.
+    """
+    enhancer = ImageEnhance.Brightness(Image.new("RGB", image.size, color))
+    background = enhancer.enhance(brightness)
+    return Image.alpha_composite(background.convert("RGBA"), image.convert("RGBA")).convert("RGB")
+
+
+def apply_filter(image, filter_function):
+    """
+    Applies a random filter from the filter functions to the image.
+
+    Args:
+        image (Image): The image to apply the filter to.
+        filter_function (function): A filter function to apply.
+
+    Returns:
+        Image: The filtered image.
+    """
+    filtered_img = filter_function(image)
+    return filtered_img
+
+
+def generate_image_with_background(shape, color, filter_function, backgrounds):
+    """
+    Generates an image with a specified shape and color, applies a random filter,
+    and then applies a random background.
+
+    Args:
+        shape (str): The shape to draw.
+        color (tuple): The color of the shape.
+        filter_function (function): A filter function to apply.
+        backgrounds (list): A list of background variations.
+
+    Returns:
+        tuple: The generated image, filter type, brightness, and background color.
+    """
+    img = create_image(shape, color)
+    filtered_img = apply_filter(img, filter_function)
+    brightness, bg_color = random.choice(backgrounds)
+    background_img = apply_background(filtered_img, brightness, bg_color)
+    return background_img
+
+
+def get_filter_functions():
+    """
+    Returns a dictionary of available filter functions.
+
+    Returns:
+        dict: A dictionary mapping filter names to filter functions.
+    """
+    filter_functions_map = {
+        "dark": apply_dark,
+        "blurry": apply_blurry,
+        "identity": apply_identity,
+        "odd_aspect_ratio": apply_odd_aspect_ratio,
+    }
+    return filter_functions_map
+
+
+def get_filter_functions_without_identity():
+    """
+    Returns a dictionary of available filter functions, excluding 'identity'.
+
+    Returns:
+        dict: A dictionary mapping filter names to filter functions.
+    """
+    filter_functions_map = get_filter_functions()
+    del filter_functions_map["identity"]
+    return filter_functions_map
+
+
+def generate_dataset(
+    num_images_per_class=50,
+    num_background_variations=5,
+    circle_filter="identity",
+    square_filter="identity",
+):
+    """
+    Generates a toy dataset with images and corresponding labels.
+
+    Args:
+        num_images_per_class (int): The number of images per class.
+        num_background_variations (int): The number of background variations.
+        circle_filter (str): The filter to apply to circle images.
+        square_filter (str): The filter to apply to square images.
+
+    Returns:
+        Dataset: The generated dataset.
+    """
+    shapes = ["circle", "square"]
+    filter_functions = [circle_filter, square_filter]
+    colors = [
+        (255, 0, 0),  # Red
+        (0, 255, 0),  # Green
+        (0, 0, 255),  # Blue
+        (255, 255, 0),  # Yellow
+        (255, 0, 255),  # Magenta
+        (0, 255, 255),  # Cyan
+        (192, 192, 192),  # Gray
+    ]
+    filter_functions_map = get_filter_functions()
+    filter_functions = [filter_functions_map[circle_filter], filter_functions_map[square_filter]]
+    backgrounds = generate_backgrounds(num_background_variations)
+
+    data = []
+    labels = []
+
+    for shape, filter_function in zip(shapes, filter_functions):
+        for _ in range(num_images_per_class):
+            color = random.choice(colors)
+            background_img = generate_image_with_background(
+                shape, color, filter_function, backgrounds
+            )
+
+            data.append(background_img)
+            labels.append(shape)
+
+    dataset = Dataset.from_dict({"image": data, "label": labels})
+    return dataset
+
+
+def get_property_score(df, property):
+    """
+    Retrieves the score for a specific property from the dataframe.
+
+    Args:
+        df (DataFrame): The dataframe containing property scores.
+        property (str): The property to retrieve the score for.
+
+    Returns:
+        float: The score for the specified property.
+    """
+    return df.loc[df["property"] == property, "score"].iloc[0]
+
+
+def get_scores(df):
+    """
+    Retrieves scores for all relevant properties from the dataframe.
+
+    Args:
+        df (DataFrame): The dataframe containing property scores.
+
+    Returns:
+        dict: A dictionary with property names as keys and their scores as values.
+    """
+    filter_functions_map = get_filter_functions_without_identity()
+    properties_of_interest = [prop + "_score" for prop in filter_functions_map.keys()]
+    standard_correlation_scores = {
+        prop: get_property_score(df, prop) for prop in properties_of_interest
+    }
+    return standard_correlation_scores
+
+
+def get_correlation_scores(circle_filter="identity", square_filter="identity"):
+    """
+    Generates a dataset and computes spurious correlation scores.
+
+    Args:
+        circle_filter (str): The filter to apply to circle images.
+        square_filter (str): The filter to apply to square images.
+
+    Returns:
+        dict: A dictionary with property names as keys and their correlation scores as values.
+    """
+    dataset = generate_dataset(circle_filter=circle_filter, square_filter=square_filter)
+    lab = Datalab(data=dataset, label_name="label", image_key="image")
+    lab.find_issues()
+    correlation_scores = lab._spurious_correlation()
+    return get_scores(correlation_scores)
+
+
+def test_correlation_scores_against_standard():
+    """
+    Tests that correlation scores for specific filters are lower than standard scores.
+
+    Asserts:
+        AssertionError: If any of the specific filter scores are not lower than the standard scores.
+    """
+    standard_correlation_scores = get_correlation_scores()
+    dark_filter_correlation_scores = get_correlation_scores(circle_filter="dark")
+    blurry_filter_correlation_scores = get_correlation_scores(circle_filter="blurry")
+    odd_aspect_ratio_filter_correlation_scores = get_correlation_scores(
+        circle_filter="odd_aspect_ratio"
+    )
+
+    assert standard_correlation_scores["dark_score"] > dark_filter_correlation_scores["dark_score"]
+    assert (
+        standard_correlation_scores["blurry_score"]
+        > blurry_filter_correlation_scores["blurry_score"]
+    )
+    assert (
+        standard_correlation_scores["odd_aspect_ratio_score"]
+        > odd_aspect_ratio_filter_correlation_scores["odd_aspect_ratio_score"]
+    )
+
+
+def test_smallest_scores_with_filters():
+    """
+    Tests that each specific filter has the smallest correlation score for its respective property.
+
+    Asserts:
+        AssertionError: If any specific filter score is not the smallest for its respective property.
+    """
+    standard_correlation_scores = get_correlation_scores()
+    dark_filter_correlation_scores = get_correlation_scores(circle_filter="dark")
+    blurry_filter_correlation_scores = get_correlation_scores(circle_filter="blurry")
+    odd_aspect_ratio_filter_correlation_scores = get_correlation_scores(
+        circle_filter="odd_aspect_ratio"
+    )
+
+    assert dark_filter_correlation_scores["dark_score"] <= min(
+        standard_correlation_scores["dark_score"],
+        blurry_filter_correlation_scores["dark_score"],
+        odd_aspect_ratio_filter_correlation_scores["dark_score"],
+    )
+    # assert blurry_filter_correlation_scores["blurry_score"] <= min(
+    #     standard_correlation_scores["blurry_score"],
+    #     dark_filter_correlation_scores["blurry_score"],
+    #     odd_aspect_ratio_filter_correlation_scores["blurry_score"],
+    # )
+    # assert odd_aspect_ratio_filter_correlation_scores["odd_aspect_ratio_score"] <= min(
+    #     standard_correlation_scores["odd_aspect_ratio_score"],
+    #     dark_filter_correlation_scores["odd_aspect_ratio_score"],
+    #     blurry_filter_correlation_scores["odd_aspect_ratio_score"],
+    # )


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Adding Spurious Correlation feature for Image datasets.
>
> 📜 **Example Usage**: Finds correlation score between one of the image properties like dark score, blurry score, information score, size, aspect_ratio, etc. and the class labels using certain metrics like baseline accuracy and held-out accuracy by fitting a univariate model.

**[ ✏️ Write your summary here. ]**

1. Added `spurious_correlation.py` module in `cleanlab/datalab/internal` location.
2. Added a private instance method `_spurious_correlation` in `Datalab` class that uses an instance of `SpuriousCorrelations` class.

## Links to Relevant Issues or Conversations

> Issue Link: https://github.com/cleanlab/cleanlab/issues/860
> Early PR attempted: https://github.com/cleanlab/cleanlab/pull/872