### PR TITLE
Fix stale version at build

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -87,6 +87,10 @@ jobs:
         run: |
           python setup.py check --metadata --strict
 
+      - name: Clean build artifacts
+        run: |
+          rm -rf build/ dist/ *.egg-info cleanlab.egg-info/
+
       - name: Build package
         run: |
           python setup.py sdist bdist_wheel


### PR DESCRIPTION
The cleanlab.egg-info/PKG-INFO file still had version from a previous build. When the TestPyPI package was built, it used this stale metadata. Add step to remove stale data