### PR TITLE
docs: Add link to Issue Types Guide in find_issues docstring

### DIFF
--- a/cleanlab/datalab/datalab.py
+++ b/cleanlab/datalab/datalab.py
@@ -248,6 +248,9 @@ class Datalab:
             which is responsible for detecting the particular issue type.
 
             .. seealso::
+                See the `Issue Types Guide <https://docs.cleanlab.ai/stable/cleanlab/datalab/guide/issue_type_description.html>`_
+                for a list of possible issue types and their descriptions.
+
                 :py:class:`IssueManager <cleanlab.datalab.internal.issue_manager.issue_manager.IssueManager>`
 
         Examples


### PR DESCRIPTION
## Summary

Adds a seealso link to the Issue Types Guide in the `issue_types` parameter docstring of `Datalab.find_issues()`.

This helps users discover the possible values for the `issue_types` argument.

## Fixes

Closes #914

## Changes

- Added a link to the [Issue Types Guide](https://docs.cleanlab.ai/stable/cleanlab/datalab/guide/issue_type_description.html) in the docstring