### PR TITLE
Add opt-in Datalab placeholder issue manager

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -151,24 +151,20 @@ def num_label_issues(
         num_issues = np.rint(frac_issues * len(labels)).astype(int)
     elif estimation_method == "off_diagonal_custom":
         if not isinstance(confident_joint, np.ndarray):
-            raise ValueError(
-                f"""
+            raise ValueError(f"""
                 No `confident_joint` provided. For 'estimation_method' = {estimation_method} you need to provide pre-calculated
                 `confident_joint` matrix. Use a different `estimation_method` if you want the `confident_joint` matrix to
                 be calculated for you.
-                """
-            )
+                """)
         else:
             joint = estimate_joint(labels, pred_probs, confident_joint=confident_joint)
             frac_issues = 1.0 - joint.trace()
             num_issues = np.rint(frac_issues * len(labels)).astype(int)
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
                 {estimation_method} is not a valid estimation method!
                 Please choose a valid estimation method: {valid_methods}
-                """
-        )
+                """)
 
     return num_issues
 

--- a/cleanlab/datalab/internal/data.py
+++ b/cleanlab/datalab/internal/data.py
@@ -30,7 +30,6 @@ except ImportError:
 
 from cleanlab.internal.validation import labels_to_array, labels_to_list_multilabel
 
-
 if TYPE_CHECKING:  # pragma: no cover
     DatasetLike = Union[Dataset, pd.DataFrame, Dict[str, Any], List[Dict[str, Any]], str]
 

--- a/cleanlab/datalab/internal/issue_finder.py
+++ b/cleanlab/datalab/internal/issue_finder.py
@@ -50,6 +50,7 @@ _CLASSIFICATION_ARGS_DICT = {
     "data_valuation": ["features", "knn_graph"],
     "class_imbalance": [],
     "null": ["features"],
+    "placeholder": ["features"],
 }
 _REGRESSION_ARGS_DICT = {
     "label": ["features", "predictions"],
@@ -58,6 +59,7 @@ _REGRESSION_ARGS_DICT = {
     "non_iid": ["features", "knn_graph"],
     "data_valuation": ["features", "knn_graph"],
     "null": ["features"],
+    "placeholder": ["features"],
 }
 
 _MULTILABEL_ARGS_DICT = {
@@ -67,6 +69,7 @@ _MULTILABEL_ARGS_DICT = {
     "non_iid": ["features", "knn_graph"],
     "data_valuation": ["features", "knn_graph"],
     "null": ["features"],
+    "placeholder": ["features"],
 }
 
 

--- a/cleanlab/datalab/internal/issue_manager/__init__.py
+++ b/cleanlab/datalab/internal/issue_manager/__init__.py
@@ -7,4 +7,5 @@ from .imbalance import ClassImbalanceIssueManager
 from .underperforming_group import UnderperformingGroupIssueManager
 from .data_valuation import DataValuationIssueManager
 from .null import NullIssueManager
+from .placeholder import PlaceholderIssueManager
 from .identifier_column import IdentifierColumnIssueManager

--- a/cleanlab/datalab/internal/issue_manager/data_valuation.py
+++ b/cleanlab/datalab/internal/issue_manager/data_valuation.py
@@ -60,9 +60,7 @@ class DataValuationIssueManager(IssueManager):
         >>> lab.find_issues(knn_graph=knn_graph, issue_types=issue_types)
     """
 
-    description: ClassVar[
-        str
-    ] = """
+    description: ClassVar[str] = """
     Examples that contribute minimally to a model's training
     receive lower valuation scores.
     Since the original knn-shapley value is in [-1, 1], we transform it to [0, 1] by:

--- a/cleanlab/datalab/internal/issue_manager/duplicate.py
+++ b/cleanlab/datalab/internal/issue_manager/duplicate.py
@@ -20,9 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class NearDuplicateIssueManager(IssueManager):
     """Manages issues related to near-duplicate examples."""
 
-    description: ClassVar[
-        str
-    ] = """A (near) duplicate issue refers to two or more examples in
+    description: ClassVar[str] = """A (near) duplicate issue refers to two or more examples in
     a dataset that are extremely similar to each other, relative
     to the rest of the dataset.  The examples flagged with this issue
     may be exactly duplicated, or lie atypically close together when

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -84,9 +84,7 @@ class NonIIDIssueManager(IssueManager):
 
     """
 
-    description: ClassVar[
-        str
-    ] = """Whether the dataset exhibits statistically significant
+    description: ClassVar[str] = """Whether the dataset exhibits statistically significant
     violations of the IID assumption like:
     changepoints or shift, drift, autocorrelation, etc.
     The specific violation considered is whether the

--- a/cleanlab/datalab/internal/issue_manager/outlier.py
+++ b/cleanlab/datalab/internal/issue_manager/outlier.py
@@ -22,9 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class OutlierIssueManager(IssueManager):
     """Manages issues related to out-of-distribution examples."""
 
-    description: ClassVar[
-        str
-    ] = """Examples that are very different from the rest of the dataset
+    description: ClassVar[str] = """Examples that are very different from the rest of the dataset
     (i.e. potentially out-of-distribution or rare/anomalous instances).
     """
     issue_name: ClassVar[str] = "outlier"

--- a/cleanlab/datalab/internal/issue_manager/placeholder.py
+++ b/cleanlab/datalab/internal/issue_manager/placeholder.py
@@ -57,9 +57,7 @@ class PlaceholderIssueManager(IssueManager):
         ]
 
     @staticmethod
-    def _column_label(
-        column_index: int, column_names: Optional[List[str]]
-    ) -> Union[str, int]:
+    def _column_label(column_index: int, column_names: Optional[List[str]]) -> Union[str, int]:
         if column_names is not None and column_index < len(column_names):
             return column_names[column_index]
         return column_index
@@ -89,9 +87,7 @@ class PlaceholderIssueManager(IssueManager):
         return abs(candidate - median) > _MAD_MULTIPLIER * mad
 
     @classmethod
-    def _find_confirmed_placeholders(
-        cls, column_values: npt.NDArray[np.floating]
-    ) -> List[float]:
+    def _find_confirmed_placeholders(cls, column_values: npt.NDArray[np.floating]) -> List[float]:
         """Return placeholder values confirmed for a single numeric column."""
         non_null = column_values[~np.isnan(column_values)]
         if non_null.size < _MIN_ROWS_FOR_ANALYSIS:
@@ -145,9 +141,14 @@ class PlaceholderIssueManager(IssueManager):
         if n_numeric_cols == 0:
             scores = np.ones(n_rows, dtype=float)
             is_placeholder_issue = np.zeros(n_rows, dtype=bool)
-            return is_placeholder_issue, scores, placeholder_tracker, {
-                "placeholder_by_column": placeholder_by_column,
-            }
+            return (
+                is_placeholder_issue,
+                scores,
+                placeholder_tracker,
+                {
+                    "placeholder_by_column": placeholder_by_column,
+                },
+            )
 
         for tracker_col, feature_col in enumerate(numeric_column_indices):
             column_values = features[:, feature_col].astype(float, copy=False)

--- a/cleanlab/datalab/internal/issue_manager/placeholder.py
+++ b/cleanlab/datalab/internal/issue_manager/placeholder.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+from cleanlab.datalab.internal.issue_manager import IssueManager
+
+if TYPE_CHECKING:  # pragma: no cover
+    import numpy.typing as npt
+
+# Minimum rows with non-null values required to analyze a column.
+_MIN_ROWS_FOR_ANALYSIS = 20
+# Subsample size for frequency-based candidate detection.
+_SUBSAMPLE_SIZE = 5000
+# Candidate must appear at least this many times and this fraction of non-null rows.
+_MIN_CANDIDATE_COUNT = 3
+_MIN_CANDIDATE_FRACTION = 0.01
+# Minimum non-candidate values needed for distribution comparisons.
+_MIN_NON_CANDIDATE_VALUES = 10
+# Negative sentinel in a mostly non-negative column.
+_SIGN_MISMATCH_NON_NEGATIVE_FRACTION = 0.8
+# Distance from bulk distribution in units of MAD (or IQR if MAD is ~0).
+_MAD_MULTIPLIER = 5.0
+
+
+class PlaceholderIssueManager(IssueManager):
+    """Manages issues related to placeholder values in numeric feature columns.
+
+    Parameters
+    ----------
+    datalab :
+        The Datalab instance that this issue manager searches for issues in.
+    """
+
+    description: ClassVar[
+        str
+    ] = """Examples identified with the placeholder issue correspond to rows that contain
+        numeric placeholder values (e.g. -99) in feature columns where such values likely
+        represent missing data rather than legitimate measurements.
+        """
+    issue_name: ClassVar[str] = "placeholder"
+    verbosity_levels = {
+        0: [],
+        1: [],
+        2: ["placeholder_by_column"],
+    }
+
+    @staticmethod
+    def _numeric_column_indices(features: pd.DataFrame) -> List[int]:
+        return [
+            i
+            for i, col in enumerate(features.columns)
+            if pd.api.types.is_numeric_dtype(features[col])
+            and not pd.api.types.is_bool_dtype(features[col])
+        ]
+
+    @staticmethod
+    def _column_label(
+        column_index: int, column_names: Optional[List[str]]
+    ) -> Union[str, int]:
+        if column_names is not None and column_index < len(column_names):
+            return column_names[column_index]
+        return column_index
+
+    @staticmethod
+    def _values_match(candidate: float, values: npt.NDArray[Any]) -> npt.NDArray[np.bool_]:
+        if np.issubdtype(values.dtype, np.floating):
+            return np.isclose(values, candidate, rtol=0.0, atol=0.0, equal_nan=False)
+        return values == candidate
+
+    @staticmethod
+    def _is_placeholder_like(candidate: float, others: npt.NDArray[np.floating]) -> bool:
+        if others.size < _MIN_NON_CANDIDATE_VALUES:
+            return False
+
+        if candidate < 0 and np.mean(others >= 0) >= _SIGN_MISMATCH_NON_NEGATIVE_FRACTION:
+            return True
+
+        median = float(np.median(others))
+        mad = float(np.median(np.abs(others - median)))
+        if mad < 1e-12:
+            iqr = float(np.percentile(others, 75) - np.percentile(others, 25))
+            if iqr > 1e-12:
+                return abs(candidate - median) > _MAD_MULTIPLIER * iqr
+            return False
+
+        return abs(candidate - median) > _MAD_MULTIPLIER * mad
+
+    @classmethod
+    def _find_confirmed_placeholders(
+        cls, column_values: npt.NDArray[np.floating]
+    ) -> List[float]:
+        """Return placeholder values confirmed for a single numeric column."""
+        non_null = column_values[~np.isnan(column_values)]
+        if non_null.size < _MIN_ROWS_FOR_ANALYSIS:
+            return []
+
+        iqr = float(np.percentile(non_null, 75) - np.percentile(non_null, 25))
+        if iqr < 1e-12:
+            return []
+
+        if non_null.size > _SUBSAMPLE_SIZE:
+            rng = np.random.default_rng(0)
+            sample = rng.choice(non_null, size=_SUBSAMPLE_SIZE, replace=False)
+        else:
+            sample = non_null
+
+        # Compare frequencies relative to the sample (not the full column) so the
+        # threshold has the same meaning regardless of whether subsampling kicked in.
+        min_count = max(_MIN_CANDIDATE_COUNT, int(_MIN_CANDIDATE_FRACTION * sample.size))
+        unique_values, counts = np.unique(sample, return_counts=True)
+
+        confirmed: List[float] = []
+        for candidate, count in zip(unique_values, counts):
+            if count < min_count:
+                continue
+            if count / sample.size < _MIN_CANDIDATE_FRACTION:
+                continue
+
+            others = non_null[~cls._values_match(candidate, non_null)]
+            if cls._is_placeholder_like(float(candidate), others.astype(float)):
+                confirmed.append(float(candidate))
+
+        return confirmed
+
+    @classmethod
+    def _calculate_placeholder_issues(
+        cls,
+        features: npt.NDArray[Any],
+        numeric_column_indices: List[int],
+        column_names: Optional[List[str]] = None,
+    ) -> Tuple[
+        npt.NDArray[np.bool_],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.bool_],
+        Dict[str, Any],
+    ]:
+        n_rows = features.shape[0]
+        n_numeric_cols = len(numeric_column_indices)
+        placeholder_tracker = np.zeros((n_rows, n_numeric_cols), dtype=bool)
+        placeholder_by_column: Dict[str, List[float]] = {}
+
+        if n_numeric_cols == 0:
+            scores = np.ones(n_rows, dtype=float)
+            is_placeholder_issue = np.zeros(n_rows, dtype=bool)
+            return is_placeholder_issue, scores, placeholder_tracker, {
+                "placeholder_by_column": placeholder_by_column,
+            }
+
+        for tracker_col, feature_col in enumerate(numeric_column_indices):
+            column_values = features[:, feature_col].astype(float, copy=False)
+            confirmed = cls._find_confirmed_placeholders(column_values)
+            if not confirmed:
+                continue
+
+            column_label = str(cls._column_label(feature_col, column_names))
+            placeholder_by_column[column_label] = confirmed
+
+            column_mask = np.zeros(n_rows, dtype=bool)
+            for value in confirmed:
+                column_mask |= cls._values_match(value, column_values)
+            placeholder_tracker[:, tracker_col] = column_mask
+
+        placeholder_counts = placeholder_tracker.sum(axis=1)
+        scores = 1.0 - (placeholder_counts / n_numeric_cols)
+        is_placeholder_issue = placeholder_counts > 0
+
+        return (
+            is_placeholder_issue,
+            scores.astype(np.float64),
+            placeholder_tracker,
+            {"placeholder_by_column": placeholder_by_column},
+        )
+
+    def find_issues(
+        self,
+        features: Optional[npt.NDArray | pd.DataFrame] = None,
+        **kwargs,
+    ) -> None:
+        if features is None:
+            raise ValueError("features must be provided to check for placeholder values.")
+
+        column_names: Optional[List[str]] = None
+        if isinstance(features, pd.DataFrame):
+            column_names = list(features.columns)
+            numeric_column_indices = self._numeric_column_indices(features)
+            features_array = features.to_numpy()
+        else:
+            features_array = np.asarray(features)
+            numeric_column_indices = list(range(features_array.shape[1]))
+
+        (
+            is_placeholder_issue,
+            scores,
+            placeholder_tracker,
+            detection_info,
+        ) = self._calculate_placeholder_issues(
+            features=features_array,
+            numeric_column_indices=numeric_column_indices,
+            column_names=column_names,
+        )
+
+        self.issues = pd.DataFrame(
+            {
+                f"is_{self.issue_name}_issue": is_placeholder_issue,
+                self.issue_score_key: scores,
+            },
+        )
+
+        self.summary = self.make_summary(score=float(scores.mean()))
+        self.info = self.collect_info(
+            placeholder_tracker=placeholder_tracker,
+            numeric_column_indices=numeric_column_indices,
+            column_names=column_names,
+            detection_info=detection_info,
+        )
+
+    @staticmethod
+    def _column_impact(placeholder_tracker: np.ndarray) -> Dict[str, List[float]]:
+        if placeholder_tracker.size == 0:
+            return {"column_impact": []}
+        return {"column_impact": placeholder_tracker.mean(axis=0).tolist()}
+
+    def collect_info(
+        self,
+        placeholder_tracker: np.ndarray,
+        numeric_column_indices: List[int],
+        column_names: Optional[List[str]],
+        detection_info: Dict[str, Any],
+    ) -> dict:
+        column_impact = self._column_impact(placeholder_tracker=placeholder_tracker)
+        average_placeholder_score = {
+            "average_placeholder_score": float(self.issues[self.issue_score_key].mean())
+        }
+        return {
+            **average_placeholder_score,
+            **detection_info,
+            **column_impact,
+        }

--- a/cleanlab/datalab/internal/issue_manager/underperforming_group.py
+++ b/cleanlab/datalab/internal/issue_manager/underperforming_group.py
@@ -42,9 +42,7 @@ class UnderperformingGroupIssueManager(IssueManager):
     >>> lab.find_issues(pred_probs=pred_probs, features=X, issue_types=issue_types)
     """
 
-    description: ClassVar[
-        str
-    ] = """An underperforming group refers to a cluster of similar examples
+    description: ClassVar[str] = """An underperforming group refers to a cluster of similar examples
     (i.e. a slice) in the dataset for which the ML model predictions
     are particularly poor (loss evaluation over this subpopulation is high).
     """

--- a/cleanlab/datalab/internal/issue_manager_factory.py
+++ b/cleanlab/datalab/internal/issue_manager_factory.py
@@ -44,7 +44,6 @@ from cleanlab.datalab.internal.issue_manager.regression import RegressionLabelIs
 from cleanlab.datalab.internal.issue_manager.multilabel.label import MultilabelIssueManager
 from cleanlab.datalab.internal.task import Task
 
-
 REGISTRY: Dict[Task, Dict[str, Type[IssueManager]]] = {
     Task.CLASSIFICATION: {
         "outlier": OutlierIssueManager,

--- a/cleanlab/datalab/internal/issue_manager_factory.py
+++ b/cleanlab/datalab/internal/issue_manager_factory.py
@@ -38,6 +38,7 @@ from cleanlab.datalab.internal.issue_manager import (
     DataValuationIssueManager,
     OutlierIssueManager,
     NullIssueManager,
+    PlaceholderIssueManager,
 )
 from cleanlab.datalab.internal.issue_manager.regression import RegressionLabelIssueManager
 from cleanlab.datalab.internal.issue_manager.multilabel.label import MultilabelIssueManager
@@ -54,6 +55,7 @@ REGISTRY: Dict[Task, Dict[str, Type[IssueManager]]] = {
         "underperforming_group": UnderperformingGroupIssueManager,
         "data_valuation": DataValuationIssueManager,
         "null": NullIssueManager,
+        "placeholder": PlaceholderIssueManager,
     },
     Task.REGRESSION: {
         "label": RegressionLabelIssueManager,
@@ -62,6 +64,7 @@ REGISTRY: Dict[Task, Dict[str, Type[IssueManager]]] = {
         "non_iid": NonIIDIssueManager,
         "data_valuation": DataValuationIssueManager,
         "null": NullIssueManager,
+        "placeholder": PlaceholderIssueManager,
     },
     Task.MULTILABEL: {
         "label": MultilabelIssueManager,
@@ -70,6 +73,7 @@ REGISTRY: Dict[Task, Dict[str, Type[IssueManager]]] = {
         "non_iid": NonIIDIssueManager,
         "data_valuation": DataValuationIssueManager,
         "null": NullIssueManager,
+        "placeholder": PlaceholderIssueManager,
     },
 }
 """Registry of issue managers that can be constructed from a task and issue type

--- a/cleanlab/experimental/cifar_cnn.py
+++ b/cleanlab/experimental/cifar_cnn.py
@@ -22,7 +22,6 @@ Code adapted from: https://github.com/bhanML/Co-teaching/blob/master/model.py
 You must have PyTorch installed: https://pytorch.org/get-started/locally/
 """
 
-
 import torch.nn as nn
 import torch.nn.functional as F
 

--- a/cleanlab/experimental/mnist_pytorch.py
+++ b/cleanlab/experimental/mnist_pytorch.py
@@ -16,7 +16,6 @@ from torch.autograd import Variable
 from torch.utils.data.sampler import SubsetRandomSampler
 import numpy as np
 
-
 MNIST_TRAIN_SIZE = 60000
 MNIST_TEST_SIZE = 10000
 SKLEARN_DIGITS_TRAIN_SIZE = 1247

--- a/cleanlab/internal/neighbor/knn_graph.py
+++ b/cleanlab/internal/neighbor/knn_graph.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 from cleanlab.internal.neighbor.metric import decide_default_metric
 from cleanlab.internal.neighbor.search import construct_knn
 
-
 DEFAULT_K = 10
 """Default number of neighbors to consider in the k-nearest neighbors search,
 unless the size of the feature array is too small or the user specifies a different value.

--- a/cleanlab/internal/neighbor/search.py
+++ b/cleanlab/internal/neighbor/search.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 
 from sklearn.neighbors import NearestNeighbors
 
-
 if TYPE_CHECKING:
 
     from cleanlab.typing import Metric

--- a/cleanlab/internal/object_detection_utils.py
+++ b/cleanlab/internal/object_detection_utils.py
@@ -40,10 +40,8 @@ def assert_valid_aggregation_weights(aggregation_weights: Dict[str, Any]) -> Non
     """assert aggregation weights are in the proper format"""
     weights = np.array(list(aggregation_weights.values()))
     if (not np.isclose(np.sum(weights), 1.0)) or (np.min(weights) < 0.0):
-        raise ValueError(
-            f"""Aggregation weights should be non-negative and must sum to 1.0
-                """
-        )
+        raise ValueError(f"""Aggregation weights should be non-negative and must sum to 1.0
+                """)
 
 
 def assert_valid_inputs(
@@ -74,16 +72,12 @@ def assert_valid_inputs(
 
     valid_methods = ["objectlab"]
     if method is not None and method not in valid_methods:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {method} is not a valid object detection scoring method!
             Please choose a valid scoring_method: {valid_methods}
-            """
-        )
+            """)
 
     if threshold is not None and threshold > 1.0:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             Threshold is a cutoff of predicted probabilities and therefore should be <= 1.
-            """
-        )
+            """)

--- a/cleanlab/internal/util.py
+++ b/cleanlab/internal/util.py
@@ -458,7 +458,7 @@ def subset_data(X, mask) -> DatasetLike:
         import torch
 
         if isinstance(X, torch.utils.data.Dataset):
-            mask_idx_list = list(np.nonzero(mask)[0])
+            mask_idx_list = np.nonzero(mask)[0].tolist()
             return torch.utils.data.Subset(X, mask_idx_list)
     except Exception:
         pass

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -253,12 +253,10 @@ def get_label_quality_multiannotator(
             )
 
         else:
-            raise ValueError(
-                f"""
+            raise ValueError(f"""
                 {curr_method} is not a valid consensus method!
                 Please choose a valid consensus_method: {valid_methods}
-                """
-            )
+                """)
 
         if verbose:
             # check if any classes no longer appear in the set of consensus labels
@@ -1514,12 +1512,10 @@ def _get_post_pred_probs_and_weights(
         post_pred_probs = label_counts / num_annotations.reshape(-1, 1)
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return post_pred_probs, return_model_weight, return_annotator_weight
 
@@ -1687,12 +1683,10 @@ def _get_consensus_quality_score(
         consensus_quality_score = annotator_agreement
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid consensus quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return consensus_quality_score
 
@@ -1729,7 +1723,7 @@ def _get_annotator_quality(
     annotator_weight: np.ndarray,
     detailed_label_quality: Optional[np.ndarray] = None,
     quality_method: str = "crowdlab",
-) -> pd.DataFrame:
+) -> np.ndarray:
     """Returns annotator quality score for each annotator.
 
     Parameters
@@ -1826,12 +1820,10 @@ def _get_annotator_quality(
                 )
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid annotator quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return annotator_quality
 

--- a/cleanlab/multilabel_classification/rank.py
+++ b/cleanlab/multilabel_classification/rank.py
@@ -14,7 +14,6 @@ from cleanlab.internal.util import get_num_classes
 from cleanlab.internal.multilabel_utils import int2onehot
 from cleanlab.internal.multilabel_scorer import MultilabelScorer, ClassLabelScorer, Aggregator
 
-
 if TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
 

--- a/cleanlab/object_detection/filter.py
+++ b/cleanlab/object_detection/filter.py
@@ -173,7 +173,7 @@ def _find_label_issues(
         scores = get_label_quality_scores(labels, predictions)
         sorted_scores_idx = issues_from_scores(scores, threshold=1.0)
         is_issue_idx = np.where(is_issue == True)[0]
-        sorted_issue_mask = np.in1d(sorted_scores_idx, is_issue_idx, assume_unique=True)
+        sorted_issue_mask = np.isin(sorted_scores_idx, is_issue_idx, assume_unique=True)
         issue_idx = sorted_scores_idx[sorted_issue_mask]
         return issue_idx
     else:

--- a/cleanlab/object_detection/rank.py
+++ b/cleanlab/object_detection/rank.py
@@ -26,7 +26,6 @@ from cleanlab.internal.object_detection_utils import (
     assert_valid_inputs,
 )
 
-
 if TYPE_CHECKING:  # pragma: no cover
     from typing import TypedDict
 
@@ -144,11 +143,9 @@ def issues_from_scores(label_quality_scores: np.ndarray, *, threshold: float = 0
     """
 
     if threshold > 1.0:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             Threshold is a cutoff of label_quality_scores and therefore should be <= 1.
-            """
-        )
+            """)
 
     issue_indices = np.argwhere(label_quality_scores <= threshold).flatten()
     issue_vals = label_quality_scores[issue_indices]

--- a/cleanlab/outlier.py
+++ b/cleanlab/outlier.py
@@ -569,12 +569,10 @@ def _get_ood_predictions_scores(
             1 - np.sum(probs_sorted**gamma * (1 - probs_sorted) ** (gamma), axis=1) / M
         )  # Use 1 + original gen score/M to make the scores lie in 0-1
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {method} is not a valid OOD scoring method!
             Please choose a valid scoring_method: {valid_methods}
-            """
-        )
+            """)
 
     return (
         ood_predictions_scores,

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -137,12 +137,10 @@ def _compute_label_quality_scores(
     try:
         scoring_func = scoring_funcs[method]
     except KeyError:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {method} is not a valid scoring method for rank_by!
             Please choose a valid rank_by: self_confidence, normalized_margin, confidence_weighted_entropy
-            """
-        )
+            """)
     if adjust_pred_probs:
         if method == "confidence_weighted_entropy":
             raise ValueError(f"adjust_pred_probs is not currently supported for {method}.")
@@ -236,23 +234,19 @@ def get_label_quality_ensemble_scores(
     assert len(pred_probs_list) > 0, "pred_probs_list is empty."
 
     if len(pred_probs_list) == 1:
-        warnings.warn(
-            """
+        warnings.warn("""
             pred_probs_list only has one element.
             Consider using get_label_quality_scores() if you only have a single array of pred_probs.
-            """
-        )
+            """)
 
     for pred_probs in pred_probs_list:
         assert_valid_inputs(X=None, y=labels, pred_probs=pred_probs, multi_label=False)
 
     # Raise ValueError if user passed custom_weights array but did not choose weight_ensemble_members_by="custom"
     if custom_weights is not None and weight_ensemble_members_by != "custom":
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             custom_weights provided but weight_ensemble_members_by is not "custom"!
-            """
-        )
+            """)
 
     # This weighting scheme performs search of t in log_loss_search_T_values for "best" log loss
     if weight_ensemble_members_by == "log_loss_search":
@@ -356,12 +350,10 @@ def get_label_quality_ensemble_scores(
         label_quality_scores = (scores_ensemble * custom_weights).sum(axis=1)
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {weight_ensemble_members_by} is not a valid weighting method for weight_ensemble_members_by!
             Please choose a valid weight_ensemble_members_by: uniform, accuracy, custom
-            """
-        )
+            """)
 
     return label_quality_scores
 

--- a/cleanlab/regression/rank.py
+++ b/cleanlab/regression/rank.py
@@ -75,12 +75,10 @@ def get_label_quality_scores(
 
     scoring_func = scoring_funcs.get(method, None)
     if not scoring_func:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {method} is not a valid scoring method.
             Please choose a valid scoring technique: {scoring_funcs.keys()}.
-            """
-        )
+            """)
 
     # Calculate scores
     label_quality_scores = scoring_func(labels, predictions)

--- a/cleanlab/segmentation/summary.py
+++ b/cleanlab/segmentation/summary.py
@@ -132,12 +132,14 @@ def display_issues(
 
         # First image - Given truth labels
         if labels is not None and plot_index < len(axes_list):
+            assert cmap is not None
             axes_list[plot_index].imshow(cmap[labels[i]])
             axes_list[plot_index].set_title("Given Labels")
             plot_index += 1
 
         # Second image - Argmaxed pred_probs
         if pred_probs is not None and plot_index < len(axes_list):
+            assert cmap is not None
             axes_list[plot_index].imshow(cmap[np.argmax(pred_probs[i], axis=0)])
             axes_list[plot_index].set_title("Argmaxed Prediction Probabilities")
             plot_index += 1

--- a/tests/datalab/datalab/end_to_end_tests/issue_types/test_placeholder.py
+++ b/tests/datalab/datalab/end_to_end_tests/issue_types/test_placeholder.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from cleanlab import Datalab
+
+SEED = 42
+
+
+def _build_features_with_placeholder():
+    rng = np.random.default_rng(SEED)
+    features = rng.uniform(10, 80, size=(200, 2))
+    features[::4, 0] = -99
+    return features
+
+
+@pytest.fixture
+def lab_with_features():
+    features = _build_features_with_placeholder()
+    df = pd.DataFrame(features, columns=["age", "income"])
+    df["label"] = (rng_labels := np.random.default_rng(SEED)).integers(0, 2, size=len(df))
+    lab = Datalab(data=df, label_name="label")
+    return lab, features
+
+
+def test_lab_find_issues_placeholder_numpy(lab_with_features):
+    lab, features = lab_with_features
+    lab.find_issues(features=features, issue_types={"placeholder": {}})
+
+    placeholder_issues = lab.get_issues("placeholder")
+    assert placeholder_issues["is_placeholder_issue"].sum() > 0
+    assert placeholder_issues["placeholder_score"].mean() < 1.0
+
+    info = lab.get_info("placeholder")
+    assert any(
+        any(np.isclose(v, -99) for v in vals)
+        for vals in info["placeholder_by_column"].values()
+    )
+
+
+def test_lab_find_issues_placeholder_dataframe(lab_with_features):
+    lab, features = lab_with_features
+    df = pd.DataFrame(features, columns=["age", "income"])
+    lab.find_issues(features=df, issue_types={"placeholder": {}})
+
+    info = lab.get_info("placeholder")
+    assert "age" in info["placeholder_by_column"]
+
+
+def test_lab_find_issues_placeholder_clean_data():
+    rng = np.random.default_rng(SEED)
+    features = rng.uniform(10, 80, size=(200, 3))
+    df = pd.DataFrame(features, columns=["c1", "c2", "c3"])
+    df["label"] = rng.integers(0, 2, size=len(df))
+    lab = Datalab(data=df, label_name="label")
+
+    lab.find_issues(features=features, issue_types={"placeholder": {}})
+    placeholder_issues = lab.get_issues("placeholder")
+    assert not placeholder_issues["is_placeholder_issue"].any()

--- a/tests/datalab/datalab/end_to_end_tests/issue_types/test_placeholder.py
+++ b/tests/datalab/datalab/end_to_end_tests/issue_types/test_placeholder.py
@@ -33,8 +33,7 @@ def test_lab_find_issues_placeholder_numpy(lab_with_features):
 
     info = lab.get_info("placeholder")
     assert any(
-        any(np.isclose(v, -99) for v in vals)
-        for vals in info["placeholder_by_column"].values()
+        any(np.isclose(v, -99) for v in vals) for vals in info["placeholder_by_column"].values()
     )
 
 

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -23,7 +23,6 @@ from cleanlab.datalab.internal.issue_manager.knn_graph_helpers import num_neighb
 from cleanlab.datalab.internal.report import Reporter
 from cleanlab.datalab.internal.task import Task
 
-
 SEED = 42
 
 

--- a/tests/datalab/datalab/test_multilabel.py
+++ b/tests/datalab/datalab/test_multilabel.py
@@ -103,7 +103,15 @@ class TestDatalabForMultilabelClassification:
             ["label", "near_duplicate", "non_iid", "outlier", "null"]
         )
         assert set(lab.list_possible_issue_types()) == set(
-            ["label", "near_duplicate", "non_iid", "outlier", "null", "data_valuation"]
+            [
+                "label",
+                "near_duplicate",
+                "non_iid",
+                "outlier",
+                "null",
+                "placeholder",
+                "data_valuation",
+            ]
         )
 
     @pytest.mark.parametrize(

--- a/tests/datalab/datalab/test_regression.py
+++ b/tests/datalab/datalab/test_regression.py
@@ -4,7 +4,6 @@ import pytest
 from sklearn.neighbors import NearestNeighbors
 from cleanlab.datalab.datalab import Datalab
 
-
 SEED = 42
 
 

--- a/tests/datalab/datalab/test_regression.py
+++ b/tests/datalab/datalab/test_regression.py
@@ -137,7 +137,15 @@ class TestDatalabForRegression:
             ["label", "outlier", "near_duplicate", "non_iid", "null"]
         )
         assert set(lab.list_possible_issue_types()) == set(
-            ["label", "outlier", "near_duplicate", "non_iid", "null", "data_valuation"]
+            [
+                "label",
+                "outlier",
+                "near_duplicate",
+                "non_iid",
+                "null",
+                "placeholder",
+                "data_valuation",
+            ]
         )
 
     def test_regression_with_features_finds_label_issues(self, lab, regression_data):

--- a/tests/datalab/issue_manager/test_placeholder.py
+++ b/tests/datalab/issue_manager/test_placeholder.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from cleanlab.datalab.internal.issue_manager.placeholder import PlaceholderIssueManager
+
+SEED = 42
+
+
+class TestPlaceholderIssueManager:
+    @pytest.fixture
+    def clean_features(self):
+        np.random.seed(SEED)
+        features = np.random.uniform(10, 80, size=(200, 3))
+        return features
+
+    @pytest.fixture
+    def features_with_placeholder(self):
+        np.random.seed(SEED)
+        features = np.random.uniform(10, 80, size=(200, 2))
+        features[::4, 0] = -99
+        features[1::5, 1] = -99
+        return features
+
+    @pytest.fixture
+    def issue_manager(self, lab):
+        return PlaceholderIssueManager(datalab=lab)
+
+    def test_init(self, lab, issue_manager):
+        assert issue_manager.datalab == lab
+
+    def test_find_issues_clean_data(self, issue_manager, clean_features):
+        issue_manager.find_issues(features=clean_features)
+        assert not issue_manager.issues["is_placeholder_issue"].any()
+        assert issue_manager.summary["score"][0] == pytest.approx(1.0, abs=1e-7)
+        assert issue_manager.info["placeholder_by_column"] == {}
+
+    def test_find_issues_detects_negative_sentinel(self, issue_manager, features_with_placeholder):
+        issue_manager.find_issues(features=features_with_placeholder)
+        issues = issue_manager.issues
+
+        assert issues["is_placeholder_issue"].sum() > 0
+        assert issues["placeholder_score"].mean() < 1.0
+        assert any(
+            any(np.isclose(v, -99) for v in vals)
+            for vals in issue_manager.info["placeholder_by_column"].values()
+        )
+
+    def test_legitimate_negative_values_not_flagged(self, issue_manager):
+        np.random.seed(SEED)
+        features = np.random.uniform(-50, -10, size=(200, 2))
+        issue_manager.find_issues(features=features)
+        assert not issue_manager.issues["is_placeholder_issue"].any()
+
+    def test_find_issues_with_dataframe(self, issue_manager, features_with_placeholder):
+        df = pd.DataFrame(features_with_placeholder, columns=["age", "income"])
+        issue_manager.find_issues(features=df)
+        assert "age" in issue_manager.info["placeholder_by_column"]
+
+    def test_report(self, issue_manager, features_with_placeholder):
+        issue_manager.find_issues(features=features_with_placeholder)
+        report = issue_manager.report(
+            issues=issue_manager.issues,
+            summary=issue_manager.summary,
+            info=issue_manager.info,
+        )
+        assert isinstance(report, str)
+        assert "placeholder issues" in report
+
+    def test_requires_features(self, issue_manager):
+        with pytest.raises(ValueError, match="features must be provided"):
+            issue_manager.find_issues()

--- a/tests/datalab/test_data.py
+++ b/tests/datalab/test_data.py
@@ -9,7 +9,6 @@ from hypothesis import given, assume, settings, HealthCheck
 
 from cleanlab.datalab.internal.task import Task
 
-
 NUM_COLS = 2
 
 

--- a/tests/datalab/test_factory.py
+++ b/tests/datalab/test_factory.py
@@ -24,6 +24,7 @@ def test_list_possible_issue_types(registry):
         "underperforming_group",
         "data_valuation",
         "null",
+        "placeholder",
     ]
     assert set(issue_types) == set(possible_issues)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -10,7 +10,6 @@ from cleanlab.internal.multilabel_utils import int2onehot, onehot2int
 from cleanlab.internal.util import num_unique_classes, format_labels, get_missing_classes
 from cleanlab.internal.validation import assert_valid_class_labels
 
-
 noise_matrix = np.array([[1.0, 0.0, 0.2], [0.0, 0.7, 0.2], [0.0, 0.3, 0.6]])
 
 noise_matrix_2 = np.array(


### PR DESCRIPTION
## Summary

- Adds `PlaceholderIssueManager` to detect likely numeric sentinel placeholders (e.g. -99 in mostly non-negative columns) via a two-stage heuristic.
- Registers the issue type for classification, regression, and multilabel tasks; requires `features` only (same as `null`).
- Keeps `placeholder` out of default `find_issues()` — opt-in via `issue_types={"placeholder": {}}`.
- Adds unit and end-to-end tests.

## Test plan

- [x] `pytest tests/datalab/issue_manager/test_placeholder.py -q`
- [x] `pytest tests/datalab/datalab/end_to_end_tests/issue_types/test_placeholder.py -q`
- [x] `pytest tests/datalab/test_factory.py tests/datalab/datalab/test_regression.py::TestDatalabForRegression::test_available_issue_types -q`

Closes #811
