### PR TITLE
Turn near-duplicate score test into a property-based test

### DIFF
--- a/tests/datalab/issue_manager/test_duplicate.py
+++ b/tests/datalab/issue_manager/test_duplicate.py
@@ -32,6 +32,56 @@ def embeddings_strategy(draw):
     return embeddings
 
 
+@composite
+def embeddings_with_near_duplicates_strategy(draw):
+    """Generate embeddings guaranteed to contain both near-duplicates and non-duplicates.
+
+    Base rows are placed far apart (>= ~1 apart per feature, well above the default
+    ``0.13`` near-duplicate threshold) so they are never flagged among themselves. A
+    non-empty proper subset of base rows is then re-appended with tiny noise, producing
+    genuine near-duplicates that must be flagged while leaving at least one non-duplicated
+    base row. This lets the "issue scores are smaller than non-issue scores" property be
+    checked without relying on a single hand-crafted toy dataset.
+    """
+    n_base = draw(st.integers(min_value=4, max_value=8))
+    dim = draw(st.integers(min_value=2, max_value=3))
+
+    # Small within-cell jitter keeps base rows distinct without bringing any two within
+    # the near-duplicate threshold (max per-feature jitter 0.05 << inter-row spacing 1.0).
+    jitter = draw(
+        arrays(
+            dtype=np.float64,
+            shape=(n_base, dim),
+            elements=st.floats(
+                min_value=0.0, max_value=0.05, allow_nan=False, allow_infinity=False
+            ),
+        )
+    )
+    base = jitter + np.arange(n_base, dtype=np.float64).reshape(-1, 1)
+
+    # Duplicate a non-empty proper subset of rows (leave >= 1 non-duplicated base row).
+    dup_indices = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=n_base - 1),
+            min_size=1,
+            max_size=n_base - 1,
+            unique=True,
+        )
+    )
+    # Tiny noise (<= 1e-4) keeps appended rows well inside the near-duplicate threshold.
+    noise = draw(
+        arrays(
+            dtype=np.float64,
+            shape=(len(dup_indices), dim),
+            elements=st.floats(
+                min_value=-1e-4, max_value=1e-4, allow_nan=False, allow_infinity=False
+            ),
+        )
+    )
+    near_duplicates = base[dup_indices] + noise
+    return np.vstack([base, near_duplicates])
+
+
 class TestNearDuplicateIssueManager:
     @pytest.fixture
     def embeddings(self, lab):
@@ -86,13 +136,20 @@ class TestNearDuplicateIssueManager:
         )
         new_issue_manager.find_issues(features=embeddings["embedding"])
 
-    def test_scores_of_examples_with_issues_are_smaller_than_those_without(
-        self, issue_manager, embeddings
-    ):
-        # TODO: Turn this into a property-based test
-        issue_manager.find_issues(features=embeddings["embedding"])
+    @given(embeddings=embeddings_with_near_duplicates_strategy())
+    @settings(deadline=None)
+    def test_scores_of_examples_with_issues_are_smaller_than_those_without(self, embeddings):
+        data = {"metadata": ["" for _ in range(len(embeddings))]}
+        lab = Datalab(data)
+        issue_manager = NearDuplicateIssueManager(datalab=lab, metric="euclidean", k=2)
+        issue_manager.find_issues(features=embeddings)
+
         is_issue = issue_manager.issues["is_near_duplicate_issue"]
         scores = issue_manager.issues["near_duplicate_score"]
+
+        # The strategy guarantees both near-duplicates and non-duplicates are present.
+        assume(is_issue.any() and (~is_issue).any())
+
         max_issue_score = np.max(scores[is_issue])
         min_non_issue_score = np.min(scores[~is_issue])
         assert max_issue_score < min_non_issue_score


### PR DESCRIPTION
Closes #944.

### Description

`TestNearDuplicateIssueManager.test_scores_of_examples_with_issues_are_smaller_than_those_without` (which carried a `# TODO: Turn this into a property-based test`) asserted the *"near-duplicate examples have worse scores than non-near-duplicates"* property against a single hand-crafted toy dataset.

This replaces it with a [Hypothesis](https://hypothesis.readthedocs.io/) property-based test, following the embedding-generation recipe from the issue:

- **`embeddings_with_near_duplicates_strategy`** places base rows far apart (spacing ≈ 1 per feature, well above the default `0.13` near-duplicate threshold), so base rows are never flagged among themselves;
- it then re-appends a **non-empty proper subset** of base rows with tiny noise (≤ `1e-4`), producing genuine near-duplicates that must be flagged while guaranteeing at least one non-duplicated row remains;
- the test asserts the property `max(score[is_issue]) < min(score[non_issue])` across generated inputs.

This checks the invariant on many randomized shapes/dimensions/duplicate-subsets instead of one fixed example, as requested.

### Verification

`--hypothesis-show-statistics`: **100 passing, 0 failing**, ~12% filtered by `assume` (the guard for "both flagged and unflagged rows present", which the strategy already makes the common case). Full `test_duplicate.py` suite passes (7 tests); `black` (line-length 100) clean; no new imports (flake8 `F401/F403` unaffected).