### PR TITLE
Updated the numpy dependency version to Numpy 2.0 to avoid nan errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "cleanlab"
 # requirements files see:
 # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/
 dependencies = [
-  "numpy~=1.22",
+  "numpy~=2.0",
   "scikit-learn>=1.1",
   "tqdm>=4.53.0",
   "pandas>=1.4.0",


### PR DESCRIPTION
## Summary

🎯 **Purpose**: 


Updating the toml dependency for Numpy to resolve the np.nan error:

```
AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.
```