### PR TITLE
docs: add Issue Types guide link to find_issues docstring

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -247,6 +247,9 @@ class Datalab:
             More specifically, the values are constructor keyword arguments passed to the corresponding ``IssueManager``,
             which is responsible for detecting the particular issue type.
 
+            See the `Issue Types guide <https://docs.cleanlab.ai/stable/cleanlab/datalab/guide/issue_type_description.html>`_
+            for a comprehensive list of all available issue types and descriptions of when they are detected.
+
             .. seealso::
                 :py:class:`IssueManager <cleanlab.datalab.internal.issue_manager.issue_manager.IssueManager>`
 


### PR DESCRIPTION
﻿## Summary

**Top of stack** — docs only.

Adds a link to the [Issue Types guide](https://docs.cleanlab.ai/stable/cleanlab/datalab/guide/issue_type_description.html) in `Datalab.find_issues` docstring.

**Diff:** +3 lines in `cleanlab/datalab/datalab.py` only.

Fixes #914

## Stack / Depends on

```
master
  └── #1326 fix(ci): NumPy 2 / black / mypy master bitrot   ← merge first
        └── #1298 this PR (docs only)
```

**Depends on:** https://github.com/cleanlab/cleanlab/pull/1326

CI on this PR may fail until #1326 is merged (master currently has NumPy 2 / black / mypy bitrot). This PR intentionally does **not** include CI repairs so review stays docs-only.

> Stacked PR base-branch chaining is not enabled on this repository, so both PRs target `master` with an explicit depends-on link.

## Test plan
- [ ] #1326 merged
- [ ] Rebase this branch onto master if needed
- [ ] CI green
- [ ] Merge
