### PR TITLE
Sanitize label column on Datalab init

### DIFF
--- a/cleanlab/datalab/internal/data.py
+++ b/cleanlab/datalab/internal/data.py
@@ -321,11 +321,11 @@ class Label(ABC):
             return
 
         raw_labels = data[label_name]
-        null_mask = pd.isna(pd.Series(raw_labels))
+        null_mask = pd.isna(pd.Series(raw_labels)).to_numpy()
         if not null_mask.any():
             return
 
-        null_indices = np.flatnonzero(null_mask.values)
+        null_indices = np.flatnonzero(null_mask)
         null_count = int(null_indices.size)
         preview_limit = 10
         preview = null_indices[:preview_limit].tolist()

--- a/cleanlab/datalab/internal/data.py
+++ b/cleanlab/datalab/internal/data.py
@@ -263,6 +263,7 @@ class Label(ABC):
         self.labels = labels_to_array([])
         self.label_map: Mapping[Union[str, int], Any] = {}
         if label_name is not None:
+            self._check_for_null_labels(data, label_name)
             self.labels, self.label_map = self._extract_labels(data, label_name, map_to_int)
             self._validate_labels()
 
@@ -299,6 +300,44 @@ class Label(ABC):
         empty_labels = self.labels is None or len(self.labels) == 0
         empty_label_map = self.label_map is None or len(self.label_map) == 0
         return not (empty_labels or empty_label_map)
+
+    @staticmethod
+    def _check_for_null_labels(data: Dataset, label_name: str) -> None:
+        """Raise a descriptive ``ValueError`` if the label column contains null values.
+
+        Detects NaN, None, ``pd.NA``, and ``NaT`` in the raw label column before
+        :meth:`_extract_labels` runs. Without this check, null values silently become
+        their own class in the label map (via ``np.unique``), corrupting downstream
+        data quality checks in Datalab.
+
+        Notes
+        -----
+        For multi-label tasks, this detects whole-row nulls (e.g., a row where the
+        label is ``None`` instead of a list of labels). Nested null values inside
+        multi-label sublists are not checked.
+        """
+        if label_name not in data.column_names:
+            # The existing `_validate_labels` method raises a clearer error for this case.
+            return
+
+        raw_labels = data[label_name]
+        null_mask = pd.isna(pd.Series(raw_labels))
+        if not null_mask.any():
+            return
+
+        null_indices = np.flatnonzero(null_mask.values)
+        null_count = int(null_indices.size)
+        preview_limit = 10
+        preview = null_indices[:preview_limit].tolist()
+        indices_str = ", ".join(str(i) for i in preview)
+        if null_count > preview_limit:
+            indices_str += f", ... ({null_count - preview_limit} more)"
+
+        raise ValueError(
+            f"Label column '{label_name}' contains {null_count} null value(s) "
+            f"(NaN/None) at index/indices: {indices_str}. "
+            f"Please remove or impute these rows before initializing Datalab."
+        )
 
     def _validate_labels(self) -> None:
         if self.label_name not in self._data.column_names:

--- a/tests/datalab/test_data.py
+++ b/tests/datalab/test_data.py
@@ -1,5 +1,6 @@
 import tempfile
 from unittest.mock import patch
+import pandas as pd
 import pytest
 from cleanlab.datalab.internal.data import Data, DataFormatError, DatasetLoadError
 from datasets import Dataset, ClassLabel
@@ -244,3 +245,73 @@ class TestData:
         data = Data(data=dataset, task=Task.MULTILABEL, label_name="label")
         label_map = data.labels.label_map
         assert list(label_map.values()) == sorted(label_map.values())
+
+
+class TestNullLabelValidation:
+    """Tests for early null-value detection in the label column.
+
+    Regression guard for https://github.com/cleanlab/cleanlab/issues/987.
+    Without this validation, NaN/None values flow into ``np.unique`` during
+    label map construction and silently become their own class, corrupting
+    downstream data quality checks.
+    """
+
+    def test_nan_in_dict_label_raises(self):
+        data = {"feature": [1, 2, 3], "label": [0, np.nan, 1]}
+        with pytest.raises(ValueError, match="contains 1 null value"):
+            Data(data=data, task=Task.CLASSIFICATION, label_name="label")
+
+    def test_none_in_dict_label_raises(self):
+        data = {"feature": [1, 2, 3], "label": [0, None, 1]}
+        with pytest.raises(ValueError, match="contains 1 null value"):
+            Data(data=data, task=Task.CLASSIFICATION, label_name="label")
+
+    def test_nan_in_dataframe_label_raises(self):
+        df = pd.DataFrame({"feature": [1, 2, 3, 4], "label": [0, np.nan, 1, 0]})
+        with pytest.raises(ValueError, match="Label column 'label' contains 1 null value"):
+            Data(data=df, task=Task.CLASSIFICATION, label_name="label")
+
+    def test_nan_in_dataset_label_raises(self):
+        dataset = Dataset.from_dict({"feature": [1, 2, 3], "label": [0.0, np.nan, 1.0]})
+        with pytest.raises(ValueError, match="contains 1 null value"):
+            Data(data=dataset, task=Task.CLASSIFICATION, label_name="label")
+
+    def test_error_message_lists_null_indices(self):
+        data = {"feature": [10, 20, 30, 40, 50], "label": [np.nan, 1, np.nan, 0, np.nan]}
+        with pytest.raises(ValueError) as exc_info:
+            Data(data=data, task=Task.CLASSIFICATION, label_name="label")
+        message = str(exc_info.value)
+        assert "contains 3 null value(s)" in message
+        assert "0, 2, 4" in message
+        assert "label" in message
+
+    def test_error_message_truncates_large_null_lists(self):
+        # 15 null values across 15 rows: preview should show first 10 and "5 more"
+        labels = [np.nan] * 15
+        data = {"feature": list(range(15)), "label": labels}
+        with pytest.raises(ValueError) as exc_info:
+            Data(data=data, task=Task.CLASSIFICATION, label_name="label")
+        message = str(exc_info.value)
+        assert "contains 15 null value(s)" in message
+        assert "0, 1, 2, 3, 4, 5, 6, 7, 8, 9" in message
+        assert "... (5 more)" in message
+
+    def test_clean_integer_labels_pass(self):
+        # Regression: fix must not break the happy path for integer labels.
+        data = {"feature": [1, 2, 3, 4], "label": [0, 1, 0, 1]}
+        result = Data(data=data, task=Task.CLASSIFICATION, label_name="label")
+        assert result.has_labels
+        assert len(result.labels) == 4
+
+    def test_clean_string_labels_pass(self):
+        # Negative test: the fix must not over-reach and reject valid string labels.
+        data = {"feature": [1, 2, 3], "label": ["cat", "dog", "cat"]}
+        result = Data(data=data, task=Task.CLASSIFICATION, label_name="label")
+        assert result.has_labels
+        assert len(result.labels) == 3
+
+    def test_multilabel_whole_row_null_raises(self):
+        # Multi-label case: entire row is None instead of a list.
+        data = {"feature": [1, 2, 3], "label": [["a", "b"], None, ["a"]]}
+        with pytest.raises(ValueError, match="contains 1 null value"):
+            Data(data=data, task=Task.MULTILABEL, label_name="label")


### PR DESCRIPTION
## Summary

Detect NaN/None in the label column at `Datalab` initialization and raise a descriptive `ValueError` with the affected row indices, instead of silently corrupting downstream data quality checks.

Fixes #987. Supersedes stale #1223.

📜 **Example Usage**:
```python
from cleanlab import Datalab
import numpy as np

data = {"feature": [1, 2, 3, 4], "label": [0, np.nan, 1, None]}
try:
    lab = Datalab(data=data, label_name="label")
except ValueError as e:
    print(e)
# Label column 'label' contains 2 null value(s) (NaN/None) at index/indices: 1, 3. Please remove or impute these rows before initializing Datalab.
```

## Impact

🌐 **Areas Affected**:
- `cleanlab/datalab/internal/data.py`: New `Label._check_for_null_labels` static method on the base `Label` class, called from `Label.__init__` before `_extract_labels`.
- `tests/datalab/test_data.py`: New `TestNullLabelValidation` class with 9 tests.

👥 **Who's Affected**: Users who pass datasets containing NaN/None in the label column to `Datalab`. They now receive an actionable error at construction time with the affected row indices.

## Testing

🔍 **Testing Done**: 9 unit tests covering dict/DataFrame/Dataset input paths, single and multiple nulls, NaN and None values, error message correctness and index truncation, multilabel whole-row null detection, plus regression tests proving clean integer and string labels remain unaffected.

Local results:
- `pytest tests/datalab/test_data.py::TestNullLabelValidation -v` — 9 passed
- `pytest tests/datalab/datalab/ -q` — 251 passed, no regressions

**Unaddressed Cases**
- Nested null values inside multi-label sublists (e.g., `[[0, np.nan], [1, 2]]`) are not detected. The check operates on whole-row nulls for both tasks. Nested cases are rare and can be added in a follow-up.

## Links to Relevant Issues or Conversations

- Fixes #987
- Supersedes stale #1223 (same intent, different implementation)

## Reviewer Notes

💡 Key design choices:

1. **Placement in `Label.__init__` (not `Data.__init__`)**: `_validate_labels` already lives on `Label`, so label-content validation belongs there. A single call site in the base class covers all input formats via the normalized `Dataset` that `Data._load_data` produces. The stale #1223 placed the check on `Data` with bifurcated call sites (one for dict, one for other types).
2. **`pd.isna` over `np.isnan`**: handles NaN, None, `pd.NA`, and `NaT` uniformly. `np.isnan` raises `TypeError` on integer and object dtypes.
3. **No new exception class**: matches the existing `_validate_labels` pattern that raises `ValueError` directly.
4. **Error message includes affected indices**: users can locate the problem rows directly. Truncated to 10 indices with a count suffix for large null lists.