### PR TITLE
Enhance knn-based outlier detection in Datalab

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/data_valuation.py
+++ b/cleanlab/datalab/internal/issue_manager/data_valuation.py
@@ -134,7 +134,7 @@ class DataValuationIssueManager(IssueManager):
             )
             raise TypeError(error_msg)
 
-        knn_graph, self.metric = set_knn_graph(
+        knn_graph, self.metric, _ = set_knn_graph(
             features=features,
             find_issues_kwargs=kwargs,
             metric=self.metric,

--- a/cleanlab/datalab/internal/issue_manager/duplicate.py
+++ b/cleanlab/datalab/internal/issue_manager/duplicate.py
@@ -69,7 +69,7 @@ class NearDuplicateIssueManager(IssueManager):
         features: Optional[npt.NDArray] = None,
         **kwargs,
     ) -> None:
-        knn_graph, self.metric = set_knn_graph(
+        knn_graph, self.metric, _ = set_knn_graph(
             features=features,
             find_issues_kwargs=kwargs,
             metric=self.metric,

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -175,7 +175,7 @@ class NonIIDIssueManager(IssueManager):
             features, pred_probs, kwargs, statistics, self.k
         )
 
-        knn_graph, self.metric = set_knn_graph(
+        knn_graph, self.metric, _ = set_knn_graph(
             features=self._determine_optional_features(features, pred_probs),
             find_issues_kwargs=kwargs,
             metric=self.metric,

--- a/cleanlab/datalab/internal/issue_manager/underperforming_group.py
+++ b/cleanlab/datalab/internal/issue_manager/underperforming_group.py
@@ -107,7 +107,7 @@ class UnderperformingGroupIssueManager(IssueManager):
             raise TypeError(error_msg)
         if cluster_ids is None:
             statistics = self.datalab.get_info("statistics")
-            knn_graph, self.metric = set_knn_graph(
+            knn_graph, self.metric, _ = set_knn_graph(
                 features, kwargs, self.metric, self.k, statistics
             )
             cluster_ids = self.perform_clustering(knn_graph)


### PR DESCRIPTION
This PR improves the KNN-based outlier detection functionality in Datalab:

1. Modify `set_knn_graph` internal helper function to return the KNN search object when creating a graph from features.
2. Add the KNN search object to the info dictionary in the outlier issue manager.
3. Store the scaling factor in the outlier issue manager when using KNN-based detection for scoring.

These changes enhance the efficiency of downstream outlier tasks by providing access to the KNN search object and scaling factor, reducing the need for re-fitting when only features are available.