### PR TITLE
handle empty pred_probs gracefully in compute_confident_joint().

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -552,12 +552,6 @@ def compute_confident_joint(
                 confident_joint[s_label][np.argmax(confident_bins)] += 1
             elif num_confident_bins > 1:
                 confident_joint[s_label][np.argmax(row)] += 1
-
-    Note
-    ----
-    In degenerate settings where no example is deemed "confident" for any class, the confident joint
-    will be constructed as an identity matrix (when `calibrate=False`) or adjusted accordingly
-    (when `calibrate=True`).
     """
 
     if multi_label:
@@ -605,18 +599,23 @@ def compute_confident_joint(
     labels_confident = labels[at_least_one_confident]
 
     if true_labels_confident.size == 0:
-        # Edge-case: if there are no confident examples, calling confusion_matrix() on empty
-        # inputs raises ValueError in scikit-learn>=1.8. For maintainability (and backwards-compatibility
-        # with scikit-learn<1.8 behavior), we construct an all-zero matrix here and let the existing
-        # diagonal-minimum rule below handle it (yielding an identity matrix when calibrate=False, and a
-        # diagonal label-counts matrix when calibrate=True).
-        confident_joint = np.zeros((pred_probs.shape[1], pred_probs.shape[1]), dtype=int)
-    else:
-        confident_joint = confusion_matrix(
-            y_true=true_labels_confident,
-            y_pred=labels_confident,
-            labels=range(pred_probs.shape[1]),
-        ).T
+        # Edge-case: no examples are "confident" for any class.
+        #
+        # This can happen if predicted probabilities are degenerate/uninformative (e.g., uniform or all zeros),
+        # or if thresholds are too strict. In scikit-learn>=1.8, calling confusion_matrix() with empty inputs
+        # raises ValueError, so we raise a clearer error message here.
+        raise ValueError(
+            "No confident examples were found for any class while computing the confident joint. "
+            "This can happen if `pred_probs` are degenerate/uninformative or if `thresholds` are too strict. "
+            "Provide meaningful predicted probabilities (typically each row sums to 1) and/or use less-strict "
+            "`thresholds`."
+        )
+
+    confident_joint = confusion_matrix(
+        y_true=true_labels_confident,
+        y_pred=labels_confident,
+        labels=range(pred_probs.shape[1]),
+    ).T
     # Guarantee at least one correctly labeled example is represented in every class
     np.fill_diagonal(confident_joint, confident_joint.diagonal().clip(min=1))
     if calibrate:

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -610,7 +610,7 @@ def test_no_fit_sample_weight(format):
 
     n = np.shape(data["true_labels_test"])[0]
     m = len(np.unique(data["true_labels_test"]))
-    pred_probs = np.zeros(shape=(n, m))
+    pred_probs = np.full(shape=(n, m), fill_value=1.0 / m)
     cl = CleanLearning(clf=Struct())
     cl.fit(
         data["X_train"],
@@ -619,6 +619,30 @@ def test_no_fit_sample_weight(format):
         noise_matrix=data["noise_matrix"],
     )
     # If we make it here, without any error:
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
+def test_no_fit_sample_weight_degenerate_pred_probs_raise_error(format):
+    data = DATA_FORMATS[format]
+
+    class Struct:
+        def fit(self, X, y):
+            pass
+
+        def predict_proba(self):
+            pass
+
+        def predict(self, X):
+            return data["true_labels_test"]
+
+    n = np.shape(data["true_labels_test"])[0]
+    m = len(np.unique(data["true_labels_test"]))
+
+    pred_probs = np.zeros(shape=(n, m))
+    cl = CleanLearning(clf=Struct())
+    with pytest.raises(ValueError, match=r"No confident examples were found for any class"):
+        cl.fit(data["X_train"], data["true_labels_train"], pred_probs=pred_probs)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")


### PR DESCRIPTION
Added regression test for scikit-learn>=1.8 compatibility, ensuring correct behavior for degenerate cases with all-zero pred_probs.

Improves current tests, but this edge-case is unlikely to be encountered in practice.

Addresses failing test cases in `test_no_fit_sample_weight()` that use `pred_probs = np.zeroes(...)`.

<details><summary>Example CI failure output</summary>
<p>

```
============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-7.4.4, pluggy-1.6.0 -- /opt/hostedtoolcache/Python/3.11.14/x64/bin/python
cachedir: .pytest_cache
hypothesis profile 'ci' -> database=None, deadline=None, print_blob=True, derandomize=True, suppress_health_check=(HealthCheck.too_slow,)
rootdir: /home/runner/work/cleanlab/cleanlab
configfile: pyproject.toml
plugins: hypothesis-6.148.7, anyio-4.12.0, cov-7.0.0
collecting ... collected 1100 items

tests/test_classification.py::test_cl[data0] PASSED                      [  0%]
tests/test_classification.py::test_cl[data1] PASSED                      [  0%]
tests/test_classification.py::test_cl[data2] PASSED                      [  0%]
tests/test_classification.py::test_cl_default_clf PASSED                 [  0%]
tests/test_classification.py::test_rare_label[data0] PASSED              [  0%]
tests/test_classification.py::test_rare_label[data1] PASSED              [  0%]
tests/test_classification.py::test_rare_label[data2] PASSED              [  0%]
tests/test_classification.py::test_invalid_inputs PASSED                 [  0%]
tests/test_classification.py::test_aux_inputs PASSED                     [  0%]
tests/test_classification.py::test_validation_data PASSED                [  0%]
tests/test_classification.py::test_raise_error_no_clf_fit PASSED         [  1%]
tests/test_classification.py::test_raise_error_no_clf_predict_proba PASSED [  1%]
tests/test_classification.py::test_raise_error_no_clf_predict PASSED     [  1%]
tests/test_classification.py::test_seed PASSED                           [  1%]
tests/test_classification.py::test_default_clf PASSED                    [  1%]
tests/test_classification.py::test_clf_fit_nm PASSED                     [  1%]
tests/test_classification.py::test_clf_fit_inm PASSED                    [  1%]
tests/test_classification.py::test_fit_with_nm[numpy] PASSED             [  1%]
tests/test_classification.py::test_fit_with_nm[sparse] PASSED            [  1%]
tests/test_classification.py::test_fit_with_nm[dataframe] PASSED         [  1%]
tests/test_classification.py::test_fit_with_inm[numpy] PASSED            [  1%]
tests/test_classification.py::test_fit_with_inm[sparse] PASSED           [  2%]
tests/test_classification.py::test_fit_with_inm[dataframe] PASSED        [  2%]
tests/test_classification.py::test_clf_fit_nm_inm[numpy] PASSED          [  2%]
tests/test_classification.py::test_clf_fit_nm_inm[sparse] PASSED         [  2%]
tests/test_classification.py::test_clf_fit_nm_inm[dataframe] PASSED      [  2%]
tests/test_classification.py::test_clf_fit_y_alias[numpy] PASSED         [  2%]
tests/test_classification.py::test_clf_fit_y_alias[sparse] PASSED        [  2%]
tests/test_classification.py::test_clf_fit_y_alias[dataframe] PASSED     [  2%]
tests/test_classification.py::test_pred_and_pred_proba[numpy] PASSED     [  2%]
tests/test_classification.py::test_pred_and_pred_proba[sparse] PASSED    [  2%]
tests/test_classification.py::test_pred_and_pred_proba[dataframe] PASSED [  2%]
tests/test_classification.py::test_score[numpy] PASSED                   [  3%]
tests/test_classification.py::test_score[sparse] PASSED                  [  3%]
tests/test_classification.py::test_score[dataframe] PASSED               [  3%]
tests/test_classification.py::test_no_score[numpy] PASSED                [  3%]
tests/test_classification.py::test_no_score[sparse] PASSED               [  3%]
tests/test_classification.py::test_no_score[dataframe] PASSED            [  3%]
tests/test_classification.py::test_no_fit_sample_weight[numpy] FAILED    [  3%]
tests/test_classification.py::test_no_fit_sample_weight[sparse] FAILED   [  3%]
tests/test_classification.py::test_no_fit_sample_weight[dataframe] FAILED [  3%]

=================================== FAILURES ===================================
_______________________ test_no_fit_sample_weight[numpy] _______________________

format = 'numpy'

    @pytest.mark.filterwarnings("ignore::UserWarning")
    @pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
    def test_no_fit_sample_weight(format):
        data = DATA_FORMATS[format]
    
        class Struct:
            def fit(self, X, y):
                pass
    
            def predict_proba(self):
                pass
    
            def predict(self, X):
                return data["true_labels_test"]
    
        n = np.shape(data["true_labels_test"])[0]
        m = len(np.unique(data["true_labels_test"]))
        pred_probs = np.zeros(shape=(n, m))
        cl = CleanLearning(clf=Struct())
>       cl.fit(
            data["X_train"],
            data["true_labels_train"],
            pred_probs=pred_probs,
            noise_matrix=data["noise_matrix"],
        )

tests/test_classification.py:615: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
cleanlab/classification.py:474: in fit
    label_issues = self.find_label_issues(
cleanlab/classification.py:892: in find_label_issues
    self.confident_joint = compute_confident_joint(
cleanlab/count.py:600: in compute_confident_joint
    confident_joint = confusion_matrix(
/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/sklearn/utils/_param_validation.py:218: in wrapper
    return func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/sklearn/metrics/_classification.py:558: in confusion_matrix
    y_type, y_true, y_pred, _ = _check_targets(y_true, y_pred)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

y_true = array([], dtype=int64), y_pred = array([], dtype=int64)
sample_weight = None

    def _check_targets(y_true, y_pred, sample_weight=None):
        """Check that y_true and y_pred belong to the same classification task.
    
        This converts multiclass or binary types to a common shape, and raises a
        ValueError for a mix of multilabel and multiclass targets, a mix of
        multilabel formats, for the presence of continuous-valued or multioutput
        targets, or for targets of different lengths.
    
        Column vectors are squeezed to 1d, while multilabel formats are returned
        as CSR sparse label indicators.
    
        Parameters
        ----------
        y_true : array-like
    
        y_pred : array-like
    
        sample_weight : array-like, default=None
    
        Returns
        -------
        type_true : one of {'multilabel-indicator', 'multiclass', 'binary'}
            The type of the true target data, as output by
            ``utils.multiclass.type_of_target``.
    
        y_true : array or indicator matrix
    
        y_pred : array or indicator matrix
    
        sample_weight : array or None
        """
        xp, _ = get_namespace(y_true, y_pred, sample_weight)
        check_consistent_length(y_true, y_pred, sample_weight)
        type_true = type_of_target(y_true, input_name="y_true")
        type_pred = type_of_target(y_pred, input_name="y_pred")
        for array in [y_true, y_pred]:
            if _num_samples(array) < 1:
>               raise ValueError(
                    "Found empty input array (e.g., `y_true` or `y_pred`) while a minimum "
                    "of 1 sample is required."
                )
E               ValueError: Found empty input array (e.g., `y_true` or `y_pred`) while a minimum of 1 sample is required.

/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/sklearn/metrics/_classification.py:113: ValueError
______________________ test_no_fit_sample_weight[sparse] _______________________

format = 'sparse'

    @pytest.mark.filterwarnings("ignore::UserWarning")
    @pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
    def test_no_fit_sample_weight(format):
        data = DATA_FORMATS[format]
    
        class Struct:
            def fit(self, X, y):
                pass
    
            def predict_proba(self):
                pass
    
            def predict(self, X):
                return data["true_labels_test"]
    
        n = np.shape(data["true_labels_test"])[0]
        m = len(np.unique(data["true_labels_test"]))
        pred_probs = np.zeros(shape=(n, m))
        cl = CleanLearning(clf=Struct())
>       cl.fit(
            data["X_train"],
            data["true_labels_train"],
            pred_probs=pred_probs,
            noise_matrix=data["noise_matrix"],
        )

tests/test_classification.py:615: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
cleanlab/classification.py:474: in fit
    label_issues = self.find_label_issues(
cleanlab/classification.py:892: in find_label_issues
    self.confident_joint = compute_confident_joint(
cleanlab/count.py:600: in compute_confident_joint
    confident_joint = confusion_matrix(
/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/sklearn/utils/_param_validation.py:218: in wrapper
    return func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/sklearn/metrics/_classification.py:558: in confusion_matrix
    y_type, y_true, y_pred, _ = _check_targets(y_true, y_pred)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

y_true = array([], dtype=int64), y_pred = array([], dtype=int64)
sample_weight = None

    def _check_targets(y_true, y_pred, sample_weight=None):
        """Check that y_true and y_pred belong to the same classification task.
    
        This converts multiclass or binary types to a common shape, and raises a
        ValueError for a mix of multilabel and multiclass targets, a mix of
        multilabel formats, for the presence of continuous-valued or multioutput
        targets, or for targets of different lengths.
    
        Column vectors are squeezed to 1d, while multilabel formats are returned
        as CSR sparse label indicators.
    
        Parameters
        ----------
        y_true : array-like
    
        y_pred : array-like
    
        sample_weight : array-like, default=None
    
        Returns
        -------
        type_true : one of {'multilabel-indicator', 'multiclass', 'binary'}
            The type of the true target data, as output by
            ``utils.multiclass.type_of_target``.
    
        y_true : array or indicator matrix
    
        y_pred : array or indicator matrix
    
        sample_weight : array or None
        """
        xp, _ = get_namespace(y_true, y_pred, sample_weight)
        check_consistent_length(y_true, y_pred, sample_weight)
        type_true = type_of_target(y_true, input_name="y_true")
        type_pred = type_of_target(y_pred, input_name="y_pred")
        for array in [y_true, y_pred]:
            if _num_samples(array) < 1:
>               raise ValueError(
                    "Found empty input array (e.g., `y_true` or `y_pred`) while a minimum "
                    "of 1 sample is required."
                )
E               ValueError: Found empty input array (e.g., `y_true` or `y_pred`) while a minimum of 1 sample is required.

/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/sklearn/metrics/_classification.py:113: ValueError
_____________________ test_no_fit_sample_weight[dataframe] _____________________

format = 'dataframe'

    @pytest.mark.filterwarnings("ignore::UserWarning")
    @pytest.mark.parametrize("format", list(DATA_FORMATS.keys()))
    def test_no_fit_sample_weight(format):
        data = DATA_FORMATS[format]
    
        class Struct:
            def fit(self, X, y):
                pass
    
            def predict_proba(self):
                pass
    
            def predict(self, X):
                return data["true_labels_test"]
    
        n = np.shape(data["true_labels_test"])[0]
        m = len(np.unique(data["true_labels_test"]))
        pred_probs = np.zeros(shape=(n, m))
        cl = CleanLearning(clf=Struct())
>       cl.fit(
            data["X_train"],
            data["true_labels_train"],
            pred_probs=pred_probs,
            noise_matrix=data["noise_matrix"],
        )

tests/test_classification.py:615: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
cleanlab/classification.py:474: in fit
    label_issues = self.find_label_issues(
cleanlab/classification.py:892: in find_label_issues
    self.confident_joint = compute_confident_joint(
cleanlab/count.py:600: in compute_confident_joint
    confident_joint = confusion_matrix(
/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/sklearn/utils/_param_validation.py:218: in wrapper
    return func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/sklearn/metrics/_classification.py:558: in confusion_matrix
    y_type, y_true, y_pred, _ = _check_targets(y_true, y_pred)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

y_true = array([], dtype=int64), y_pred = array([], dtype=int64)
sample_weight = None

    def _check_targets(y_true, y_pred, sample_weight=None):
        """Check that y_true and y_pred belong to the same classification task.
    
        This converts multiclass or binary types to a common shape, and raises a
        ValueError for a mix of multilabel and multiclass targets, a mix of
        multilabel formats, for the presence of continuous-valued or multioutput
        targets, or for targets of different lengths.
    
        Column vectors are squeezed to 1d, while multilabel formats are returned
        as CSR sparse label indicators.
    
        Parameters
        ----------
        y_true : array-like
    
        y_pred : array-like
    
        sample_weight : array-like, default=None
    
        Returns
        -------
        type_true : one of {'multilabel-indicator', 'multiclass', 'binary'}
            The type of the true target data, as output by
            ``utils.multiclass.type_of_target``.
    
        y_true : array or indicator matrix
    
        y_pred : array or indicator matrix
    
        sample_weight : array or None
        """
        xp, _ = get_namespace(y_true, y_pred, sample_weight)
        check_consistent_length(y_true, y_pred, sample_weight)
        type_true = type_of_target(y_true, input_name="y_true")
        type_pred = type_of_target(y_pred, input_name="y_pred")
        for array in [y_true, y_pred]:
            if _num_samples(array) < 1:
>               raise ValueError(
                    "Found empty input array (e.g., `y_true` or `y_pred`) while a minimum "
                    "of 1 sample is required."
                )
E               ValueError: Found empty input array (e.g., `y_true` or `y_pred`) while a minimum of 1 sample is required.

/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/sklearn/metrics/_classification.py:113: ValueError
=========================== short test summary info ============================
FAILED tests/test_classification.py::test_no_fit_sample_weight[numpy] - ValueError: Found empty input array (e.g., `y_true` or `y_pred`) while a minimum of 1 sample is required.
FAILED tests/test_classification.py::test_no_fit_sample_weight[sparse] - ValueError: Found empty input array (e.g., `y_true` or `y_pred`) while a minimum of 1 sample is required.
FAILED tests/test_classification.py::test_no_fit_sample_weight[dataframe] - ValueError: Found empty input array (e.g., `y_true` or `y_pred`) while a minimum of 1 sample is required.
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 3 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
======================== 3 failed, 38 passed in 27.08s =========================
```

</p>
</details> 


## Testing

Tested on scikit-learn 1.7 and 1.8 on Python 3.11.
Verified that the new regression test reproduces the failures above without changing count.py.

