### PR TITLE
Change wording in issue type description for spurious correlations.

### DIFF
--- a/docs/source/cleanlab/datalab/guide/issue_type_description.rst
+++ b/docs/source/cleanlab/datalab/guide/issue_type_description.rst
@@ -454,7 +454,7 @@ A categorical column that identifies specific image-related characteristics asse
 ``score``
 ~~~~~~~~~
 
-A numeric column that gives the level of label uncorrelatedness for each image-specific property computed while calling `lab.find_issues()`. The score lies between 0 and 1. The lower the score for an image-property, the more correlated the image-property is with the given labels.
+A numeric column that gives the level of label uncorrelatedness for a given image-specific property. The score lies between 0 and 1. The lower the score for an image-property, the more correlated the image-property is with the given labels.
 
 .. tip::
 

--- a/tests/spurious_correlation/test_spurious_correlation.py
+++ b/tests/spurious_correlation/test_spurious_correlation.py
@@ -451,7 +451,9 @@ class TestImagelabReporterAdapter:
         self.threshold = 0.01
         dataset = generate_dataset(circle_filter=test_attribute)
         lab = Datalab(data=dataset, label_name="label", image_key="image")
-        lab.find_issues()
+        lab.find_issues()  # Easiest way to get default imagelab checks
+        # Rerun checks with threshold for spurious correlations for simplicity.
+        lab.find_issues(issue_types={"spurious_correlations": {"threshold": self.threshold}})
         self.label_uncorrelatedness_scores = lab.get_info("spurious_correlations")[
             "correlations_df"
         ]


### PR DESCRIPTION
The default threshold (for spurious correlations) has been bumped to 0.05, but a previous test didn't actually pass the original threshold.

To simplify the test. `lab.find_issues()` is still run once without args to run all default (imagelab) checks.
Rerunning `lab.find_issues` for spurious correlations a second time uses the specified threshold 0.01 as expected in the test.