### PR TITLE
Improve matplotlib Axes typing

### DIFF
--- a/cleanlab/object_detection/summary.py
+++ b/cleanlab/object_detection/summary.py
@@ -19,7 +19,18 @@ Methods to display examples and their label issues in an object detection datase
 Here each image can have multiple objects, each with its own bounding box and class label.
 """
 from multiprocessing import Pool
-from typing import Optional, Any, Dict, Tuple, Union, List, TYPE_CHECKING, TypeVar, DefaultDict
+from typing import (
+    Optional,
+    Any,
+    Dict,
+    Tuple,
+    Union,
+    List,
+    TYPE_CHECKING,
+    TypeVar,
+    DefaultDict,
+    cast,
+)
 
 import numpy as np
 import collections
@@ -393,6 +404,7 @@ def visualize(
     """
     try:
         import matplotlib.pyplot as plt
+        from matplotlib.axes import Axes
     except ImportError as e:
         raise ImportError(
             "This functionality requires matplotlib. Install it via: `pip install matplotlib`"
@@ -430,6 +442,7 @@ def visualize(
     else:
         figsize = (14, 10) if figsize is None else figsize
         fig, axes = plt.subplots(nrows=1, ncols=2, frameon=False, figsize=figsize)
+        axes = cast(Tuple[Axes, Axes], axes)
         axes[0].axis("off")
         axes[0].imshow(image)
         axes[1].axis("off")

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -18,7 +18,7 @@
 Methods to display images and their label issues in a semantic segmentation dataset, as well as summarize the overall types of issues identified.
 """
 
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, cast
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
## Summary

🎯 **Purpose**: Fix type hints for matplotlib Axes in segmentation and object-detection modules to resolve mypy errors and improve static analysis.

📜 **Example Usage**: 

```python
# In cleanlab/segmentation/summary.py or cleanlab/object_detection/summary.py

from typing import cast
from matplotlib.axes import Axes

# When dealing with plt.subplots() return value
fig, axes = plt.subplots(1, output_plots, figsize=(5 * output_plots, 5))
if output_plots == 1:
    axes_list = [cast(Axes, axes)]
else:
    axes_list = cast(List[Axes], axes) if isinstance(axes, np.ndarray) else [axes]

# Now axes_list can be safely used without type errors
for ax in axes_list:
    ax.imshow(...)  # No mypy errors
```

## Impact

- 🌐 Areas Affected: `cleanlab/segmentation/summary.py`, `cleanlab/object_detection/summary.py`
- 👥 Who's Affected: Developers working on or using these modules, especially when running type checks

## Testing

- 🔍 Testing Done: Ran mypy on the affected files (cleanlab/segmentation/summary.py and cleanlab/object_detection/summary.py) to verify type correctness.
Executed all relevant notebooks and compared outputs with the master branch to ensure identical functionality.
- 🔗 Test Case Link: N/A (type hint changes, verified by running mypy)


## References

- [Matplotlib subplots documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.subplots.html)