### PR TITLE
test_datalab.py code improvements

### DIFF
--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -147,6 +147,7 @@ class TestDatalab:
             }
         )
         monkeypatch.setattr(lab, "issue_summary", mock_summary)
+        assert lab.issue_summary is lab.data_issues.issue_summary
 
         label_summary = lab.get_issue_summary(issue_name="label")
         pd.testing.assert_frame_equal(label_summary, mock_summary.iloc[[0]])
@@ -171,6 +172,7 @@ class TestDatalab:
             },
         )
         monkeypatch.setattr(lab, "issues", mock_issues)
+        assert lab.issues is lab.data_issues.issues
 
         mock_predicted_labels = np.array([0, 1, 2, 1, 2])
 

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -179,7 +179,6 @@ class TestDatalab:
             }
         )
         monkeypatch.setattr(lab, "issue_summary", mock_summary)
-        assert lab.issue_summary is lab.data_issues.issue_summary
 
         label_summary = lab.get_issue_summary(issue_name="label")
         pd.testing.assert_frame_equal(label_summary, mock_summary.iloc[[0]])

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -970,16 +970,16 @@ class TestDatalabFindNonIIDIssues:
         assert "weighted_knn_graph" not in lab.get_info("statistics")
 
     def test_incremental_search(self, lab, sorted_embeddings):
-        lab.find_issues(features=sorted_embeddings)
+        lab.find_issues(features=sorted_embeddings, issue_types={"null": {}})
         check_issues_dtypes(lab)
         check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
-        assert len(summary) == 5
+        assert len(summary) == 1
         lab.find_issues(features=sorted_embeddings, issue_types={"non_iid": {}})
         check_issues_dtypes(lab)
         check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
-        assert len(summary) == 5
+        assert len(summary) == 2
         assert "non_iid" in summary["issue_type"].values
         non_iid_summary = lab.get_issue_summary("non_iid")
         assert non_iid_summary["score"].values[0] == 0

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -80,7 +80,7 @@ def check_issue_summary_dtypes(lab):
         series = lab.issue_summary[col]
         dtype = series.dtype
         assert np.issubdtype(dtype, np.number), (
-            f"Column '{column}' must be numeric"
+            f"Column '{col}' must be numeric"
         )
 
 @pytest.fixture(scope="function")

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -203,7 +203,6 @@ class TestDatalab:
             },
         )
         monkeypatch.setattr(lab, "issues", mock_issues)
-        assert lab.issues is lab.data_issues.issues
 
         mock_predicted_labels = np.array([0, 1, 2, 1, 2])
 

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -50,6 +50,38 @@ def test_datalab_invalid_datasetdict(dataset, label_name):
         Datalab(datadict, label_name)  # type: ignore
         assert "Please pass a single dataset, not a DatasetDict." in str(e)
 
+def check_issues_dtypes(lab):
+    """
+    Asserts that each column in lab.issues has the expected dtype.
+    
+    """
+
+    for col in lab.issues.filter(like="is_").columns:
+        assert lab.issues[col].dtype.kind == 'b', f"Column '{col}' must be boolean."
+
+    for col in lab.issues.filter(like="_score").columns:
+        assert lab.issues[col].dtype.kind in {'i', 'f'}, f"Column '{col}' must be numeric."
+
+    for col in ["given_label", "predicted_label", "distance_to_nearest_neighbor"]:
+        if col in lab.issues.columns:
+            series = lab.issue_summary[col]
+            dtype = series.dtype
+            assert np.issubdtype(dtype, np.number), (
+                f"Column '{col}' must be numeric"
+            )
+
+def check_issue_summary_dtypes(lab):
+    """
+    Asserts that each column in lab.issue_summary has the expected dtype.
+    
+    """
+    
+    for col in ["score", "num_issues"]:
+        series = lab.issue_summary[col]
+        dtype = series.dtype
+        assert np.issubdtype(dtype, np.number), (
+            f"Column '{column}' must be numeric"
+        )
 
 @pytest.fixture(scope="function")
 def list_possible_issue_types(monkeypatch, request):
@@ -248,6 +280,8 @@ class TestDatalab:
         assert lab.issue_summary.empty, "Issue summary should be empty before calling find_issues"
         assert lab.info["statistics"]["health_score"] is None
         lab.find_issues(pred_probs=pred_probs, issue_types=issue_types)
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         assert not lab.issues.empty, "Issues weren't updated"
         assert not lab.issue_summary.empty, "Issue summary wasn't updated"
         assert (
@@ -333,6 +367,8 @@ class TestDatalab:
         large_lab.find_issues(
             features=features, pred_probs=pred_probs, knn_graph=knn_graph, issue_types=issue_types
         )
+        check_issues_dtypes(large_lab)
+        check_issue_summary_dtypes(large_lab)
         with contextlib.redirect_stdout(io.StringIO()) as f:
             large_lab.report()
         first_report = f.getvalue()
@@ -364,6 +400,8 @@ class TestDatalab:
             features=mock_embeddings,
             issue_types=issue_types,
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         assert lab.info["outlier"]["k"] == k
         statistics = lab.get_info("statistics")
         assert statistics["knn_metric"] == metric
@@ -394,6 +432,8 @@ class TestDatalab:
         monkeypatch.setattr(lab, "issue_summary", mock_issue_summary)
 
         lab.find_issues(pred_probs=pred_probs, issue_types={"label": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         # Check that the issues dataframe has the right columns
         expected_issues_df = pd.DataFrame(
             {
@@ -595,6 +635,8 @@ class TestDatalabUsingKNNGraph:
         lab, knn_graph, _ = data_tuple
         assert lab.get_info("statistics").get("weighted_knn_graph") is None
         lab.find_issues(knn_graph=knn_graph)
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         knn_graph_stats = lab.get_info("statistics").get("weighted_knn_graph")
         np.testing.assert_array_equal(knn_graph_stats.toarray(), knn_graph.toarray())
 
@@ -607,6 +649,8 @@ class TestDatalabUsingKNNGraph:
 
         assert lab.get_info("statistics").get("weighted_knn_graph") is None
         lab.find_issues(knn_graph=knn_graph, features=features, issue_types={"outlier": {"k": 4}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         knn_graph_stats = lab.get_info("statistics").get("weighted_knn_graph")
 
         # expect_k is 3 because we're using the passed-in knn_graph, not the k specified in the issue_types
@@ -633,6 +677,8 @@ class TestDatalabUsingKNNGraph:
 
         # Test that a warning is raised
         lab.find_issues()
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         # Only class_imbalance issue columns should be present
         assert list(lab.issues.columns) == ["is_class_imbalance_issue", "class_imbalance_score"]
 
@@ -640,6 +686,8 @@ class TestDatalabUsingKNNGraph:
         lab, knn_graph, features = data_tuple
         assert lab.get_info("statistics").get("weighted_knn_graph") is None
         lab.find_issues(knn_graph=knn_graph, issue_types={"data_valuation": {"k": 3}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         score = lab.get_issues().get(["data_valuation_score"])
         assert isinstance(score, pd.DataFrame)
         assert len(score) == len(lab.data)
@@ -648,6 +696,8 @@ class TestDatalabUsingKNNGraph:
         lab, knn_graph, features = data_tuple
         lab.find_issues(features=features, issue_types={"outlier": {"k": 3}})
         lab.find_issues(issue_types={"data_valuation": {"k": 3}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         score = lab.get_issues().get(["data_valuation_score"])
         assert isinstance(score, pd.DataFrame)
         assert len(score) == len(lab.data)
@@ -661,6 +711,8 @@ class TestDatalabUsingKNNGraph:
     def test_data_valuation_issue_without_knn_graph(self, data_tuple):
         lab, _, features = data_tuple
         lab.find_issues(features=features, issue_types={"data_valuation": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         assert (
             lab.issues.empty
         ), "The issues dataframe should be empty as the issue manager expects an existing knn_graph"
@@ -702,6 +754,8 @@ class TestDatalabIssueManagerInteraction:
         assert lab.issue_summary.empty
 
         lab.find_issues(issue_types={"custom_issue": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
 
         expected_is_custom_issue_issue = [False, True] + [False] * 3
         expected_custom_issue_score = [1 / 1, 0 / 2, 1 / 3, 2 / 4, 3 / 5]
@@ -726,6 +780,8 @@ class TestDatalabIssueManagerInteraction:
         assert lab.issue_summary.empty
 
         lab.find_issues(issue_types={"custom_issue": {"custom_argument": 3}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
 
         expected_is_custom_issue_issue = [False, False, False, True, False]
         expected_custom_issue_score = [3 / 3, 2 / 4, 1 / 5, 0 / 6, 1 / 7]
@@ -758,6 +814,8 @@ def test_report_for_outlier_issues_via_pred_probs(find_issues_kwargs):
     lab = Datalab(data=data, label_name="labels")
     find_issues_kwargs["issue_types"] = {"outlier": {"k": 1}}
     lab.find_issues(**find_issues_kwargs)
+    check_issues_dtypes(lab)
+    check_issue_summary_dtypes(lab)
 
     reporter = Reporter(
         lab.data_issues, task=Task.CLASSIFICATION, verbosity=0, include_description=False
@@ -787,6 +845,8 @@ def test_near_duplicates_reuses_knn_graph():
         lambda: lab.find_issues(features=features, **find_issues_kwargs),
         number=1,
     )
+    check_issues_dtypes(lab)
+    check_issue_summary_dtypes(lab)
 
     # Run 2: near_duplicate and outlier with same k
     lab = Datalab(data=data, label_name="labels")
@@ -798,6 +858,8 @@ def test_near_duplicates_reuses_knn_graph():
         lambda: lab.find_issues(features=features, **find_issues_kwargs),
         number=1,
     )
+    check_issues_dtypes(lab)
+    check_issue_summary_dtypes(lab)
 
     # Run 3: Same Datalab instance with same issues, but in different order
     find_issues_kwargs = {
@@ -807,6 +869,9 @@ def test_near_duplicates_reuses_knn_graph():
         lambda: lab.find_issues(features=features, **find_issues_kwargs),
         number=1,
     )
+
+    check_issues_dtypes(lab)
+    check_issue_summary_dtypes(lab)
 
     # Run 2 does an extra check, so it should be slower
     assert time_only_near_duplicates < time_near_duplicates_and_outlier, (
@@ -866,6 +931,8 @@ class TestDatalabFindNonIIDIssues:
 
     def test_find_non_iid_issues(self, lab, random_embeddings):
         lab.find_issues(features=random_embeddings, issue_types={"non_iid": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert ["non_iid"] == summary["issue_type"].values
         assert summary["score"].values[0] > 0.05
@@ -874,6 +941,8 @@ class TestDatalabFindNonIIDIssues:
     def test_find_non_iid_issues_using_pred_probs(self, lab, random_embeddings):
         pred_probs = pred_probs_from_features(random_embeddings)
         lab.find_issues(pred_probs=pred_probs, issue_types={"non_iid": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert ["non_iid"] == summary["issue_type"].values
         assert summary["score"].values[0] > 0.05
@@ -882,6 +951,8 @@ class TestDatalabFindNonIIDIssues:
 
     def test_find_non_iid_issues_sorted(self, lab, sorted_embeddings):
         lab.find_issues(features=sorted_embeddings, issue_types={"non_iid": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert ["non_iid"] == summary["issue_type"].values
         assert summary["score"].values[0] == 0
@@ -890,6 +961,8 @@ class TestDatalabFindNonIIDIssues:
     def test_find_non_iid_issues_sorted_using_pred_probs(self, lab, sorted_embeddings):
         pred_probs = pred_probs_from_features(sorted_embeddings)
         lab.find_issues(pred_probs=pred_probs, issue_types={"non_iid": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert ["non_iid"] == summary["issue_type"].values
         assert summary["score"].values[0] == 0
@@ -898,9 +971,13 @@ class TestDatalabFindNonIIDIssues:
 
     def test_incremental_search(self, lab, sorted_embeddings):
         lab.find_issues(features=sorted_embeddings)
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 5
         lab.find_issues(features=sorted_embeddings, issue_types={"non_iid": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 5
         assert "non_iid" in summary["issue_type"].values
@@ -911,9 +988,13 @@ class TestDatalabFindNonIIDIssues:
     def test_incremental_search_using_pred_probs(self, lab, sorted_embeddings):
         pred_probs = pred_probs_from_features(sorted_embeddings)
         lab.find_issues(pred_probs=pred_probs, issue_types={"non_iid": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         lab.find_issues(pred_probs=pred_probs, issue_types={"non_iid": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "non_iid" in summary["issue_type"].values
@@ -934,6 +1015,8 @@ class TestDatalabFindNonIIDIssues:
         lab.find_issues(
             features=random_embeddings, pred_probs=pred_probs, issue_types={"outlier": {}}
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         cached_knn_graph = lab.get_info("statistics").get("weighted_knn_graph")
         assert cached_knn_graph is not None
         lab.find_issues(pred_probs=pred_probs, issue_types={"non_iid": {}})
@@ -946,6 +1029,8 @@ class TestDatalabFindNonIIDIssues:
         lab_2.find_issues(
             pred_probs=pred_probs, knn_graph=cached_knn_graph, issue_types={"non_iid": {}}
         )
+        check_issues_dtypes(lab_2)
+        check_issue_summary_dtypes(lab_2)
         knn_graph_after_non_iid = lab.get_info("statistics").get("weighted_knn_graph")
         # Check if stored knn graph is same as the knn graph passed to find_issues
         assert cached_knn_graph is knn_graph_after_non_iid
@@ -961,6 +1046,8 @@ class TestDatalabFindNonIIDIssues:
         features = np.full((N, M), fill_value=np.random.rand(M))
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(features=features, issue_types={"non_iid": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         assert lab.get_issues()["is_non_iid_issue"].sum() == 1
         assert lab.get_issue_summary()["score"].values[0] < 0.05
 
@@ -981,10 +1068,14 @@ class TestDatalabFindLabelIssues:
         data = {"labels": np.random.randint(0, 2, 100)}
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(features=random_embeddings)
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 6
         assert "label" in summary["issue_type"].values
         lab.find_issues(pred_probs=pred_probs, issue_types={"label": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 6
         assert "label" in summary["issue_type"].values
@@ -995,6 +1086,8 @@ class TestDatalabFindLabelIssues:
         issue_types = {"label": {"clean_learning_kwargs": {"low_memory": True}}}
         lab_lm = Datalab(data=data, label_name="labels")
         lab_lm.find_issues(pred_probs=pred_probs, issue_types=issue_types)
+        check_issues_dtypes(lab_lm)
+        check_issue_summary_dtypes(lab_lm)
         issues_df_lm = lab_lm.get_issues("label")
         # jaccard similarity
         intersection = len(list(set(issues_df).intersection(set(issues_df_lm))))
@@ -1005,10 +1098,14 @@ class TestDatalabFindLabelIssues:
         data = {"labels": np.random.randint(0, 2, 100)}
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(features=random_embeddings, issue_types={"label": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "label" in summary["issue_type"].values
         lab.find_issues(features=random_embeddings, issue_types={"label": {"k": 5}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "label" in summary["issue_type"].values
@@ -1017,6 +1114,8 @@ class TestDatalabFindLabelIssues:
         data = {"labels": np.random.randint(0, 2, 100)}
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(pred_probs=pred_probs, issue_types={"label": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert "label" in summary["issue_type"].values
         label_summary_pred_probs = lab.get_issue_summary("label")
@@ -1025,6 +1124,8 @@ class TestDatalabFindLabelIssues:
         lab.find_issues(
             features=random_embeddings, pred_probs=pred_probs, issue_types={"label": {}}
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert "label" in summary["issue_type"].values
         label_summary_both = lab.get_issue_summary("label")
@@ -1052,10 +1153,14 @@ class TestDatalabFindOutlierIssues:
         data = {"labels": np.random.randint(0, 2, 100)}
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(pred_probs=pred_probs, issue_types={"label": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "outlier" not in summary["issue_type"].values
         lab.find_issues(features=random_embeddings, issue_types={"outlier": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 2
         assert "outlier" in summary["issue_type"].values
@@ -1069,6 +1174,8 @@ class TestDatalabFindOutlierIssues:
         features = np.full((N, M), fill_value=np.random.rand(M))
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(features=features, issue_types={"outlier": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         outlier_issues = lab.get_issues("outlier")
         assert outlier_issues["is_outlier_issue"].sum() == 0
         np.testing.assert_allclose(outlier_issues["outlier_score"].to_numpy(), 1)
@@ -1115,10 +1222,14 @@ class TestDatalabFindNearDuplicateIssues:
         data = {"labels": np.random.randint(0, 2, 100)}
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(pred_probs=pred_probs, issue_types={"label": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "near_duplicate" not in summary["issue_type"].values
         lab.find_issues(features=random_embeddings, issue_types={"near_duplicate": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 2
         assert "near_duplicate" in summary["issue_type"].values
@@ -1128,6 +1239,8 @@ class TestDatalabFindNearDuplicateIssues:
     def test_fixed_embeddings_outputs(self, fixed_embeddings):
         lab = Datalab(data={"a": ["" for _ in range(len(fixed_embeddings))]})
         lab.find_issues(features=fixed_embeddings, issue_types={"near_duplicate": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         issues = lab.get_issues("near_duplicate")
 
         assert issues["is_near_duplicate_issue"].sum() == 18
@@ -1192,6 +1305,8 @@ class TestDatalabFindNearDuplicateIssues:
         features = np.full((N, M), fill_value=np.random.rand(M))
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(features=features, issue_types={"near_duplicate": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         near_duplicate_issues = lab.get_issues("near_duplicate")
         assert near_duplicate_issues["is_near_duplicate_issue"].sum() == N
         np.testing.assert_allclose(near_duplicate_issues["near_duplicate_score"].to_numpy(), 0)
@@ -1229,21 +1344,31 @@ class TestDatalabWithoutLabels:
     def test_find_issues(self, lab, features, pred_probs):
         lab = Datalab(data={"X": features})
         lab.find_issues(pred_probs=pred_probs)
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         assert set(lab.issues.columns) == {"is_non_iid_issue", "non_iid_score"}
 
         lab = Datalab(data={"X": features})
         lab.find_issues(features=features)
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         assert not lab.issues.empty
 
     def test_find_issues_features_works_with_and_without_labels(self, features, labels):
         lab_without_labels = Datalab(data={"X": features})
         lab_without_labels.find_issues(features=features)
+        check_issues_dtypes(lab_without_labels)
+        check_issue_summary_dtypes(lab_without_labels)
 
         lab_with_labels = Datalab(data={"X": features, "labels": labels}, label_name="labels")
         lab_with_labels.find_issues(features=features)
+        check_issues_dtypes(lab_with_labels)
+        check_issue_summary_dtypes(lab_with_labels)
 
         lab_without_label_name = Datalab(data={"X": features, "labels": labels})
         lab_without_label_name.find_issues(features=features)
+        check_issues_dtypes(lab_without_label_name)
+        check_issue_summary_dtypes(lab_without_label_name)
 
         issues_without_labels = lab_without_labels.issues
         issues_with_labels = lab_with_labels.issues
@@ -1282,10 +1407,14 @@ class TestDataLabClassImbalanceIssues:
         data = {"labels": imbalance_labels}
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(pred_probs=pred_probs, issue_types={"label": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "class_imbalance" not in summary["issue_type"].values
         lab.find_issues(features=random_embeddings, issue_types={"class_imbalance": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)       
         summary = lab.get_issue_summary()
         assert len(summary) == 2
         assert "class_imbalance" in summary["issue_type"].values
@@ -1296,6 +1425,8 @@ class TestDataLabClassImbalanceIssues:
         data = {"labels": imbalance_labels}
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(issue_types={"class_imbalance": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "class_imbalance" in summary["issue_type"].values
@@ -1327,12 +1458,16 @@ class TestDataLabUnderperformingIssue:
         features, labels, pred_probs = data["features"], data["labels"], data["pred_probs"]
         lab = Datalab(data={"labels": labels}, label_name="labels")
         lab.find_issues(pred_probs=pred_probs, issue_types={"label": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "underperforming_group" not in summary["issue_type"].values
         lab.find_issues(
             features=features, pred_probs=pred_probs, issue_types={"underperforming_group": {}}
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 2
         assert "underperforming_group" in summary["issue_type"].values
@@ -1367,6 +1502,8 @@ class TestDataLabUnderperformingIssue:
             pred_probs=pred_probs,
             issue_types={"underperforming_group": {"cluster_ids": cluster_ids}},
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         info = lab.get_info("underperforming_group")
         assert info["clustering"]["stats"]["underperforming_cluster_id"] == bad_cluster_id
         # Check that no underperforming cluster is found for correct predictions
@@ -1376,6 +1513,8 @@ class TestDataLabUnderperformingIssue:
             pred_probs=pred_probs,
             issue_types={"underperforming_group": {"cluster_ids": cluster_ids}},
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         info = lab.get_info("underperforming_group")
         assert info["clustering"]["stats"]["underperforming_cluster_id"] not in cluster_ids
 
@@ -1412,6 +1551,8 @@ class TestDataLabUnderperformingIssue:
             pred_probs=pred_probs,
             issue_types={"underperforming_group": {"cluster_ids": cluster_ids}},
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         issues = lab.get_issues("underperforming_group")
         cluster_ids_to_score = {2: 0.097, 3: 0.8208}
         expected_scores = np.ones(N)
@@ -1435,6 +1576,8 @@ class TestDataLabUnderperformingIssue:
             pred_probs=pred_probs_correct,
             issue_types={"underperforming_group": {"cluster_ids": cluster_ids}},
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         assert lab.get_issue_summary()["score"].values[0] == 1.0
 
     def test_features_and_knn_graph(self, data):
@@ -1448,6 +1591,8 @@ class TestDataLabUnderperformingIssue:
         lab.find_issues(
             features=features, pred_probs=pred_probs, issue_types={"underperforming_group": {}}
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         issues_1 = lab.get_issues("underperforming_group")
         knn_graph = lab.get_info("statistics")["weighted_knn_graph"]
         # Use another datalab instance to check preference of knn graph over features
@@ -1459,6 +1604,8 @@ class TestDataLabUnderperformingIssue:
             knn_graph=knn_graph,
             issue_types={"underperforming_group": {}},
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         issues_2 = lab.get_issues("underperforming_group")
         pd.testing.assert_frame_equal(issues_1, issues_2)
 
@@ -1470,6 +1617,8 @@ class TestDataLabUnderperformingIssue:
             pred_probs=pred_probs,
             issue_types={"underperforming_group": {"cluster_ids": labels}},
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         info = lab.get_info("underperforming_group")
         assert info["clustering"]["algorithm"] is None
         underperforming_group_summary = lab.get_issue_summary("underperforming_group")
@@ -1483,6 +1632,8 @@ class TestDataLabUnderperformingIssue:
             ),
             number=1,
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         # Use another datalab instance to emphasize absense of precomputed info
         lab = Datalab(data={"labels": labels}, label_name="labels")
         time_without_clustering = timeit.timeit(
@@ -1493,6 +1644,8 @@ class TestDataLabUnderperformingIssue:
             ),
             number=1,
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         # find_issues must be slower when clustering needs to be performed.
         assert (
             time_without_clustering < time_with_clustering
@@ -1506,6 +1659,8 @@ class TestDataLabUnderperformingIssue:
             pred_probs=pred_probs,
             issue_types={"underperforming_group": {"cluster_ids": np.array([], dtype=int)}},
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         assert len(lab.issue_summary["issue_type"].values) == 0
 
     def test_all_identical_dataset(self):
@@ -1518,6 +1673,8 @@ class TestDataLabUnderperformingIssue:
         lab.find_issues(
             features=features, pred_probs=pred_probs, issue_types={"underperforming_group": {}}
         )
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         underperforming_issues = lab.get_issues("underperforming_group")
         assert underperforming_issues["is_underperforming_group_issue"].sum() == 0
         np.testing.assert_allclose(
@@ -1555,10 +1712,14 @@ class TestDataLabNullIssues:
         data = {"labels": labels}
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(pred_probs=pred_probs, issue_types={"label": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 1
         assert "class_imbalance" not in summary["issue_type"].values
         lab.find_issues(features=embeddings_with_null, issue_types={"null": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         summary = lab.get_issue_summary()
         assert len(summary) == 2
         assert "null" in summary["issue_type"].values
@@ -1568,6 +1729,8 @@ class TestDataLabNullIssues:
     def test_null_issues(self, embeddings_with_null):
         lab = Datalab(data={"features": embeddings_with_null})
         lab.find_issues(features=embeddings_with_null, issue_types={"null": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         issues = lab.get_issues("null")
         expected_issue_mask = np.zeros(100, dtype=bool)
         expected_issue_mask[[5, 10, 22]] = True
@@ -1671,6 +1834,8 @@ class TestDatalabDataValuation:
             lab = Datalab(data=dataset, label_name=self.label_name)
             assert lab.issue_summary.empty
             lab.find_issues(**kwargs, issue_types={"data_valuation": {}})
+            check_issues_dtypes(lab)
+            check_issue_summary_dtypes(lab)
             summary = lab.get_issue_summary()
             assert len(summary) == 1
             assert "data_valuation" in summary["issue_type"].values
@@ -1706,6 +1871,8 @@ class TestDatalabDataValuation:
 
         lab = Datalab(data=dataset, label_name=self.label_name)
         lab.find_issues(features=dataset["X"], issue_types={"data_valuation": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
 
         # The default metric should be "cosine" for "high-dimensional" features
         assert lab.get_info("statistics")["knn_metric"] == "cosine"
@@ -1726,6 +1893,8 @@ class TestDatalabDataValuation:
             lab.find_issues(
                 features=dataset["X"], issue_types={"data_valuation": {"metric": metric}}
             )
+            check_issues_dtypes(lab)
+            check_issue_summary_dtypes(lab)
             assert metric == lab.get_info("statistics")["knn_metric"]
             assert np.allclose(
                 expected_knn_graph.toarray(),
@@ -1739,6 +1908,8 @@ class TestDatalabDataValuation:
         features = np.full((N, M), fill_value=np.random.rand(M))
         lab = Datalab(data=data, label_name="labels")
         lab.find_issues(features=features, issue_types={"data_valuation": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
         data_valuation_issues = lab.get_issues("data_valuation")
         assert data_valuation_issues["is_data_valuation_issue"].sum() == 0
 
@@ -1761,6 +1932,8 @@ class TestDatalabDataValuation:
         # Run dataset through Datalab
         lab = Datalab(data={"X": X, "y": y_noisy}, label_name="y")
         lab.find_issues(features=X, issue_types={"data_valuation": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
 
         data_valuation_issues = lab.get_issues("data_valuation")
 
@@ -1802,6 +1975,8 @@ class TestDatalabDataValuation:
         # Run dataset through Datalab
         lab = Datalab(data={"X": X_outlier, "y": y_true}, label_name="y")
         lab.find_issues(features=X_outlier, issue_types={"data_valuation": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
 
         data_valuation_issues = lab.get_issues("data_valuation")
 
@@ -1836,6 +2011,8 @@ class TestDatalabDataValuation:
         # Run dataset through Datalab
         lab = Datalab(data={"X": X, "y": y}, label_name="y")
         lab.find_issues(features=X, issue_types={"data_valuation": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
 
         data_valuation_issues = lab.get_issues("data_valuation")
 
@@ -1861,6 +2038,8 @@ class TestDatalabDataValuation:
         # Run dataset through Datalab
         lab = Datalab(data={"X": X, "y": y}, label_name="y")
         lab.find_issues(features=X, issue_types={"data_valuation": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
 
         data_valuation_issues = lab.get_issues("data_valuation")
         is_issue = data_valuation_issues["is_data_valuation_issue"]
@@ -1913,6 +2092,8 @@ class TestDatalabDataValuation:
         # Run dataset through Datalab
         lab = Datalab(data={"X": X_train, "y": y_noisy}, label_name="y")
         lab.find_issues(features=X_train, issue_types={"data_valuation": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
 
         data_valuation_issues = lab.get_issues("data_valuation")
         scores = data_valuation_issues["data_valuation_score"].to_numpy()
@@ -1994,6 +2175,8 @@ class TestDatalabDataValuation:
         # Run dataset through Datalab
         lab = Datalab(data={"X": X_train, "y": y_noisy}, label_name="y")
         lab.find_issues(features=X_train, issue_types={"data_valuation": {}})
+        check_issues_dtypes(lab)
+        check_issue_summary_dtypes(lab)
 
         data_valuation_issues = lab.get_issues("data_valuation")
         scores = data_valuation_issues["data_valuation_score"].to_numpy()

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -64,7 +64,7 @@ def check_issues_dtypes(lab):
 
     for col in ["given_label", "predicted_label", "distance_to_nearest_neighbor"]:
         if col in lab.issues.columns:
-            series = lab.issue_summary[col]
+            series = lab.issues[col]
             dtype = series.dtype
             assert np.issubdtype(dtype, np.number), (
                 f"Column '{col}' must be numeric"

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -62,14 +62,6 @@ def check_issues_dtypes(lab):
     for col in lab.issues.filter(like="_score").columns:
         assert lab.issues[col].dtype.kind in {'i', 'f'}, f"Column '{col}' must be numeric."
 
-    for col in ["given_label", "predicted_label", "distance_to_nearest_neighbor"]:
-        if col in lab.issues.columns:
-            series = lab.issues[col]
-            dtype = series.dtype
-            assert np.issubdtype(dtype, np.number), (
-                f"Column '{col}' must be numeric"
-            )
-
 def check_issue_summary_dtypes(lab):
     """
     Asserts that each column in lab.issue_summary has the expected dtype.


### PR DESCRIPTION
## Summary

> 🎯 **Purpose**: Add data type checks for `datalab.find_issues`.

✏️ Added unit tests for: 
* datalab.issues
  * `is_{issue_type}` columns only contain boolean values 
  * `{issue_type}_score` columns only contain numerical values
  * `["given_label", "predicted_label", "distance_to_nearest_neighbor"]` columns only contain numerical values
* datalab.issue_summary: solely contains numeric value
  * `["score", "num_issues"]` columns only contain numerical values 

✏️ Modified `TestDatalabFindNonIIDIssues::test_incremental_search`:

Issue: `TestDatalabFindNonIIDIssues` uses `sorted_embeddings` with 1000 samples but only 3 labels. This causes `test_incremental_search` to fail aforementioned tests because `is_class_imbalance_issue` and `class_imbalance_score` would have NaNs due to incomplete labeling. 

Fix: Test incremental search with only `issue_types={"null": {}}` followed by `issue_types={"non_iid": {}}` as opposed to all default issue types followed by `non_iid`. Change expected `len(summary)` accordingly. As such, we can ignore the class_imbalance columns. This aligns with other tests for incremental search in the rest of the file -- call `find_issues()` with one issue_type followed by the one of interest.

**Unaddressed Cases**

My code adds functions to perform type checks for `datalab.issues` and `datalab.issue_summary`. I call those functions for every 
 test of `datalab.find_issues()`. As such the coverage is limited to the existing scope of inputs.

## Links to Relevant Issues or Conversations

> Resolves [#937](https://github.com/cleanlab/cleanlab/issues/937)🔗 

Previous effort by @01PrathamS [[#946]](https://github.com/cleanlab/cleanlab/pull/946) used mocked data and did not test for different combinations of inputs to `find_issues()`.

## Reviewer Notes
> @sanjanag left a comment in [#937](https://github.com/cleanlab/cleanlab/issues/937) to have the same tests for [tests/datalab/test_cleanvision_integration.py](https://github.com/cleanlab/cleanlab/blob/master/tests/datalab/test_cleanvision_integration.py). In theory, I can reuse my functions in that script and create a single test that does the check for the given image dataset. However, I am not able run any tests because `./tests/datalab/data` is missing. How may I download this?

