### PR TITLE
Pin codecov-action to version "v0.7.3" in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Test with coverage
         run: pytest --verbose --maxfail=3 --order-tests --cov=cleanlab/ --cov-config .coveragerc --cov-report=xml
       - uses: codecov/codecov-action@v3
+        with:
+          version: "v0.7.3"
   test-macos-linux:
     name: "Test: Python ${{ matrix.python }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -64,6 +66,8 @@ jobs:
       - name: Test with coverage
         run: pytest --verbose --maxfail=3 --order-tests --cov=cleanlab/ --cov-config .coveragerc --cov-report=xml
       - uses: codecov/codecov-action@v3
+        with:
+          version: "v0.7.3"
   test-without-extras-min-versions:
     name: Test without optional dependencies and with minimum compatible versions of dependencies
     runs-on: ubuntu-latest


### PR DESCRIPTION
The [codecov uploader had a recent release](https://github.com/codecov/uploader/releases/tag/v0.8.0) that broke the codecov-action on macos-12. This PR reverts the uploader to a working version (0.7.3).

Example failures looked like this:

```
Run codecov/codecov-action@v3
  with:
  env:
    pythonLocation: /Users/runner/hostedtoolcache/Python/3.11.9/x64
    PKG_CONFIG_PATH: /Users/runner/hostedtoolcache/Python/3.11.9/x64/lib/pkgconfig
    Python_ROOT_DIR: /Users/runner/hostedtoolcache/Python/3.11.9/x64
    Python[2](https://github.com/cleanlab/cleanlab/actions/runs/10223080430/job/28356081600#step:8:2)_ROOT_DIR: /Users/runner/hostedtoolcache/Python/[3](https://github.com/cleanlab/cleanlab/actions/runs/10223080430/job/28356081600#step:8:3).11.9/x6[4](https://github.com/cleanlab/cleanlab/actions/runs/10223080430/job/28356081600#step:8:4)
    Python3_ROOT_DIR: /Users/runner/hostedtoolcache/Python/3.11.9/x64
==> macos OS detected
https://uploader.codecov.io/latest/macos/codecov.SHA2[5](https://github.com/cleanlab/cleanlab/actions/runs/10223080430/job/28356081600#step:8:5)6SUM
==> SHASUM file signed by key id 806bb28aed779869
==> Uploader SHASUM verified (7508[6](https://github.com/cleanlab/cleanlab/actions/runs/10223080430/job/28356081600#step:8:6)ee436f6f74c4e8f65448eaa399e38bc93bb27a53d057b24b275b9f78c89  codecov)
==> Running version latest
==> Running version v0.8.0
/Users/runner/work/_actions/codecov/codecov-action/v3/dist/codecov -n  -Q github-action-3.1.6
Error: spawn Unknown system error -86
    at ChildProcess.spawn (node:internal/child_process:421:11)
    at Object.spawn (node:child_process:[7](https://github.com/cleanlab/cleanlab/actions/runs/10223080430/job/28356081600#step:8:7)61:9)
    at ToolRunner.<anonymous> (/Users/runner/work/_actions/codecov/codecov-action/v3/webpack:/codecov-action/node_modules/@actions/exec/lib/toolrunner.js:413:1)
    at Generator.next (<anonymous>)
    at /Users/runner/work/_actions/codecov/codecov-action/v3/webpack:/codecov-action/node_modules/@actions/exec/lib/toolrunner.js:27:1
    at new Promise (<anonymous>)
    at __webpack_modules__.[8](https://github.com/cleanlab/cleanlab/actions/runs/10223080430/job/28356081600#step:8:8)159.__awaiter (/Users/runner/work/_actions/codecov/codecov-action/v3/webpack:/codecov-action/node_modules/@actions/exec/lib/toolrunner.js:23:1)
    at /Users/runner/work/_actions/codecov/codecov-action/v3/webpack:/codecov-action/node_modules/@actions/exec/lib/toolrunner.js:3[9](https://github.com/cleanlab/cleanlab/actions/runs/10223080430/job/28356081600#step:8:10)5:1
    at new Promise (<anonymous>)
    at ToolRunner.<anonymous> (/Users/runner/work/_actions/codecov/codecov-action/v3/webpack:/codecov-action/node_modules/@actions/exec/lib/toolrunner.js:395:1)
```



<details><summary>See success case:</summary>
<p>

```
Run codecov/codecov-action@v3
  with:
  env:
    pythonLocation: /Users/runner/hostedtoolcache/Python/3.8.18/x64
    PKG_CONFIG_PATH: /Users/runner/hostedtoolcache/Python/3.8.18/x64/lib/pkgconfig
    Python_ROOT_DIR: /Users/runner/hostedtoolcache/Python/3.8.18/x64
    Python[2](https://github.com/cleanlab/cleanlab/actions/runs/10166152621/job/28115652313#step:8:2)_ROOT_DIR: /Users/runner/hostedtoolcache/Python/[3](https://github.com/cleanlab/cleanlab/actions/runs/10166152621/job/28115652313#step:8:3).8.18/x6[4](https://github.com/cleanlab/cleanlab/actions/runs/10166152621/job/28115652313#step:8:4)
    Python3_ROOT_DIR: /Users/runner/hostedtoolcache/Python/3.8.18/x64
==> macos OS detected
https://uploader.codecov.io/latest/macos/codecov.SHA2[5](https://github.com/cleanlab/cleanlab/actions/runs/10166152621/job/28115652313#step:8:5)6SUM
==> SHASUM file signed by key id 806bb28aed779869
==> Uploader SHASUM verified (f544d03e5c2b9e4[6](https://github.com/cleanlab/cleanlab/actions/runs/10166152621/job/28115652313#step:8:6)912b727af23dbc3727ab5a86efa95c5325902db4c034f934  codecov)
==> Running version latest
==> Running version v0.[7](https://github.com/cleanlab/cleanlab/actions/runs/10166152621/job/28115652313#step:8:7).3
/Users/runner/work/_actions/codecov/codecov-action/v3/dist/codecov -n  -Q github-action-3.1.6
[2024-07-30T17:15:54.001Z] ['info'] 
     _____          _
    / ____|        | |
   | |     ___   __| | ___  ___ _____   __
   | |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
   | |___| (_) | (_| |  __/ (_| (_) \ V /
    \_____\___/ \__,_|\___|\___\___/ \_/

  Codecov report uploader 0.7.3
[2024-07-30T17:15:54.015Z] ['info'] => Project root located at: /Users/runner/work/cleanlab/cleanlab
[2024-07-30T17:15:54.017Z] ['info'] -> No token specified or token is empty
[2024-07-30T17:15:54.179Z] ['info'] Running coverage xml...
[2024-07-30T17:15:56.516Z] ['info'] Searching for coverage files...
[2024-07-30T17:15:56.559Z] ['info'] Warning: Some files located via search were excluded from upload.
[2024-07-30T17:15:56.559Z] ['info'] If Codecov did not locate your files, please review https://docs.codecov.com/docs/supported-report-formats
[2024-07-30T17:15:56.559Z] ['info'] => Found 1 possible coverage files:
  coverage.xml
[2024-07-30T17:15:56.559Z] ['info'] Processing /Users/runner/work/cleanlab/cleanlab/coverage.xml...
[2024-07-30T17:15:56.565Z] ['info'] Detected GitHub Actions as the CI provider.
[2024-07-30T17:15:57.394Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=github-action-3.1.6-uploader-0.7.3&token=*******&branch=master&build=10166152621&build_url=https%3A%2F%2Fgithub.com%2Fcleanlab%2Fcleanlab%2Factions%2Fruns%2F10166152621&commit=774f5b4625f50[8](https://github.com/cleanlab/cleanlab/actions/runs/10166152621/job/28115652313#step:8:8)53a4527b3bf0414f14a7116208&job=CI&pr=&service=github-actions&slug=cleanlab%2Fcleanlab&name=&tag=&flags=&parent=
[2024-07-30T17:15:57.713Z] ['error'] There was an error running the uploader: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 42[9](https://github.com/cleanlab/cleanlab/actions/runs/10166152621/job/28115652313#step:8:10) - {'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 269s.', code='throttled')}
[2024-07-30T17:15:57.7[14](https://github.com/cleanlab/cleanlab/actions/runs/10166152621/job/28115652313#step:8:15)Z] ['info'] Codecov will exit with status code 0. If you are expecting a non-zero exit code, please pass in the `-Z` flag
``` 

</p>
</details> 