### PR TITLE
Add documentation for cleanlab.datalab.internal.adapter

### DIFF
--- a/docs/source/cleanlab/datalab/internal/adapter/imagelab.rst
+++ b/docs/source/cleanlab/datalab/internal/adapter/imagelab.rst
@@ -1,0 +1,9 @@
+imagelab
+=============
+
+
+.. automodule:: cleanlab.datalab.internal.adapter.imagelab
+    :autosummary:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/cleanlab/datalab/internal/adapter/index.rst
+++ b/docs/source/cleanlab/datalab/internal/adapter/index.rst
@@ -2,7 +2,7 @@ adapter
 =============
 
 .. warning::
-    Methods in this ``adapter`` module are bleeding edge and may have sharp edges. They are not guaranteed to be stable between different ``cleanlab`` versions.
+    Methods in this ``adapter`` module are intended for internal use within the ``cleanlab`` package. They are not guaranteed to be stable between different versions.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/source/cleanlab/datalab/internal/adapter/index.rst
+++ b/docs/source/cleanlab/datalab/internal/adapter/index.rst
@@ -1,0 +1,10 @@
+adapter
+=============
+
+.. warning::
+    Methods in this ``adapter`` module are bleeding edge and may have sharp edges. They are not guaranteed to be stable between different ``cleanlab`` versions.
+
+.. toctree::
+    :maxdepth: 2
+
+    imagelab

--- a/docs/source/cleanlab/datalab/internal/index.rst
+++ b/docs/source/cleanlab/datalab/internal/index.rst
@@ -15,6 +15,7 @@ internal
 .. toctree::
     :maxdepth: 2
 
+    adapter/index
     data
     data_issues
     issue_finder


### PR DESCRIPTION
## Summary

Update document to include the API reference for the `cleanlab.datalab.internal.adapter` modules


## Impact

 🌐 Areas Affected: Surface the API reference for `cleanlab.datalab.internal.adapter.imagelab`


**Screenshots**
- TOC tree
<img width="252" alt="Screenshot 2024-08-30 at 11 17 50 PM" src="https://github.com/user-attachments/assets/e2af0571-3e42-4dd5-86d6-09fae569f294">

- adapter page
<img width="774" alt="Screenshot 2024-08-30 at 11 18 04 PM" src="https://github.com/user-attachments/assets/a581613b-dc26-4dae-bec4-f92e36c772d3">




## Testing

Local run of 
```sh
SKIP_NOTEBOOKS=1  sphinx-build docs/source cleanlab-docs
```


## Links to Relevant Issues or Conversations

- fix #1041 

