### PR TITLE
Fix numpy2 compatibility

### DIFF
--- a/cleanlab/datalab/internal/issue_manager/outlier.py
+++ b/cleanlab/datalab/internal/issue_manager/outlier.py
@@ -147,7 +147,9 @@ class OutlierIssueManager(IssueManager):
 
             # Ensure scaling factor is not too small to avoid numerical issues
             if self.scaling_factor is None:
-                self.scaling_factor = float(max(median_avg_distance, 100 * np.finfo(np.float_).eps))
+                self.scaling_factor = float(
+                    max(median_avg_distance, 100 * np.finfo(np.float64).eps)
+                )
             scores = transform_distances_to_scores(
                 avg_distances, t=self.t, scaling_factor=self.scaling_factor
             )

--- a/cleanlab/internal/multiannotator_utils.py
+++ b/cleanlab/internal/multiannotator_utils.py
@@ -229,7 +229,7 @@ def format_multiannotator_labels(labels: LabelLike) -> Tuple[pd.DataFrame, dict]
         unique_labels = unique_labels[~np.isnan(unique_labels)]
         unique_labels.sort()
     except TypeError:  # np.unique / np.sort cannot handle string values or pd.NA types
-        nan_mask = np.array([(l is np.NaN) or (l is pd.NA) or (l == "nan") for l in unique_labels])
+        nan_mask = np.array([(l is np.nan) or (l is pd.NA) or (l == "nan") for l in unique_labels])
         unique_labels = unique_labels[~nan_mask]
         unique_labels.sort()
 
@@ -275,7 +275,7 @@ def compute_soft_cross_entropy(
     """Compute soft cross entropy between the annotators' empirical label distribution and model pred_probs"""
     num_classes = get_num_classes(pred_probs=pred_probs)
 
-    empirical_label_distribution = np.full((len(labels_multiannotator), num_classes), np.NaN)
+    empirical_label_distribution = np.full((len(labels_multiannotator), num_classes), np.nan)
     for i, labels in enumerate(labels_multiannotator):
         labels_subset = labels[~np.isnan(labels)]
         empirical_label_distribution[i, :] = value_counts(
@@ -299,7 +299,7 @@ def find_best_temp_scaler(
     """Find the best temperature scaling factor that minimizes the soft cross entropy between the annotators' empirical label distribution
     and model pred_probs"""
 
-    soft_cross_entropy_coarse = np.full(len(coarse_search_range), np.NaN)
+    soft_cross_entropy_coarse = np.full(len(coarse_search_range), np.nan)
     log_pred_probs = np.log(
         pred_probs, where=pred_probs > 0, out=np.full(pred_probs.shape, -np.inf)
     )
@@ -313,7 +313,7 @@ def find_best_temp_scaler(
     fine_search_range = _set_fine_search_range(
         coarse_search_range, fine_search_size, min_entropy_ind
     )
-    soft_cross_entropy_fine = np.full(len(fine_search_range), np.NaN)
+    soft_cross_entropy_fine = np.full(len(fine_search_range), np.nan)
     for i, curr_temp in enumerate(fine_search_range):
         scaled_pred_probs = softmax(log_pred_probs, temperature=curr_temp, axis=1, shift=False)
         soft_cross_entropy_fine[i] = np.mean(

--- a/cleanlab/internal/outlier.py
+++ b/cleanlab/internal/outlier.py
@@ -113,13 +113,13 @@ def correct_precision_errors(
         An array of scores of shape ``(N,)`` for N examples with scores between 0 and 1.
     """
     if metric == "cosine":
-        tolerance = C * np.finfo(np.float_).epsneg
+        tolerance = C * np.finfo(np.float64).epsneg
     elif metric == "euclidean":
-        tolerance = np.sqrt(C * np.finfo(np.float_).eps)
+        tolerance = np.sqrt(C * np.finfo(np.float64).eps)
     elif metric == "minkowski":
         if p is None:
             raise ValueError("When metric is 'minkowski' you must specify the 'p' parameter")
-        tolerance = (C * np.finfo(np.float_).eps) ** (1 / p)
+        tolerance = (C * np.finfo(np.float64).eps) ** (1 / p)
     else:
         return scores
 

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -175,7 +175,7 @@ def get_label_quality_multiannotator(
         annotator_ids = labels_multiannotator.columns
         index_col = labels_multiannotator.index
         labels_multiannotator = (
-            labels_multiannotator.replace({pd.NA: np.NaN}).astype(float).to_numpy()
+            labels_multiannotator.replace({pd.NA: np.nan}).astype(float).to_numpy()
         )
     elif isinstance(labels_multiannotator, np.ndarray):
         annotator_ids = None
@@ -432,7 +432,7 @@ def get_label_quality_multiannotator_ensemble(
         annotator_ids = labels_multiannotator.columns
         index_col = labels_multiannotator.index
         labels_multiannotator = (
-            labels_multiannotator.replace({pd.NA: np.NaN}).astype(float).to_numpy()
+            labels_multiannotator.replace({pd.NA: np.nan}).astype(float).to_numpy()
         )
     elif isinstance(labels_multiannotator, np.ndarray):
         annotator_ids = None
@@ -643,7 +643,7 @@ def get_active_learning_scores(
 
         if isinstance(labels_multiannotator, pd.DataFrame):
             labels_multiannotator = (
-                labels_multiannotator.replace({pd.NA: np.NaN}).astype(float).to_numpy()
+                labels_multiannotator.replace({pd.NA: np.nan}).astype(float).to_numpy()
             )
         elif not isinstance(labels_multiannotator, np.ndarray):
             raise ValueError(
@@ -795,7 +795,7 @@ def get_active_learning_scores_ensemble(
 
         if isinstance(labels_multiannotator, pd.DataFrame):
             labels_multiannotator = (
-                labels_multiannotator.replace({pd.NA: np.NaN}).astype(float).to_numpy()
+                labels_multiannotator.replace({pd.NA: np.nan}).astype(float).to_numpy()
             )
         elif not isinstance(labels_multiannotator, np.ndarray):
             raise ValueError(
@@ -833,7 +833,7 @@ def get_active_learning_scores_ensemble(
 
         # examples are annotated by multiple annotators
         else:
-            optimal_temp = np.full(len(pred_probs), np.NaN)
+            optimal_temp = np.full(len(pred_probs), np.nan)
             for i, curr_pred_probs in enumerate(pred_probs):
                 curr_optimal_temp = find_best_temp_scaler(labels_multiannotator, curr_pred_probs)
                 pred_probs[i] = temp_scale_pred_probs(curr_pred_probs, curr_optimal_temp)
@@ -943,7 +943,7 @@ def get_majority_vote_label(
     if isinstance(labels_multiannotator, pd.DataFrame):
         annotator_ids = labels_multiannotator.columns
         labels_multiannotator = (
-            labels_multiannotator.replace({pd.NA: np.NaN}).astype(float).to_numpy()
+            labels_multiannotator.replace({pd.NA: np.nan}).astype(float).to_numpy()
         )
     elif isinstance(labels_multiannotator, np.ndarray):
         annotator_ids = None
@@ -1028,7 +1028,7 @@ def get_majority_vote_label(
             labels = nontied_labels_multiannotator[:, i]
             labels_mask = ~np.isnan(labels)
             if np.sum(labels_mask) == 0:
-                annotator_agreement_with_consensus[i] = np.NaN
+                annotator_agreement_with_consensus[i] = np.nan
             else:
                 annotator_agreement_with_consensus[i] = np.mean(
                     labels[labels_mask] == nontied_majority_vote_label[labels_mask]
@@ -1390,7 +1390,7 @@ def _get_single_annotator_agreement(
     """
     adjusted_num_annotations = num_annotations - 1
     if np.sum(adjusted_num_annotations) == 0:
-        return np.NaN
+        return np.nan
 
     multi_annotations_mask = num_annotations > 1
     annotator_agreement_per_example = np.zeros(len(labels_multiannotator))
@@ -1523,7 +1523,7 @@ def _get_post_pred_probs_and_weights(
 
     elif quality_method == "agreement":
         num_classes = get_num_classes(pred_probs=prior_pred_probs)
-        label_counts = np.full((len(labels_multiannotator), num_classes), np.NaN)
+        label_counts = np.full((len(labels_multiannotator), num_classes), np.nan)
         for i, labels in enumerate(labels_multiannotator):
             label_counts[i, :] = value_counts(labels[~np.isnan(labels)], num_classes=num_classes)
 
@@ -1812,7 +1812,7 @@ def _get_annotator_quality(
             # case where annotator does not annotate any examples with any other annotators
             # TODO: do we want to impute the mean or just return np.nan
             if np.sum(labels_mask) == 0:
-                annotator_agreement[i] = np.NaN
+                annotator_agreement[i] = np.nan
             else:
                 annotator_agreement[i] = np.mean(
                     labels[labels_mask] == consensus_label_subset[labels_mask],
@@ -1835,7 +1835,7 @@ def _get_annotator_quality(
             labels_mask = ~np.isnan(labels)
             # case where annotator does not annotate any examples with any other annotators
             if np.sum(labels_mask) == 0:
-                annotator_quality[i] = np.NaN
+                annotator_quality[i] = np.nan
             else:
                 annotator_quality[i] = np.mean(
                     labels[labels_mask] == consensus_label_subset[labels_mask],

--- a/cleanlab/outlier.py
+++ b/cleanlab/outlier.py
@@ -473,7 +473,7 @@ class OutOfDistribution:
 
         if self.params["scaling_factor"] is None:
             self.params["scaling_factor"] = float(
-                max(np.median(avg_knn_distances), 100 * np.finfo(np.float_).eps)
+                max(np.median(avg_knn_distances), 100 * np.finfo(np.float64).eps)
             )
         scaling_factor = self.params["scaling_factor"]
 

--- a/cleanlab/regression/learn.py
+++ b/cleanlab/regression/learn.py
@@ -777,7 +777,7 @@ class CleanLearning(BaseEstimator):
         else:
             # conduct coarse search
             coarse_search_range = sorted(coarse_search_range)  # sort to conduct fine search well
-            r2_coarse = np.full(len(coarse_search_range), np.NaN)
+            r2_coarse = np.full(len(coarse_search_range), np.nan)
             for i in range(len(coarse_search_range)):
                 curr_k = coarse_search_range[i]
                 num_examples_kept = math.floor(len(y) * (1 - curr_k))
@@ -824,7 +824,7 @@ class CleanLearning(BaseEstimator):
                         )[1:],
                     )
 
-                r2_fine = np.full(len(fine_search_range), np.NaN)
+                r2_fine = np.full(len(fine_search_range), np.nan)
                 for i in range(len(fine_search_range)):
                     curr_k = fine_search_range[i]
                     num_examples_kept = math.floor(len(y) * (1 - curr_k))

--- a/tests/datalab/issue_manager/test_null.py
+++ b/tests/datalab/issue_manager/test_null.py
@@ -21,8 +21,8 @@ class TestNullIssueManager:
     def embeddings_with_null(self):
         np.random.seed(SEED)
         embeddings_array = np.random.random((4, 3))
-        embeddings_array[[0, 3], 0] = np.NaN
-        embeddings_array[1] = np.NaN
+        embeddings_array[[0, 3], 0] = np.nan
+        embeddings_array[1] = np.nan
         return embeddings_array
 
     @pytest.fixture

--- a/tests/test_multiannotator.py
+++ b/tests/test_multiannotator.py
@@ -104,7 +104,7 @@ def make_data(
         "true_labels_train_unlabeled": true_labels_train_unlabeled,
         "labels": s[row_NA_check].reset_index(drop=True),
         "labels_unlabeled": pd.DataFrame(
-            np.full((len(true_labels_train_unlabeled), num_annotators), np.NaN)
+            np.full((len(true_labels_train_unlabeled), num_annotators), np.nan)
         ),
         "complete_labels": complete_labels,
         "pred_probs": latent[4][row_NA_check],
@@ -327,7 +327,7 @@ def test_label_quality_scores_multiannotator():
 
     # try same thing as above but with numpy array
     labels_nan = deepcopy(labels).values.astype(float)
-    labels_nan[:, 1] = np.NaN
+    labels_nan[:, 1] = np.nan
     try:
         multiannotator_dict = get_label_quality_multiannotator(
             labels_nan,
@@ -340,11 +340,11 @@ def test_label_quality_scores_multiannotator():
     # test error catching when labels_multiannotator has NaN rows
     labels_nan = pd.DataFrame(
         [
-            [0, np.NaN, np.NaN],
-            [np.NaN, 1, np.NaN],
-            [np.NaN, np.NaN, 2],
-            [np.NaN, np.NaN, np.NaN],
-            [np.NaN, np.NaN, 2],
+            [0, np.nan, np.nan],
+            [np.nan, 1, np.nan],
+            [np.nan, np.nan, 2],
+            [np.nan, np.nan, np.nan],
+            [np.nan, np.nan, 2],
         ]
     )
     pred_probs = np.random.random((5, 3))
@@ -486,11 +486,11 @@ def test_get_active_learning_scores():
     # test when each example is only labeled by one annotator
     labels = pd.DataFrame(
         [
-            [0, np.NaN, np.NaN],
-            [np.NaN, 1, np.NaN],
-            [np.NaN, np.NaN, 2],
-            [np.NaN, 1, np.NaN],
-            [np.NaN, np.NaN, 2],
+            [0, np.nan, np.nan],
+            [np.nan, 1, np.nan],
+            [np.nan, np.nan, 2],
+            [np.nan, 1, np.nan],
+            [np.nan, np.nan, 2],
         ]
     )
     pred_probs = np.random.random((5, 3))
@@ -545,11 +545,11 @@ def test_get_active_learning_scores_ensemble():
     # test when each example is only labeled by one annotator
     labels = pd.DataFrame(
         [
-            [0, np.NaN, np.NaN],
-            [np.NaN, 1, np.NaN],
-            [np.NaN, np.NaN, 2],
-            [np.NaN, 1, np.NaN],
-            [np.NaN, np.NaN, 2],
+            [0, np.nan, np.nan],
+            [np.nan, 1, np.nan],
+            [np.nan, np.nan, 2],
+            [np.nan, 1, np.nan],
+            [np.nan, np.nan, 2],
         ]
     )
     pred_probs = np.random.random((2, 5, 3))
@@ -636,12 +636,12 @@ def test_single_label_active_learning_ensemble():
 def test_missing_class():
     labels = np.array(
         [
-            [1, np.NaN, 2],
+            [1, np.nan, 2],
             [1, 1, 2],
             [2, 2, 1],
-            [np.NaN, 2, 2],
-            [np.NaN, 2, 1],
-            [np.NaN, 2, 2],
+            [np.nan, 2, 2],
+            [np.nan, 2, 1],
+            [np.nan, 2, 2],
         ]
     )
 
@@ -674,12 +674,12 @@ def test_missing_class():
 def test_rare_class():
     labels = np.array(
         [
-            [1, np.NaN, 2],
+            [1, np.nan, 2],
             [1, 1, 0],
             [2, 2, 0],
-            [np.NaN, 2, 2],
-            [np.NaN, 2, 1],
-            [np.NaN, 2, 2],
+            [np.nan, 2, 2],
+            [np.nan, 2, 1],
+            [np.nan, 2, 2],
         ]
     )
 
@@ -739,12 +739,12 @@ def test_get_consensus_label():
     # more tiebreak testing (without pred_probs + non-overlapping annotators)
     labels_tiebreaks = np.array(
         [
-            [1, np.NaN, np.NaN, 2, np.NaN],
-            [np.NaN, 1, 0, np.NaN, np.NaN],
-            [np.NaN, np.NaN, 0, np.NaN, np.NaN],
-            [np.NaN, 2, np.NaN, np.NaN, np.NaN],
-            [2, np.NaN, 0, 2, np.NaN],
-            [np.NaN, np.NaN, np.NaN, 2, 1],
+            [1, np.nan, np.nan, 2, np.nan],
+            [np.nan, 1, 0, np.nan, np.nan],
+            [np.nan, np.nan, 0, np.nan, np.nan],
+            [np.nan, 2, np.nan, np.nan, np.nan],
+            [2, np.nan, 0, 2, np.nan],
+            [np.nan, np.nan, np.nan, 2, 1],
         ]
     )
     consensus_label = get_majority_vote_label(labels_tiebreaks)
@@ -754,12 +754,12 @@ def test_get_consensus_label():
 def test_impute_nonoverlaping_annotators():
     labels = np.array(
         [
-            [1, np.NaN, np.NaN],
-            [np.NaN, 1, 0],
-            [np.NaN, 0, 0],
-            [np.NaN, 2, 2],
-            [np.NaN, 2, 0],
-            [np.NaN, 2, 0],
+            [1, np.nan, np.nan],
+            [np.nan, 1, 0],
+            [np.nan, 0, 0],
+            [np.nan, 2, 2],
+            [np.nan, 2, 0],
+            [np.nan, 2, 0],
         ]
     )
     pred_probs = np.array(
@@ -783,8 +783,8 @@ def test_format_multiannotator_labels():
     str_labels = np.array(
         [
             ["a", "b", "c"],
-            ["b", "b", np.NaN],
-            ["z", np.NaN, "c"],
+            ["b", "b", np.nan],
+            ["z", np.nan, "c"],
         ]
     )
     labels, label_map = format_multiannotator_labels(str_labels)
@@ -796,8 +796,8 @@ def test_format_multiannotator_labels():
     num_labels = pd.DataFrame(
         [
             [3, 2, 1],
-            [1, 2, np.NaN],
-            [3, np.NaN, 3],
+            [1, 2, np.nan],
+            [3, np.nan, 3],
         ]
     )
     labels, label_map = format_multiannotator_labels(num_labels)

--- a/tests/test_outlier.py
+++ b/tests/test_outlier.py
@@ -663,7 +663,7 @@ def test_wrong_info_get_ood_predictions_scores():
 
 @given(
     fill_value=st.floats(
-        min_value=5 * float(np.finfo(np.float_).eps),
+        min_value=5 * float(np.finfo(np.float64).eps),
         max_value=5,
         exclude_min=False,
         allow_subnormal=False,


### PR DESCRIPTION
This is a first step towards supporting `numpy` 2.
By simply replacing `np.NaN` with `np.nan` and `np.float_` with `np.float64`, I got most of the test suite working.

The only two failures that I observe are:
```
=========================== short test summary info ============================
FAILED tests/datalab/datalab/test_datalab.py::TestDatalabDataValuation::test_duplicate_points_have_similar_scores - assert np.float64(0.492) == 0.491
FAILED tests/test_multiannotator.py::test_label_quality_scores_multiannotator - AssertionError: assert 'Annotators [1] did not label any examples.' in 'lab...
= 2 failed, 1019 passed, 2 deselected, 2 xfailed, 7052 warnings in 272.25s (0:04:32) =
```

Fixes #1151