### PR TITLE
Fix PyPI publish workflow metadata error by switching to setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -73,8 +73,7 @@ Documentation = "https://docs.cleanlab.ai"
 [tool.setuptools]
 include-package-data = true
 
-[tool.setuptools.dynamic]
-version = {attr = "cleanlab.version.__version__"}
+[tool.setuptools_scm]
 
 [tool.setuptools.packages.find]
 include = ["cleanlab*", "cleanlab.*"]


### PR DESCRIPTION
Fixes the GitHub Actions release workflow that was failing with "Metadata is missing required fields: Name, Version" when publishing to PyPI.

**Issue:** The dynamic version configuration in pyproject.toml was trying to import the cleanlab package during build to read `__version__`, but this failed because sklearn and other runtime dependencies weren't available in the isolated build environment.

**Solution:** Switched to setuptools-scm for automatic git-based versioning, which reads the version directly from git tags without requiring package imports. This eliminates the build-time dependency issues while maintaining backward compatibility with setup.py for legacy installations.

**Changes:**
- Updated pyproject.toml to use setuptools-scm instead of attr-based dynamic versioning
- Added setuptools-scm to build-system requirements
- Keeps existing setup.py version handling for backward compatibility