### PR TITLE
docs: add FAQ entry and tutorial cross-references for running Datalab on unlabeled datasets (#1159)

### DIFF
--- a/docs/source/tutorials/faq.ipynb
+++ b/docs/source/tutorials/faq.ipynb
@@ -477,7 +477,7 @@
    "id": "3868ee8b",
    "metadata": {},
    "source": [
-    "### Why isn’t CleanLearning working for me?"
+    "### Why isn\u2019t CleanLearning working for me?"
    ]
   },
   {
@@ -639,7 +639,7 @@
    "id": "de5c984b",
    "metadata": {},
    "source": [
-    "To effectively identify errors in a regression dataset, the methods in [regression.learn.CleanLearning](../../cleanlab/regression/learn.html#cleanlab.regression.learn.CleanLearning) estimate each datapoint's aleatoric uncertainty (by fitting a second copy of the regression model to predict the residuals’ magnitudes), as well as its epistemic uncertainty (by fitting multiple copies of the regression model with bootstrap resampling). These uncertainty estimates help provide a robust quality score that accounts for the model's imperfect predictions. \n",
+    "To effectively identify errors in a regression dataset, the methods in [regression.learn.CleanLearning](../../cleanlab/regression/learn.html#cleanlab.regression.learn.CleanLearning) estimate each datapoint's aleatoric uncertainty (by fitting a second copy of the regression model to predict the residuals\u2019 magnitudes), as well as its epistemic uncertainty (by fitting multiple copies of the regression model with bootstrap resampling). These uncertainty estimates help provide a robust quality score that accounts for the model's imperfect predictions. \n",
     "\n",
     "These uncertainty estimates help produce better results but require longer runtimes. Here are a few options to speed up the runtime of these methods:\n",
     "\n",
@@ -886,6 +886,17 @@
     "print(\"Near-duplicate examples to keep:\", np.where(~ids_to_remove_series)[0].tolist())\n",
     "\n",
     "print(\"Near-duplicate examples to remove:\", np.where(ids_to_remove_series)[0].tolist())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How do I run Datalab on an unlabeled dataset?\n",
+    "\n",
+    "If your dataset does not have labels (or if you are working with modalities such as token-classification, image segmentation, or object detection where Datalab does not yet support label-specific issue types), you can still run `Datalab` to detect general data quality issues (such as outliers, near-duplicates, non-IID data, etc.) by providing feature embeddings.\n",
+    "\n",
+    "To do this, extract feature embeddings from your data using a pre-trained model and pass them into `Datalab.find_issues(features=embeddings)`. For detailed guidance and examples of how to compute model embeddings for different data modalities, refer to the [Image Datalab Tutorial](https://docs.cleanlab.ai/master/tutorials/datalab/image.html) and [Text Datalab Tutorial](https://docs.cleanlab.ai/master/tutorials/datalab/text.html)."
    ]
   },
   {

--- a/docs/source/tutorials/object_detection.ipynb
+++ b/docs/source/tutorials/object_detection.ipynb
@@ -715,6 +715,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Detecting Other Data Quality Issues\n",
+    "\n",
+    "While Datalab does not currently support label-specific issue detection for this task modality, you can still use Datalab to automatically detect many other types of data quality issues in your dataset (such as outliers, near-duplicates, and representation issues) by using feature embeddings.\n",
+    "\n",
+    "To learn how to run Datalab without required prediction labels, refer to the FAQ entry on [How do I run Datalab on an unlabeled dataset?](https://docs.cleanlab.ai/master/tutorials/faq.html#how-do-i-run-datalab-on-an-unlabeled-dataset)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "8ce74938",

--- a/docs/source/tutorials/segmentation.ipynb
+++ b/docs/source/tutorials/segmentation.ipynb
@@ -437,6 +437,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Detecting Other Data Quality Issues\n",
+    "\n",
+    "While Datalab does not currently support label-specific issue detection for this task modality, you can still use Datalab to automatically detect many other types of data quality issues in your dataset (such as outliers, near-duplicates, and representation issues) by using feature embeddings.\n",
+    "\n",
+    "To learn how to run Datalab without required prediction labels, refer to the FAQ entry on [How do I run Datalab on an unlabeled dataset?](https://docs.cleanlab.ai/master/tutorials/faq.html#how-do-i-run-datalab-on-an-unlabeled-dataset)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "86bac686",

--- a/docs/source/tutorials/token_classification.ipynb
+++ b/docs/source/tutorials/token_classification.ipynb
@@ -506,6 +506,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Detecting Other Data Quality Issues\n",
+    "\n",
+    "While Datalab does not currently support label-specific issue detection for this task modality, you can still use Datalab to automatically detect many other types of data quality issues in your dataset (such as outliers, near-duplicates, and representation issues) by using feature embeddings.\n",
+    "\n",
+    "To learn how to run Datalab without required prediction labels, refer to the FAQ entry on [How do I run Datalab on an unlabeled dataset?](https://docs.cleanlab.ai/master/tutorials/faq.html#how-do-i-run-datalab-on-an-unlabeled-dataset)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a18795eb",


### PR DESCRIPTION
Fixes #1159.

## Summary
Adds an FAQ entry explaining how to run `Datalab` on unlabeled datasets (or task modalities without label-specific issue support) using feature embeddings, with links to the Image and Text Datalab tutorials. Also updates the token classification, segmentation, and object detection tutorials with a cross-reference to this FAQ entry.

## Changes
- Added `### How do I run Datalab on an unlabeled dataset?` section to `docs/source/tutorials/faq.ipynb`.
- Added `## Detecting Other Data Quality Issues` section to the bottom of `token_classification.ipynb`, `segmentation.ipynb`, and `object_detection.ipynb` pointing to the new FAQ entry.

## Testing
- Verified Jupyter notebook JSON structure and markdown rendering integrity.