### PR TITLE
Fixed empty label handling in filter.py

### DIFF
--- a/cleanlab/object_detection/filter.py
+++ b/cleanlab/object_detection/filter.py
@@ -314,18 +314,22 @@ def _calculate_ap_per_class(
     return ap_per_class_list
 
 
-def _filter_by_class(
-    labels: List[Dict[str, Any]], predictions: List[np.ndarray], class_num: int
-) -> Tuple[List, List]:
-    """
-    Filters predictions and labels based on a specific class number.
-    """
-    pred_bboxes = [prediction[class_num] for prediction in predictions]
+def _filter_by_class(labels, predictions, class_num):
+    """Filters bounding boxes and labels by a given class number."""
+    pred_bboxes = []
     lab_bboxes = []
+
     for label in labels:
-        gt_inds = label["labels"] == class_num
-        lab_bboxes.append(label["bboxes"][gt_inds, :])
+        gt_inds = np.where(label["labels"] == class_num)[0]
+
+        # FIX: Handle case when `bboxes` is empty
+        if "bboxes" not in label or label["bboxes"].size == 0:
+            lab_bboxes.append(np.array([]))  # Append empty array
+        else:
+            lab_bboxes.append(label["bboxes"][gt_inds, :])  # Safe indexing
+
     return pred_bboxes, lab_bboxes
+
 
 
 def _calculate_true_positives_false_positives(


### PR DESCRIPTION
## Hey Team,
## Summary

### Purpose  
Fix the issue where images with no labels (background-only) cause an `IndexError` in `cleanlab.object_detection.filter.py`.  

### Fix  
Added a check to handle empty label cases properly.  

## Example Code Snippet to Demonstrate Fix

```python
from cleanlab.object_detection.filter import find_label_issues
import numpy as np

# Test case: Image with no labels (only background)
labels = [{"labels": np.array([]), "bboxes": np.array([])}]
predictions = [np.array([])]  # No predictions either

# Function should now handle empty labels without errors
result = find_label_issues(labels, predictions)
print(result)  # Expected Output: []
