### PR TITLE
test: cover multilabel label validation

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -27,3 +27,15 @@ def test_label_to_array_raises_error():
     y = pd.DataFrame({"a": [0, 1], "b": [2, 3]})
     with pytest.raises(ValueError):
         validation.labels_to_array(y)
+
+
+def test_labels_to_list_multilabel_returns_nested_list():
+    labels = [[0, 1], [1], []]
+
+    assert validation.labels_to_list_multilabel(labels) == labels
+
+
+@pytest.mark.parametrize("labels", [np.array([[0], [1]]), [0, 1]])
+def test_labels_to_list_multilabel_rejects_unsupported_formats(labels):
+    with pytest.raises(ValueError):
+        validation.labels_to_list_multilabel(labels)


### PR DESCRIPTION
## Summary

Adds focused unit coverage for `labels_to_list_multilabel`:

- verifies valid nested-list input is returned unchanged
- verifies NumPy arrays and flat lists are rejected

## Impact

Test-only change covering the accepted and rejected input contracts of the multilabel validation helper.

## Testing

- `18 passed in 0.91s` for `tests/test_validation.py`
- `cleanlab/internal/validation.py`: 100% statement and branch coverage in the targeted run
- `git diff --check`

## Links to Relevant Issues or Conversations

Contributes to #363.