### PR TITLE
Update CI to macos-13 instead of 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-12
+          - macos-13
           - windows-latest
         python:
           - "3.8"


### PR DESCRIPTION
macos-12 now deprecated in GH actions

