### PR TITLE
refactor: add strict type annotations to Task enum methods

### DIFF
--- a/cleanlab/datalab/internal/task.py
+++ b/cleanlab/datalab/internal/task.py
@@ -32,7 +32,7 @@ class Task(Enum):
     MULTILABEL = "multilabel"
     """Multilabel task."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Returns the string representation of the task.
 
@@ -76,7 +76,7 @@ class Task(Enum):
             raise ValueError(f"Invalid task: {task_str}. Datalab only supports {valid_tasks}.")
 
     @property
-    def is_classification(self):
+    def is_classification(self) -> bool:
         """
         Checks if the task is classification.
 
@@ -94,7 +94,7 @@ class Task(Enum):
         return self == Task.CLASSIFICATION
 
     @property
-    def is_regression(self):
+    def is_regression(self) -> bool:
         """
         Checks if the task is regression.
 
@@ -112,7 +112,7 @@ class Task(Enum):
         return self == Task.REGRESSION
 
     @property
-    def is_multilabel(self):
+    def is_multilabel(self) -> bool:
         """
         Checks if the task is multilabel.
 


### PR DESCRIPTION
Resolves #1313.

### Description
Currently, several methods in the internal `Task` enum do not specify return type annotations, preventing mypy from checking them with `--strict` mode.

### Changes
- Added `-> str` annotation to `__str__`.
- Added `-> bool` annotations to properties `is_classification`, `is_regression`, and `is_multilabel`.
- Verified that `cleanlab/datalab/internal/task.py` now passes `mypy --strict --ignore-missing-imports` with 0 issues.