### PR TITLE
Add dynamic versioning to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ Documentation = "https://docs.cleanlab.ai"
 [tool.setuptools]
 include-package-data = true
 
+[tool.setuptools.dynamic]
+version = {attr = "cleanlab.version.__version__"}
+
 [tool.setuptools.packages.find]
 include = ["cleanlab*", "cleanlab.*"]
 exclude = ["tests*", "tests.*", "*.tests", "*.tests.*", "*.tests*"]


### PR DESCRIPTION
Automatic release process fails because recent setuptools behavioral change regarding explicit dynamic versioning. This updates the way dynamic versioning is handled.