### PR TITLE
Add strict mypy type annotations to datalab/internal/task.py

### DIFF
--- a/cleanlab/datalab/internal/task.py
+++ b/cleanlab/datalab/internal/task.py
@@ -32,7 +32,7 @@ class Task(Enum):
     MULTILABEL = "multilabel"
     """Multilabel task."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Returns the string representation of the task.
 
@@ -76,7 +76,7 @@ class Task(Enum):
             raise ValueError(f"Invalid task: {task_str}. Datalab only supports {valid_tasks}.")
 
     @property
-    def is_classification(self):
+    def is_classification(self) -> bool:
         """
         Checks if the task is classification.
 
@@ -94,7 +94,7 @@ class Task(Enum):
         return self == Task.CLASSIFICATION
 
     @property
-    def is_regression(self):
+    def is_regression(self) -> bool:
         """
         Checks if the task is regression.
 
@@ -112,7 +112,7 @@ class Task(Enum):
         return self == Task.REGRESSION
 
     @property
-    def is_multilabel(self):
+    def is_multilabel(self) -> bool:
         """
         Checks if the task is multilabel.
 


### PR DESCRIPTION
## Summary
Adds missing return type annotations to `cleanlab/datalab/internal/task.py` so the file passes `mypy --strict`.

## Changes
Four methods in the `Task` enum class were missing return type annotations:
- `__str__` → `-> str`
- `is_classification` → `-> bool`
- `is_regression` → `-> bool`
- `is_multilabel` → `-> bool`

## Testing
- Verified `cleanlab/datalab/internal/task.py` passes `mypy --strict --ignore-missing-imports` with no errors
- Ran existing test suite covering `Task` across 4 test files (22 tests), all passing

Part of #407