### PR TITLE
[temp] pin twine version for package deployment

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -81,9 +81,7 @@ jobs:
           python-version: 3.11
 
       - name: Install dependencies
-        run: |
-          pip install --upgrade setuptools wheel twine
-          pip install importlib_metadata==7.2.1
+        run: pip install --upgrade setuptools wheel twine==5.0.0
 
       - name: Perform some tests on the metadata of the package
         run: |

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -81,7 +81,9 @@ jobs:
           python-version: 3.11
 
       - name: Install dependencies
-        run: pip install --upgrade setuptools wheel twine
+        run: |
+          pip install --upgrade setuptools wheel twine
+          pip install importlib_metadata==7.2.1
 
       - name: Perform some tests on the metadata of the package
         run: |


### PR DESCRIPTION
twine has a temporary regression on the latest version that affects the release process