### PR TITLE
updating default value of threshold for spurious correlations

### DIFF
--- a/cleanlab/datalab/internal/adapter/constants.py
+++ b/cleanlab/datalab/internal/adapter/constants.py
@@ -1,6 +1,6 @@
 SPURIOUS_CORRELATION_ISSUE = {
     "spurious_correlations": {
-        "threshold": 0.05,
+        "threshold": 0.3,
     },
 }  # Default issue type for spurious correlation in Datalab
 

--- a/tests/spurious_correlation/test_spurious_correlation.py
+++ b/tests/spurious_correlation/test_spurious_correlation.py
@@ -448,7 +448,7 @@ class TestImagelabReporterAdapter:
     @pytest.fixture(autouse=True)
     def lab(self, test_attribute):
         self.test_attribute = test_attribute
-        self.threshold = 0.01
+        self.threshold = SPURIOUS_CORRELATION_ISSUE["spurious_correlations"]["threshold"]
         dataset = generate_dataset(circle_filter=test_attribute)
         lab = Datalab(data=dataset, label_name="label", image_key="image")
         lab.find_issues()  # Easiest way to get default imagelab checks

--- a/tests/spurious_correlation/test_spurious_correlation.py
+++ b/tests/spurious_correlation/test_spurious_correlation.py
@@ -448,7 +448,7 @@ class TestImagelabReporterAdapter:
     @pytest.fixture(autouse=True)
     def lab(self, test_attribute):
         self.test_attribute = test_attribute
-        self.threshold = SPURIOUS_CORRELATION_ISSUE["spurious_correlations"]["threshold"]
+        self.threshold = 0.01
         dataset = generate_dataset(circle_filter=test_attribute)
         lab = Datalab(data=dataset, label_name="label", image_key="image")
         lab.find_issues()  # Easiest way to get default imagelab checks


### PR DESCRIPTION
Updating default value of threshold from 0.05 to 0.3. The threshold value for one of the test cases is hard-coded back to 0.01 to avoid dependency on the default threshold value should it need to be updated in the future.