### PR TITLE
Nan values error Report

### DIFF
--- a/tests/datalab/test_data.py
+++ b/tests/datalab/test_data.py
@@ -1,7 +1,7 @@
 import tempfile
 from unittest.mock import patch
 import pytest
-from cleanlab.datalab.internal.data import Data, DataFormatError, DatasetLoadError
+from cleanlab.datalab.internal.data import Data, DataFormatError, DatasetLoadError, LabelNanError
 from datasets import Dataset, ClassLabel
 import numpy as np
 import hypothesis.strategies as st
@@ -232,6 +232,40 @@ class TestData:
                 Data._load_dataset_from_string("non_external_dataset")
 
             expected_error_substring = "Failed to load dataset from <class 'str'>.\n"
+
+    def test_check_label_nan_with_dict_and_dataset(self):
+        valid_data = {
+            "features": [1, 2, 3],
+            "labels": [0, 1, 0]
+        }
+        data_instance = Data(data=valid_data, task=Task.CLASSIFICATION, label_name="labels")
+        data_instance._check_label_nan(valid_data, "labels")
+        
+        invalid_data = {
+            "features": [1, 2, 3],
+            "labels": [0, np.nan, 0]
+        }
+        with pytest.raises(LabelNanError) as exc_info:
+            data_instance._check_label_nan(invalid_data, "labels")
+        assert "Found 1 NaN value(s) in the label column 'labels'. Please handle NaN values in before creating Datalab instance." in str(exc_info.value)
+
+        multiple_nan_data = {
+        "features": [1, 2, 3, 4],
+        "labels": [np.nan, 1, np.nan, 0]
+        }
+        with pytest.raises(LabelNanError) as exc_info:
+            data_instance._check_label_nan(multiple_nan_data, "labels")
+        assert "Found 2 NaN value(s) in the label column 'labels'. Please handle NaN values in before creating Datalab instance." in str(exc_info.value)
+
+        valid_dataset= Dataset.from_dict(valid_data)
+        
+        data_instance = Data(data=valid_dataset, task=Task.CLASSIFICATION, label_name="labels")
+        data_instance._check_label_nan(valid_dataset, "labels")
+
+        invalid_dataset = Dataset.from_dict(invalid_data)
+        with pytest.raises(LabelNanError) as exc_info:
+            data_instance._check_label_nan(invalid_dataset, "labels")
+        assert "Found 1 NaN value(s) in the label column 'labels'. Please handle NaN values in before creating Datalab instance." in str(exc_info.value)
 
     @given(dataset=dataset_strategy(task=Task.CLASSIFICATION))
     def test_label_map_is_lexicographically_ordered(self, dataset):


### PR DESCRIPTION
## Summary
🎯 **Purpose**: Add validation to check for NaN values in label columns before creating a Datalab instance, providing more helpful error messages to users.

📜 **Example Usage**: 
```python
from cleanlab import Datalab
import numpy as np
import pandas as pd

data_dict = {
    "features": [1, 2, 3, 4],
    "label": [0, np.nan, 1, 0]
}
try:
    lab = Datalab(data_dict, label_name="label")
except ValueError as e:
    print(e)
# Found 1 NaN value(s) in the label column 'labels'. Please handle NaN values in before creating Datalab instance.
```

## Impact
🌐 **Areas Affected**:
- `cleanlab/datalab/internal/data.py`: Added `_check_label_nan` method and `LabelNanError` class
- Test file updated to include tests for NaN validation

👥 **Who's Affected**: Users who attempt to create Datalab instances with datasets containing NaN values in label columns will now receive clearer error messages guiding them to handle NaN values before proceeding.

## Testing
🔍 **Testing Done**: 
- Added unit tests covering NaN validation.
- Tested with single and multiple NaN values
- Verified error message clarity and helpfulness

## Links to Relevant Issues or Conversations
- #987 