### PR TITLE
Reduce plot sizes in Datalab tutorials for better docs display

### DIFF
--- a/docs/source/tutorials/datalab/datalab_advanced.ipynb
+++ b/docs/source/tutorials/datalab/datalab_advanced.ipynb
@@ -426,7 +426,7 @@
     "\n",
     "def plot_data(X_train, y_train_idx, noisy_labels_idx, X_out, X_duplicate):\n",
     "    # Plot data with clean labels and noisy labels, use BINS_MAP for the legend\n",
-    "    fig, ax = plt.subplots(figsize=(6, 4))\n",
+    "    fig, ax = plt.subplots(figsize=(6, 4.5))\n",
     "        \n",
     "    low = ax.scatter(X_train[noisy_labels_idx == 0, 0], X_train[noisy_labels_idx == 0, 1], label=\"low\")\n",
     "    mid = ax.scatter(X_train[noisy_labels_idx == 1, 0], X_train[noisy_labels_idx == 1, 1], label=\"mid\")\n",

--- a/docs/source/tutorials/datalab/datalab_quickstart.ipynb
+++ b/docs/source/tutorials/datalab/datalab_quickstart.ipynb
@@ -429,7 +429,7 @@
     "\n",
     "def plot_data(X_train, y_train_idx, noisy_labels_idx, X_out, X_duplicate):\n",
     "    # Plot data with clean labels and noisy labels, use BINS_MAP for the legend\n",
-    "    fig, ax = plt.subplots(figsize=(6, 4))\n",
+    "    fig, ax = plt.subplots(figsize=(5, 3))\n",
     "        \n",
     "    low = ax.scatter(X_train[noisy_labels_idx == 0, 0], X_train[noisy_labels_idx == 0, 1], label=\"low\")\n",
     "    mid = ax.scatter(X_train[noisy_labels_idx == 1, 0], X_train[noisy_labels_idx == 1, 1], label=\"mid\")\n",

--- a/docs/source/tutorials/datalab/image.ipynb
+++ b/docs/source/tutorials/datalab/image.ipynb
@@ -1191,7 +1191,7 @@
     "    ncols = 5\n",
     "    nrows = int(math.ceil(num_examples / ncols))\n",
     "\n",
-    "    _, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=(1.5 * ncols, 1.5 * nrows))\n",
+    "    _, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=(1.0 * ncols, 1.0 * nrows))\n",
     "    axes_list = axes.flatten()\n",
     "    issue_indices = issues_df.index.values\n",
     "\n",

--- a/docs/source/tutorials/datalab/workflows.ipynb
+++ b/docs/source/tutorials/datalab/workflows.ipynb
@@ -1288,7 +1288,7 @@
     "import seaborn as sns\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "plt.figure(figsize=(8, 6))\n",
+    "plt.figure(figsize=(6, 4))\n",
     "\n",
     "# Plot the distribution of labels in the dataset\n",
     "ax = sns.countplot(x=\"given_label\", data=class_imbalance_issues, order=[\"a\", \"b\", \"c\"], hue=\"is_class_imbalance_issue\")\n",

--- a/docs/source/tutorials/indepth_overview.ipynb
+++ b/docs/source/tutorials/indepth_overview.ipynb
@@ -301,7 +301,7 @@
     "\n",
     "# Display dataset visually using matplotlib\n",
     "def plot_data(data, circles, title, alpha=1.0):\n",
-    "    plt.figure(figsize=(14, 5))\n",
+    "    plt.figure(figsize=(10, 4))\n",
     "    plt.scatter(data[:, 0], data[:, 1], c=labels, s=60)\n",
     "    for i in circles:\n",
     "        plt.plot(\n",

--- a/docs/source/tutorials/multilabel_classification.ipynb
+++ b/docs/source/tutorials/multilabel_classification.ipynb
@@ -349,7 +349,7 @@
     "    return [\"#\"+dcolors[str(i)] for i in labels]\n",
     "\n",
     "def plot_data(data, circles, title, alpha=1.0,colors = []):\n",
-    "    plt.figure(figsize=(14, 5))\n",
+    "    plt.figure(figsize=(10, 4))\n",
     "    done = set()\n",
     "    for i in range(0,len(data)):\n",
     "        lab = str(labels[i])\n",

--- a/docs/source/tutorials/outliers.ipynb
+++ b/docs/source/tutorials/outliers.ipynb
@@ -310,7 +310,7 @@
     "    return np.transpose(npimg, (1, 2, 0))\n",
     "\n",
     "def plot_images(dataset, show_labels=False):\n",
-    "    plt.rcParams[\"figure.figsize\"] = (9,7)\n",
+    "    plt.rcParams[\"figure.figsize\"] = (6,4)\n",
     "    for i in range(15):\n",
     "        X,y = dataset[i]\n",
     "        ax = plt.subplot(3,5,i+1)\n",


### PR DESCRIPTION
## Summary
Reduced plot sizes in Datalab tutorials to improve display on docs.cleanlab.ai

## Changes
- Modified `figsize` parameters in 7 tutorial notebooks:
  - `datalab/image.ipynb`: Reduced subplot sizes
  - `outliers.ipynb`: Reduced from (9,7) to (6,4)
  - `indepth_overview.ipynb`: Reduced from (14,5) to (10,4)
  - `datalab_quickstart.ipynb`: Reduced from (6,4) to (5,3)
  - `workflows.ipynb`: Reduced from (8,6) to (6,4)
  - `multilabel_classification.ipynb`: Reduced from (14,5) to (10,4)
  - `datalab_advanced.ipynb`: Reduced from (6,4) to (6,4.5)

## Testing
- Plots maintain readability while being more compact
- Better suited for documentation website display

Fixes #718