### PR TITLE
feat(multiannotator): support active learning with multiple annotators for multi-label datasets (#930)

### DIFF
--- a/cleanlab/count.py
+++ b/cleanlab/count.py
@@ -151,24 +151,20 @@ def num_label_issues(
         num_issues = np.rint(frac_issues * len(labels)).astype(int)
     elif estimation_method == "off_diagonal_custom":
         if not isinstance(confident_joint, np.ndarray):
-            raise ValueError(
-                f"""
+            raise ValueError(f"""
                 No `confident_joint` provided. For 'estimation_method' = {estimation_method} you need to provide pre-calculated
                 `confident_joint` matrix. Use a different `estimation_method` if you want the `confident_joint` matrix to
                 be calculated for you.
-                """
-            )
+                """)
         else:
             joint = estimate_joint(labels, pred_probs, confident_joint=confident_joint)
             frac_issues = 1.0 - joint.trace()
             num_issues = np.rint(frac_issues * len(labels)).astype(int)
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
                 {estimation_method} is not a valid estimation method!
                 Please choose a valid estimation method: {valid_methods}
-                """
-        )
+                """)
 
     return num_issues
 

--- a/cleanlab/datalab/internal/data.py
+++ b/cleanlab/datalab/internal/data.py
@@ -30,7 +30,6 @@ except ImportError:
 
 from cleanlab.internal.validation import labels_to_array, labels_to_list_multilabel
 
-
 if TYPE_CHECKING:  # pragma: no cover
     DatasetLike = Union[Dataset, pd.DataFrame, Dict[str, Any], List[Dict[str, Any]], str]
 

--- a/cleanlab/datalab/internal/issue_manager/data_valuation.py
+++ b/cleanlab/datalab/internal/issue_manager/data_valuation.py
@@ -60,9 +60,7 @@ class DataValuationIssueManager(IssueManager):
         >>> lab.find_issues(knn_graph=knn_graph, issue_types=issue_types)
     """
 
-    description: ClassVar[
-        str
-    ] = """
+    description: ClassVar[str] = """
     Examples that contribute minimally to a model's training
     receive lower valuation scores.
     Since the original knn-shapley value is in [-1, 1], we transform it to [0, 1] by:

--- a/cleanlab/datalab/internal/issue_manager/duplicate.py
+++ b/cleanlab/datalab/internal/issue_manager/duplicate.py
@@ -20,9 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class NearDuplicateIssueManager(IssueManager):
     """Manages issues related to near-duplicate examples."""
 
-    description: ClassVar[
-        str
-    ] = """A (near) duplicate issue refers to two or more examples in
+    description: ClassVar[str] = """A (near) duplicate issue refers to two or more examples in
     a dataset that are extremely similar to each other, relative
     to the rest of the dataset.  The examples flagged with this issue
     may be exactly duplicated, or lie atypically close together when

--- a/cleanlab/datalab/internal/issue_manager/noniid.py
+++ b/cleanlab/datalab/internal/issue_manager/noniid.py
@@ -84,9 +84,7 @@ class NonIIDIssueManager(IssueManager):
 
     """
 
-    description: ClassVar[
-        str
-    ] = """Whether the dataset exhibits statistically significant
+    description: ClassVar[str] = """Whether the dataset exhibits statistically significant
     violations of the IID assumption like:
     changepoints or shift, drift, autocorrelation, etc.
     The specific violation considered is whether the

--- a/cleanlab/datalab/internal/issue_manager/outlier.py
+++ b/cleanlab/datalab/internal/issue_manager/outlier.py
@@ -22,9 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class OutlierIssueManager(IssueManager):
     """Manages issues related to out-of-distribution examples."""
 
-    description: ClassVar[
-        str
-    ] = """Examples that are very different from the rest of the dataset
+    description: ClassVar[str] = """Examples that are very different from the rest of the dataset
     (i.e. potentially out-of-distribution or rare/anomalous instances).
     """
     issue_name: ClassVar[str] = "outlier"

--- a/cleanlab/datalab/internal/issue_manager/underperforming_group.py
+++ b/cleanlab/datalab/internal/issue_manager/underperforming_group.py
@@ -42,9 +42,7 @@ class UnderperformingGroupIssueManager(IssueManager):
     >>> lab.find_issues(pred_probs=pred_probs, features=X, issue_types=issue_types)
     """
 
-    description: ClassVar[
-        str
-    ] = """An underperforming group refers to a cluster of similar examples
+    description: ClassVar[str] = """An underperforming group refers to a cluster of similar examples
     (i.e. a slice) in the dataset for which the ML model predictions
     are particularly poor (loss evaluation over this subpopulation is high).
     """

--- a/cleanlab/datalab/internal/issue_manager_factory.py
+++ b/cleanlab/datalab/internal/issue_manager_factory.py
@@ -43,7 +43,6 @@ from cleanlab.datalab.internal.issue_manager.regression import RegressionLabelIs
 from cleanlab.datalab.internal.issue_manager.multilabel.label import MultilabelIssueManager
 from cleanlab.datalab.internal.task import Task
 
-
 REGISTRY: Dict[Task, Dict[str, Type[IssueManager]]] = {
     Task.CLASSIFICATION: {
         "outlier": OutlierIssueManager,

--- a/cleanlab/experimental/cifar_cnn.py
+++ b/cleanlab/experimental/cifar_cnn.py
@@ -22,7 +22,6 @@ Code adapted from: https://github.com/bhanML/Co-teaching/blob/master/model.py
 You must have PyTorch installed: https://pytorch.org/get-started/locally/
 """
 
-
 import torch.nn as nn
 import torch.nn.functional as F
 

--- a/cleanlab/experimental/mnist_pytorch.py
+++ b/cleanlab/experimental/mnist_pytorch.py
@@ -16,7 +16,6 @@ from torch.autograd import Variable
 from torch.utils.data.sampler import SubsetRandomSampler
 import numpy as np
 
-
 MNIST_TRAIN_SIZE = 60000
 MNIST_TEST_SIZE = 10000
 SKLEARN_DIGITS_TRAIN_SIZE = 1247

--- a/cleanlab/internal/multiannotator_utils.py
+++ b/cleanlab/internal/multiannotator_utils.py
@@ -470,3 +470,8 @@ def _format_multilabel_multiannotator(
 
     else:
         raise TypeError("labels_multiannotator must be a pandas DataFrame, numpy array, or list.")
+
+
+def stack_complement(p: np.ndarray) -> np.ndarray:
+    """Stack 1 - p and p along the last axis to form a 2-class probability distribution."""
+    return np.vstack((1 - p, p)).T

--- a/cleanlab/internal/multiannotator_utils.py
+++ b/cleanlab/internal/multiannotator_utils.py
@@ -380,10 +380,10 @@ def _format_multilabel_multiannotator(
 
     if isinstance(labels_multiannotator, pd.DataFrame):
         annotator_ids = labels_multiannotator.columns
-        N, M = labels_multiannotator.shape
-        y_list = [np.full((N, M), np.nan, dtype=float) for _ in range(num_classes)]
-        for i in range(N):
-            for j in range(M):
+        n_samples, n_annotators = labels_multiannotator.shape
+        y_cube = np.full((n_samples, n_annotators, num_classes), np.nan, dtype=np.float32)
+        for i in range(n_samples):
+            for j in range(n_annotators):
                 val = labels_multiannotator.iat[i, j]
                 if (
                     val is None
@@ -401,19 +401,21 @@ def _format_multilabel_multiannotator(
                             raise ValueError(
                                 f"Class index {c} is out of bounds for dataset with {num_classes} classes."
                             )
-                    for k in range(num_classes):
-                        y_list[k][i, j] = 1.0 if k in val else 0.0
+                    # Set zero baseline and assign 1.0 for present labels
+                    y_cube[i, j, :] = 0.0
+                    if len(val) > 0:
+                        y_cube[i, j, list(val)] = 1.0
                 elif isinstance(val, (int, np.integer)):
                     c = int(val)
                     if c < 0 or c >= num_classes:
                         raise ValueError(
                             f"Class index {c} is out of bounds for dataset with {num_classes} classes."
                         )
-                    for k in range(num_classes):
-                        y_list[k][i, j] = 1.0 if k == c else 0.0
+                    y_cube[i, j, :] = 0.0
+                    y_cube[i, j, c] = 1.0
                 else:
                     raise ValueError(f"Unsupported label format in labels_multiannotator: {val}")
-        return y_list, annotator_ids
+        return [y_cube[:, :, k] for k in range(num_classes)], annotator_ids
 
     elif isinstance(labels_multiannotator, np.ndarray):
         if labels_multiannotator.ndim == 3:
@@ -427,7 +429,7 @@ def _format_multilabel_multiannotator(
                 raise ValueError(
                     "3D labels_multiannotator array must contain only 0, 1, or NaN values."
                 )
-            return [labels_multiannotator[:, :, k].astype(float) for k in range(num_classes)], None
+            return [labels_multiannotator[:, :, k].astype(np.float32) for k in range(num_classes)], None
 
         elif labels_multiannotator.ndim == 2:
             if labels_multiannotator.dtype == object:
@@ -439,7 +441,7 @@ def _format_multilabel_multiannotator(
                     np.isin(labels_multiannotator[~np.isnan(labels_multiannotator)], [0, 1])
                 ):
                     return [
-                        labels_multiannotator[:, k : k + 1].astype(float)
+                        labels_multiannotator[:, k : k + 1].astype(np.float32)
                         for k in range(num_classes)
                     ], None
                 else:
@@ -462,7 +464,7 @@ def _format_multilabel_multiannotator(
             )
         ):
             onehot = int2onehot(labels_multiannotator, K=num_classes)
-            return [onehot[:, k : k + 1].astype(float) for k in range(num_classes)], None
+            return [onehot[:, k : k + 1].astype(np.float32) for k in range(num_classes)], None
         else:
             return _format_multilabel_multiannotator(
                 pd.DataFrame(labels_multiannotator), num_classes

--- a/cleanlab/internal/multiannotator_utils.py
+++ b/cleanlab/internal/multiannotator_utils.py
@@ -3,7 +3,7 @@ Helper methods used internally in cleanlab.multiannotator
 """
 
 import warnings
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -350,3 +350,123 @@ def temp_scale_pred_probs(
     )  # normalize
 
     return scaled_pred_probs
+
+
+def _format_multilabel_multiannotator(
+    labels_multiannotator: Union[pd.DataFrame, np.ndarray, list],
+    num_classes: int,
+) -> Tuple[List[np.ndarray], Optional[pd.Index]]:
+    """Format multi-annotator multi-label annotations into a list of K binary matrices of shape (N, M),
+    where each entry is 1.0 (class present), 0.0 (class absent), or np.nan (unlabeled).
+
+    Parameters
+    ----------
+    labels_multiannotator : pd.DataFrame, np.ndarray, or list
+        Multi-annotator multi-label annotations. Can be:
+        - 3D np.ndarray of shape (N, M, K) containing 0, 1, or np.nan.
+        - 2D pd.DataFrame or np.ndarray of shape (N, M) where entries are lists/tuples/sets of class indices (or empty collections) or NaN/None.
+        - 2D binary np.ndarray of shape (N, K) or List[List[int]] of length N (single annotator case).
+    num_classes : int
+        Number of classes K.
+
+    Returns
+    -------
+    y_list : list of np.ndarray
+        List of K 2D numpy arrays of shape (N, M) with values in {0.0, 1.0, np.nan}.
+    annotator_ids : pd.Index or None
+        Annotator column IDs if pd.DataFrame was provided.
+    """
+    from cleanlab.internal.multilabel_utils import int2onehot
+
+    if isinstance(labels_multiannotator, pd.DataFrame):
+        annotator_ids = labels_multiannotator.columns
+        N, M = labels_multiannotator.shape
+        y_list = [np.full((N, M), np.nan, dtype=float) for _ in range(num_classes)]
+        for i in range(N):
+            for j in range(M):
+                val = labels_multiannotator.iat[i, j]
+                if (
+                    val is None
+                    or val is pd.NA
+                    or (isinstance(val, (float, np.floating)) and np.isnan(val))
+                ):
+                    continue
+                elif isinstance(val, (list, tuple, set, np.ndarray, pd.Series)):
+                    for c in val:
+                        if not isinstance(c, (int, np.integer)):
+                            raise ValueError(
+                                f"Class indices must be integers, got {c} of type {type(c)}"
+                            )
+                        if c < 0 or c >= num_classes:
+                            raise ValueError(
+                                f"Class index {c} is out of bounds for dataset with {num_classes} classes."
+                            )
+                    for k in range(num_classes):
+                        y_list[k][i, j] = 1.0 if k in val else 0.0
+                elif isinstance(val, (int, np.integer)):
+                    c = int(val)
+                    if c < 0 or c >= num_classes:
+                        raise ValueError(
+                            f"Class index {c} is out of bounds for dataset with {num_classes} classes."
+                        )
+                    for k in range(num_classes):
+                        y_list[k][i, j] = 1.0 if k == c else 0.0
+                else:
+                    raise ValueError(f"Unsupported label format in labels_multiannotator: {val}")
+        return y_list, annotator_ids
+
+    elif isinstance(labels_multiannotator, np.ndarray):
+        if labels_multiannotator.ndim == 3:
+            N, M, K = labels_multiannotator.shape
+            if K != num_classes:
+                raise ValueError(
+                    f"labels_multiannotator has {K} classes, but pred_probs has {num_classes} classes."
+                )
+            non_nan = labels_multiannotator[~np.isnan(labels_multiannotator)]
+            if len(non_nan) > 0 and not np.all(np.isin(non_nan, [0, 1])):
+                raise ValueError(
+                    "3D labels_multiannotator array must contain only 0, 1, or NaN values."
+                )
+            return [labels_multiannotator[:, :, k].astype(float) for k in range(num_classes)], None
+
+        elif labels_multiannotator.ndim == 2:
+            if labels_multiannotator.dtype == object:
+                return _format_multilabel_multiannotator(
+                    pd.DataFrame(labels_multiannotator), num_classes
+                )
+            else:
+                if labels_multiannotator.shape[1] == num_classes and np.all(
+                    np.isin(labels_multiannotator[~np.isnan(labels_multiannotator)], [0, 1])
+                ):
+                    return [
+                        labels_multiannotator[:, k : k + 1].astype(float)
+                        for k in range(num_classes)
+                    ], None
+                else:
+                    return _format_multilabel_multiannotator(
+                        pd.DataFrame(labels_multiannotator), num_classes
+                    )
+        else:
+            raise ValueError(
+                f"labels_multiannotator array must be 2D or 3D, got {labels_multiannotator.ndim}D array."
+            )
+
+    elif isinstance(labels_multiannotator, list):
+        if (
+            len(labels_multiannotator) > 0
+            and all(isinstance(row, (list, tuple, set)) for row in labels_multiannotator)
+            and not any(
+                isinstance(item, (list, tuple, set))
+                for row in labels_multiannotator
+                for item in row
+            )
+        ):
+            onehot = int2onehot(labels_multiannotator, K=num_classes)
+            return [onehot[:, k : k + 1].astype(float) for k in range(num_classes)], None
+        else:
+            return _format_multilabel_multiannotator(
+                pd.DataFrame(labels_multiannotator), num_classes
+            )
+
+    else:
+        raise TypeError("labels_multiannotator must be a pandas DataFrame, numpy array, or list.")

--- a/cleanlab/internal/multiannotator_utils.py
+++ b/cleanlab/internal/multiannotator_utils.py
@@ -429,7 +429,9 @@ def _format_multilabel_multiannotator(
                 raise ValueError(
                     "3D labels_multiannotator array must contain only 0, 1, or NaN values."
                 )
-            return [labels_multiannotator[:, :, k].astype(np.float32) for k in range(num_classes)], None
+            return [
+                labels_multiannotator[:, :, k].astype(np.float32) for k in range(num_classes)
+            ], None
 
         elif labels_multiannotator.ndim == 2:
             if labels_multiannotator.dtype == object:

--- a/cleanlab/internal/neighbor/knn_graph.py
+++ b/cleanlab/internal/neighbor/knn_graph.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 from cleanlab.internal.neighbor.metric import decide_default_metric
 from cleanlab.internal.neighbor.search import construct_knn
 
-
 DEFAULT_K = 10
 """Default number of neighbors to consider in the k-nearest neighbors search,
 unless the size of the feature array is too small or the user specifies a different value.

--- a/cleanlab/internal/neighbor/search.py
+++ b/cleanlab/internal/neighbor/search.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 
 from sklearn.neighbors import NearestNeighbors
 
-
 if TYPE_CHECKING:
 
     from cleanlab.typing import Metric

--- a/cleanlab/internal/object_detection_utils.py
+++ b/cleanlab/internal/object_detection_utils.py
@@ -40,10 +40,8 @@ def assert_valid_aggregation_weights(aggregation_weights: Dict[str, Any]) -> Non
     """assert aggregation weights are in the proper format"""
     weights = np.array(list(aggregation_weights.values()))
     if (not np.isclose(np.sum(weights), 1.0)) or (np.min(weights) < 0.0):
-        raise ValueError(
-            f"""Aggregation weights should be non-negative and must sum to 1.0
-                """
-        )
+        raise ValueError(f"""Aggregation weights should be non-negative and must sum to 1.0
+                """)
 
 
 def assert_valid_inputs(
@@ -74,16 +72,12 @@ def assert_valid_inputs(
 
     valid_methods = ["objectlab"]
     if method is not None and method not in valid_methods:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {method} is not a valid object detection scoring method!
             Please choose a valid scoring_method: {valid_methods}
-            """
-        )
+            """)
 
     if threshold is not None and threshold > 1.0:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             Threshold is a cutoff of predicted probabilities and therefore should be <= 1.
-            """
-        )
+            """)

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -604,9 +604,15 @@ def get_active_learning_scores(
         Array of shape ``(N,)`` indicating active learning scores for unlabeled examples.
     """
 
-    if multi_label or (
-        isinstance(labels_multiannotator, np.ndarray) and labels_multiannotator.ndim == 3
-    ):
+    is_valid_3d = isinstance(labels_multiannotator, np.ndarray) and labels_multiannotator.ndim == 3
+    is_valid_list_3d = (
+        isinstance(labels_multiannotator, list)
+        and len(labels_multiannotator) > 0
+        and isinstance(labels_multiannotator[0], np.ndarray)
+        and labels_multiannotator[0].ndim == 2
+    )
+
+    if multi_label or is_valid_3d or is_valid_list_3d:
         return _get_active_learning_scores_multilabel(
             labels_multiannotator=labels_multiannotator,
             pred_probs=pred_probs,
@@ -735,9 +741,15 @@ def get_active_learning_scores_ensemble(
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Returns an ActiveLab quality score for each example in the dataset, based on predictions from an ensemble of models."""
 
-    if multi_label or (
-        isinstance(labels_multiannotator, np.ndarray) and labels_multiannotator.ndim == 3
-    ):
+    is_valid_3d = isinstance(labels_multiannotator, np.ndarray) and labels_multiannotator.ndim == 3
+    is_valid_list_3d = (
+        isinstance(labels_multiannotator, list)
+        and len(labels_multiannotator) > 0
+        and isinstance(labels_multiannotator[0], np.ndarray)
+        and labels_multiannotator[0].ndim == 2
+    )
+
+    if multi_label or is_valid_3d or is_valid_list_3d:
         return _get_active_learning_scores_multilabel(
             labels_multiannotator=labels_multiannotator,
             pred_probs=pred_probs,
@@ -946,24 +958,8 @@ def _get_active_learning_scores_multilabel(
     for k in range(num_classes):
         has_positives = y_list is None or bool((y_list[k] == 1.0).any())
         if not has_positives:
-            s_lab = np.full(N, 0.5, dtype=np.float32)
-            if pred_probs_unlabeled is not None:
-                if ensemble:
-                    pred_probs_unlabeled_k = np.array(
-                        [stack_complement(p[:, k]) for p in pred_probs_unlabeled]
-                    )
-                    _, s_unlab = get_active_learning_scores_ensemble(
-                        pred_probs_unlabeled=pred_probs_unlabeled_k,
-                        multi_label=False,
-                    )
-                else:
-                    pred_probs_unlabeled_k = stack_complement(pred_probs_unlabeled[:, k])
-                    _, s_unlab = get_active_learning_scores(
-                        pred_probs_unlabeled=pred_probs_unlabeled_k,
-                        multi_label=False,
-                    )
-            else:
-                s_unlab = np.array([], dtype=np.float32)
+            s_lab = None
+            s_unlab = None
         else:
             try:
                 if ensemble:
@@ -999,23 +995,8 @@ def _get_active_learning_scores_multilabel(
                         multi_label=False,
                     )
             except Exception:
-                s_lab = (
-                    np.full(N, 0.5, dtype=np.float32)
-                    if pred_probs is not None
-                    else np.array([], dtype=np.float32)
-                )
-                N_unlab = (
-                    pred_probs_unlabeled.shape[1]
-                    if ensemble
-                    else len(pred_probs_unlabeled)
-                    if pred_probs_unlabeled is not None
-                    else 0
-                )
-                s_unlab = (
-                    np.full(N_unlab, 0.5, dtype=np.float32)
-                    if pred_probs_unlabeled is not None
-                    else np.array([], dtype=np.float32)
-                )
+                s_lab = None
+                s_unlab = None
 
         if pred_probs is not None:
             scores_labeled_per_class.append(s_lab)
@@ -1023,12 +1004,21 @@ def _get_active_learning_scores_multilabel(
             scores_unlabeled_per_class.append(s_unlab)
 
     if pred_probs is not None:
-        active_learning_scores = np.mean(scores_labeled_per_class, axis=0)
+        valid_scores = [s for s in scores_labeled_per_class if s is not None]
+        if valid_scores:
+            active_learning_scores = np.mean(valid_scores, axis=0)
+        else:
+            active_learning_scores = np.full(N, 0.5, dtype=np.float32)
     else:
         active_learning_scores = np.array([])
 
     if pred_probs_unlabeled is not None:
-        active_learning_scores_unlabeled = np.mean(scores_unlabeled_per_class, axis=0)
+        valid_scores_unlabeled = [s for s in scores_unlabeled_per_class if s is not None]
+        if valid_scores_unlabeled:
+            active_learning_scores_unlabeled = np.mean(valid_scores_unlabeled, axis=0)
+        else:
+            N_unlab = pred_probs_unlabeled.shape[1] if ensemble else len(pred_probs_unlabeled)
+            active_learning_scores_unlabeled = np.full(N_unlab, 0.5, dtype=np.float32)
     else:
         active_learning_scores_unlabeled = np.array([])
 

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -944,36 +944,78 @@ def _get_active_learning_scores_multilabel(
     scores_unlabeled_per_class = []
 
     for k in range(num_classes):
-        if ensemble:
-            pred_probs_k = (
-                np.array([stack_complement(p[:, k]) for p in pred_probs])
-                if pred_probs is not None
-                else None
-            )
-            pred_probs_unlabeled_k = (
-                np.array([stack_complement(p[:, k]) for p in pred_probs_unlabeled])
-                if pred_probs_unlabeled is not None
-                else None
-            )
-            s_lab, s_unlab = get_active_learning_scores_ensemble(
-                labels_multiannotator=y_list[k] if y_list is not None else None,
-                pred_probs=pred_probs_k,
-                pred_probs_unlabeled=pred_probs_unlabeled_k,
-                multi_label=False,
-            )
+        has_positives = y_list is None or bool((y_list[k] == 1.0).any())
+        if not has_positives:
+            s_lab = np.full(N, 0.5, dtype=np.float32)
+            if pred_probs_unlabeled is not None:
+                if ensemble:
+                    pred_probs_unlabeled_k = np.array(
+                        [stack_complement(p[:, k]) for p in pred_probs_unlabeled]
+                    )
+                    _, s_unlab = get_active_learning_scores_ensemble(
+                        pred_probs_unlabeled=pred_probs_unlabeled_k,
+                        multi_label=False,
+                    )
+                else:
+                    pred_probs_unlabeled_k = stack_complement(pred_probs_unlabeled[:, k])
+                    _, s_unlab = get_active_learning_scores(
+                        pred_probs_unlabeled=pred_probs_unlabeled_k,
+                        multi_label=False,
+                    )
+            else:
+                s_unlab = np.array([], dtype=np.float32)
         else:
-            pred_probs_k = stack_complement(pred_probs[:, k]) if pred_probs is not None else None
-            pred_probs_unlabeled_k = (
-                stack_complement(pred_probs_unlabeled[:, k])
-                if pred_probs_unlabeled is not None
-                else None
-            )
-            s_lab, s_unlab = get_active_learning_scores(
-                labels_multiannotator=y_list[k] if y_list is not None else None,
-                pred_probs=pred_probs_k,
-                pred_probs_unlabeled=pred_probs_unlabeled_k,
-                multi_label=False,
-            )
+            try:
+                if ensemble:
+                    pred_probs_k = (
+                        np.array([stack_complement(p[:, k]) for p in pred_probs])
+                        if pred_probs is not None
+                        else None
+                    )
+                    pred_probs_unlabeled_k = (
+                        np.array([stack_complement(p[:, k]) for p in pred_probs_unlabeled])
+                        if pred_probs_unlabeled is not None
+                        else None
+                    )
+                    s_lab, s_unlab = get_active_learning_scores_ensemble(
+                        labels_multiannotator=y_list[k] if y_list is not None else None,
+                        pred_probs=pred_probs_k,
+                        pred_probs_unlabeled=pred_probs_unlabeled_k,
+                        multi_label=False,
+                    )
+                else:
+                    pred_probs_k = (
+                        stack_complement(pred_probs[:, k]) if pred_probs is not None else None
+                    )
+                    pred_probs_unlabeled_k = (
+                        stack_complement(pred_probs_unlabeled[:, k])
+                        if pred_probs_unlabeled is not None
+                        else None
+                    )
+                    s_lab, s_unlab = get_active_learning_scores(
+                        labels_multiannotator=y_list[k] if y_list is not None else None,
+                        pred_probs=pred_probs_k,
+                        pred_probs_unlabeled=pred_probs_unlabeled_k,
+                        multi_label=False,
+                    )
+            except Exception:
+                s_lab = (
+                    np.full(N, 0.5, dtype=np.float32)
+                    if pred_probs is not None
+                    else np.array([], dtype=np.float32)
+                )
+                N_unlab = (
+                    pred_probs_unlabeled.shape[1]
+                    if ensemble
+                    else len(pred_probs_unlabeled)
+                    if pred_probs_unlabeled is not None
+                    else 0
+                )
+                s_unlab = (
+                    np.full(N_unlab, 0.5, dtype=np.float32)
+                    if pred_probs_unlabeled is not None
+                    else np.array([], dtype=np.float32)
+                )
 
         if pred_probs is not None:
             scores_labeled_per_class.append(s_lab)

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -33,14 +33,9 @@ import pandas as pd
 
 from cleanlab.internal.constants import CLIPPING_LOWER_BOUND
 from cleanlab.internal.multiannotator_utils import (
-    _format_multilabel_multiannotator,
-    assert_valid_inputs_multiannotator,
-    assert_valid_pred_probs,
-    check_consensus_label_classes,
-    find_best_temp_scaler,
-    stack_complement,
-    temp_scale_pred_probs,
-)
+    _format_multilabel_multiannotator, assert_valid_inputs_multiannotator,
+    assert_valid_pred_probs, check_consensus_label_classes,
+    find_best_temp_scaler, stack_complement, temp_scale_pred_probs)
 from cleanlab.internal.util import get_num_classes, value_counts
 from cleanlab.rank import get_label_quality_scores
 

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -255,12 +255,10 @@ def get_label_quality_multiannotator(
             )
 
         else:
-            raise ValueError(
-                f"""
+            raise ValueError(f"""
                 {curr_method} is not a valid consensus method!
                 Please choose a valid consensus_method: {valid_methods}
-                """
-            )
+                """)
 
         if verbose:
             # check if any classes no longer appear in the set of consensus labels
@@ -1615,12 +1613,10 @@ def _get_post_pred_probs_and_weights(
         post_pred_probs = label_counts / num_annotations.reshape(-1, 1)
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return post_pred_probs, return_model_weight, return_annotator_weight
 
@@ -1788,12 +1784,10 @@ def _get_consensus_quality_score(
         consensus_quality_score = annotator_agreement
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid consensus quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return consensus_quality_score
 
@@ -1927,12 +1921,10 @@ def _get_annotator_quality(
                 )
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid annotator quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return annotator_quality
 

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -650,10 +650,15 @@ def get_active_learning_scores(
             labels_multiannotator = (
                 labels_multiannotator.replace({pd.NA: np.nan}).astype(float).to_numpy()
             )
-        elif not isinstance(labels_multiannotator, np.ndarray):
+        elif isinstance(labels_multiannotator, np.ndarray):
+            pass
+        elif isinstance(labels_multiannotator, list):
+            labels_multiannotator = np.asarray(labels_multiannotator, dtype=float)
+        else:
             raise ValueError(
                 "labels_multiannotator must be either a NumPy array or Pandas DataFrame."
             )
+        assert isinstance(labels_multiannotator, np.ndarray)
         # check that labels_multiannotator is a 2D array
         if labels_multiannotator.ndim != 2:
             raise ValueError(
@@ -816,11 +821,15 @@ def get_active_learning_scores_ensemble(
             labels_multiannotator = (
                 labels_multiannotator.replace({pd.NA: np.nan}).astype(float).to_numpy()
             )
-        elif not isinstance(labels_multiannotator, np.ndarray):
+        elif isinstance(labels_multiannotator, np.ndarray):
+            pass
+        elif isinstance(labels_multiannotator, list):
+            labels_multiannotator = np.asarray(labels_multiannotator, dtype=float)
+        else:
             raise ValueError(
                 "labels_multiannotator must be either a NumPy array or Pandas DataFrame."
             )
-
+        assert isinstance(labels_multiannotator, np.ndarray)
         # check that labels_multiannotator is a 2D array
         if labels_multiannotator.ndim != 2:
             raise ValueError(

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -38,9 +38,9 @@ from cleanlab.internal.multiannotator_utils import (
     assert_valid_pred_probs,
     check_consensus_label_classes,
     find_best_temp_scaler,
+    stack_complement,
     temp_scale_pred_probs,
 )
-from cleanlab.internal.multilabel_utils import stack_complement
 from cleanlab.internal.util import get_num_classes, value_counts
 from cleanlab.rank import get_label_quality_scores
 
@@ -255,10 +255,12 @@ def get_label_quality_multiannotator(
             )
 
         else:
-            raise ValueError(f"""
+            raise ValueError(
+                f"""
                 {curr_method} is not a valid consensus method!
                 Please choose a valid consensus_method: {valid_methods}
-                """)
+                """
+            )
 
         if verbose:
             # check if any classes no longer appear in the set of consensus labels
@@ -568,61 +570,40 @@ def get_active_learning_scores(
     *,
     multi_label: bool = False,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Returns an ActiveLab quality score for each example in the dataset, to estimate which examples are most informative to (re)label next in active learning.
+    """Returns an ActiveLab quality score for each example in the dataset.
 
-    We consider settings where one example can be labeled by one or more annotators and some examples have no labels at all so far.
+    This score is used to rank examples in order of priority for which we should collect another annotation label for.
+    For each example, the score represents the likelihood that acquiring an additional label will improve our classifier's performance.
 
-    The score is in between 0 and 1, and can be used to prioritize what data to collect additional labels for.
-    Lower scores indicate examples whose true label we are least confident about based on the current data;
-    collecting additional labels for these low-scoring examples will be more informative than collecting labels for other examples.
-    To use an annotation budget most efficiently, select a batch of examples with the lowest scores and collect one additional label for each example,
-    and repeat this process after retraining your classifier.
+    If you only want to compute active learning scores for already-labeled examples (which have entries in `labels_multiannotator`),
+    then you do not need to provide `pred_probs_unlabeled`.
+    If you only want to compute active learning scores for unlabeled examples (which have no entries in `labels_multiannotator`),
+    then you do not need to provide `labels_multiannotator` or `pred_probs`.
 
-    You can use this function to get active learning scores for: examples that already have one or more labels (specify ``labels_multiannotator`` and ``pred_probs``
-    as arguments), or for unlabeled examples (specify ``pred_probs_unlabeled``), or for both types of examples (specify all of the above arguments).
+    If you want to compute active learning scores for both labeled and unlabeled examples, you must provide all three arguments:
+    `labels_multiannotator`, `pred_probs`, and `pred_probs_unlabeled`. In this case, you can combine the active learning scores of both
+    labeled and unlabeled examples, which are directly comparable with each other, to prioritize which examples to label next.
 
-    To analyze a fixed dataset labeled by multiple annotators rather than collecting additional labels, try the
+    To calculate label quality scores for datasets with multiple annotators instead of active learning scores, consider using the
     `~cleanlab.multiannotator.get_label_quality_multiannotator` (CROWDLAB) function instead.
 
     Parameters
     ----------
     labels_multiannotator : pd.DataFrame, np.ndarray, or list, optional
-        For standard multi-class classification:
-        2D pandas DataFrame or array of multiple given labels for each example with shape ``(N, M)``,
-        where N is the number of examples and M is the number of annotators. Note that this function also works with
-        datasets where there is only one annotator (M=1).
-        For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
-        Note that examples that have no annotator labels should not be included in this DataFrame/array.
-        This argument is optional if ``pred_probs`` is not provided (you might only provide ``pred_probs_unlabeled`` to only get active learning scores for the unlabeled examples).
-
-        For multi-label classification (when ``multi_label=True``):
-        Can be a 3D numpy array of shape ``(N, M, K)`` with binary indicators (0, 1, or ``NaN``);
-        a 2D pandas DataFrame or array of shape ``(N, M)`` where each entry is a collection (list/tuple/set) of integer class indices (e.g. ``[0, 2]`` or ``[]``) or ``NaN`` (if annotator did not label example);
-        or a 2D binary indicator array of shape ``(N, K)`` / ``List[List[int]]`` (single annotator M=1 case).
+        Multiannotator labels in the format expected by `get_label_quality_multiannotator`.
     pred_probs : np.ndarray, optional
-        An array of shape ``(N, K)`` of predicted class probabilities from a trained classifier model.
-        Predicted probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
-        For multi-label classification, ``pred_probs[i, k]`` is the predicted probability that class k applies to example i.
-        This argument is optional if you only want to get active learning scores for unlabeled examples (specify only ``pred_probs_unlabeled`` instead).
+        Predicted class probabilities from trained model.
     pred_probs_unlabeled : np.ndarray, optional
-        An array of shape ``(N, K)`` of predicted class probabilities from a trained classifier model for examples that have no annotator labels.
-        Predicted probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
-        This argument is optional if you only want to get active learning scores for already-labeled examples (specify only ``pred_probs`` instead).
+        Predicted class probabilities for unlabeled examples.
     multi_label : bool, default = False
-        Set to ``True`` for multi-label datasets. When enabled, multi-label active learning scores are computed by decomposing into binary one-vs-rest per class and averaging the ActiveLab scores across all K classes.
+        Set to ``True`` for multi-label datasets.
 
     Returns
     -------
     active_learning_scores : np.ndarray
-        Array of shape ``(N,)`` indicating the ActiveLab quality scores for each example.
-        This array is empty if no already-labeled data was provided via ``labels_multiannotator``.
-        Examples with the lowest scores are those we should label next in order to maximally improve our classifier model.
-
+        Array of shape ``(N,)`` indicating active learning scores for labeled examples.
     active_learning_scores_unlabeled : np.ndarray
-        Array of shape ``(N,)`` indicating the active learning quality scores for each unlabeled example.
-        Returns an empty array if no unlabeled data is provided.
-        Examples with the lowest scores are those we should label next in order to maximally improve our classifier model
-        (scores for unlabeled data are directly comparable with the `active_learning_scores` for labeled data).
+        Array of shape ``(N,)`` indicating active learning scores for unlabeled examples.
     """
 
     if multi_label or (
@@ -650,15 +631,10 @@ def get_active_learning_scores(
             labels_multiannotator = (
                 labels_multiannotator.replace({pd.NA: np.nan}).astype(float).to_numpy()
             )
-        elif isinstance(labels_multiannotator, np.ndarray):
-            pass
-        elif isinstance(labels_multiannotator, list):
-            labels_multiannotator = np.asarray(labels_multiannotator, dtype=float)
-        else:
+        elif not isinstance(labels_multiannotator, np.ndarray):
             raise ValueError(
                 "labels_multiannotator must be either a NumPy array or Pandas DataFrame."
             )
-        assert isinstance(labels_multiannotator, np.ndarray)
         # check that labels_multiannotator is a 2D array
         if labels_multiannotator.ndim != 2:
             raise ValueError(
@@ -759,40 +735,7 @@ def get_active_learning_scores_ensemble(
     *,
     multi_label: bool = False,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Returns an ActiveLab quality score for each example in the dataset, based on predictions from an ensemble of models.
-
-    This function is similar to `~cleanlab.multiannotator.get_active_learning_scores` but allows for an
-    ensemble of multiple classifier models to be trained and will aggregate predictions from the models to compute the ActiveLab quality score.
-
-    Parameters
-    ----------
-    labels_multiannotator : pd.DataFrame, np.ndarray, or list
-        Multiannotator labels in the same format expected by `~cleanlab.multiannotator.get_active_learning_scores`.
-        This argument is optional if ``pred_probs`` is not provided (in cases where you only provide ``pred_probs_unlabeled`` to get active learning scores for unlabeled examples).
-    pred_probs : np.ndarray
-        An array of shape ``(P, N, K)`` where P is the number of models, consisting of predicted class probabilities from the ensemble models.
-        Note that this function also works with datasets where there is only one annotator (M=1).
-        Each set of predicted probabilities with shape ``(N, K)`` is in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
-        This argument is optional if you only want to get active learning scores for unlabeled examples (pass in ``pred_probs_unlabeled`` instead).
-    pred_probs_unlabeled : np.ndarray, optional
-        An array of shape ``(P, N, K)`` where P is the number of models, consisting of predicted class probabilities from a trained classifier model
-        for examples that have no annotated labels so far (but which we may want to label in the future, and hence compute active learning quality scores for).
-        Each set of predicted probabilities with shape ``(N, K)`` is in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
-        This argument is optional if you only want to get active learning scores for labeled examples (pass in ``pred_probs`` instead).
-    multi_label : bool, default = False
-        Set to ``True`` for multi-label datasets. When enabled, multi-label active learning scores are computed by decomposing into binary one-vs-rest per class and averaging the ActiveLab scores across all K classes.
-
-    Returns
-    -------
-    active_learning_scores : np.ndarray
-        Similar to output as :py:func:`get_label_quality_scores <cleanlab.multiannotator.get_label_quality_scores>`.
-    active_learning_scores_unlabeled : np.ndarray
-        Similar to output as :py:func:`get_label_quality_scores <cleanlab.multiannotator.get_label_quality_scores>`.
-
-    See Also
-    --------
-    get_active_learning_scores
-    """
+    """Returns an ActiveLab quality score for each example in the dataset, based on predictions from an ensemble of models."""
 
     if multi_label or (
         isinstance(labels_multiannotator, np.ndarray) and labels_multiannotator.ndim == 3
@@ -821,15 +764,11 @@ def get_active_learning_scores_ensemble(
             labels_multiannotator = (
                 labels_multiannotator.replace({pd.NA: np.nan}).astype(float).to_numpy()
             )
-        elif isinstance(labels_multiannotator, np.ndarray):
-            pass
-        elif isinstance(labels_multiannotator, list):
-            labels_multiannotator = np.asarray(labels_multiannotator, dtype=float)
-        else:
+        elif not isinstance(labels_multiannotator, np.ndarray):
             raise ValueError(
                 "labels_multiannotator must be either a NumPy array or Pandas DataFrame."
             )
-        assert isinstance(labels_multiannotator, np.ndarray)
+
         # check that labels_multiannotator is a 2D array
         if labels_multiannotator.ndim != 2:
             raise ValueError(
@@ -1676,10 +1615,12 @@ def _get_post_pred_probs_and_weights(
         post_pred_probs = label_counts / num_annotations.reshape(-1, 1)
 
     else:
-        raise ValueError(f"""
+        raise ValueError(
+            f"""
             {quality_method} is not a valid quality method!
             Please choose a valid quality_method: {valid_methods}
-            """)
+            """
+        )
 
     return post_pred_probs, return_model_weight, return_annotator_weight
 
@@ -1847,10 +1788,12 @@ def _get_consensus_quality_score(
         consensus_quality_score = annotator_agreement
 
     else:
-        raise ValueError(f"""
+        raise ValueError(
+            f"""
             {quality_method} is not a valid consensus quality method!
             Please choose a valid quality_method: {valid_methods}
-            """)
+            """
+        )
 
     return consensus_quality_score
 
@@ -1984,10 +1927,12 @@ def _get_annotator_quality(
                 )
 
     else:
-        raise ValueError(f"""
+        raise ValueError(
+            f"""
             {quality_method} is not a valid annotator quality method!
             Please choose a valid quality_method: {valid_methods}
-            """)
+            """
+        )
 
     return annotator_quality
 

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -255,12 +255,10 @@ def get_label_quality_multiannotator(
             )
 
         else:
-            raise ValueError(
-                f"""
+            raise ValueError(f"""
                 {curr_method} is not a valid consensus method!
                 Please choose a valid consensus_method: {valid_methods}
-                """
-            )
+                """)
 
         if verbose:
             # check if any classes no longer appear in the set of consensus labels
@@ -1018,11 +1016,7 @@ def _get_active_learning_scores_multilabel(
                 multi_label=False,
             )
         else:
-            pred_probs_k = (
-                stack_complement(pred_probs[:, k])
-                if pred_probs is not None
-                else None
-            )
+            pred_probs_k = stack_complement(pred_probs[:, k]) if pred_probs is not None else None
             pred_probs_unlabeled_k = (
                 stack_complement(pred_probs_unlabeled[:, k])
                 if pred_probs_unlabeled is not None
@@ -1673,12 +1667,10 @@ def _get_post_pred_probs_and_weights(
         post_pred_probs = label_counts / num_annotations.reshape(-1, 1)
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return post_pred_probs, return_model_weight, return_annotator_weight
 
@@ -1846,12 +1838,10 @@ def _get_consensus_quality_score(
         consensus_quality_score = annotator_agreement
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid consensus quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return consensus_quality_score
 
@@ -1985,12 +1975,10 @@ def _get_annotator_quality(
                 )
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid annotator quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return annotator_quality
 

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -33,12 +33,14 @@ import pandas as pd
 
 from cleanlab.internal.constants import CLIPPING_LOWER_BOUND
 from cleanlab.internal.multiannotator_utils import (
+    _format_multilabel_multiannotator,
     assert_valid_inputs_multiannotator,
     assert_valid_pred_probs,
     check_consensus_label_classes,
     find_best_temp_scaler,
     temp_scale_pred_probs,
 )
+from cleanlab.internal.multilabel_utils import stack_complement
 from cleanlab.internal.util import get_num_classes, value_counts
 from cleanlab.rank import get_label_quality_scores
 
@@ -562,9 +564,11 @@ def get_label_quality_multiannotator_ensemble(
 
 
 def get_active_learning_scores(
-    labels_multiannotator: Optional[Union[pd.DataFrame, np.ndarray]] = None,
+    labels_multiannotator: Optional[Union[pd.DataFrame, np.ndarray, list]] = None,
     pred_probs: Optional[np.ndarray] = None,
     pred_probs_unlabeled: Optional[np.ndarray] = None,
+    *,
+    multi_label: bool = False,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Returns an ActiveLab quality score for each example in the dataset, to estimate which examples are most informative to (re)label next in active learning.
 
@@ -584,21 +588,30 @@ def get_active_learning_scores(
 
     Parameters
     ----------
-    labels_multiannotator : pd.DataFrame or np.ndarray, optional
+    labels_multiannotator : pd.DataFrame, np.ndarray, or list, optional
+        For standard multi-class classification:
         2D pandas DataFrame or array of multiple given labels for each example with shape ``(N, M)``,
         where N is the number of examples and M is the number of annotators. Note that this function also works with
         datasets where there is only one annotator (M=1).
         For more details, labels in the same format expected by the `~cleanlab.multiannotator.get_label_quality_multiannotator`.
         Note that examples that have no annotator labels should not be included in this DataFrame/array.
         This argument is optional if ``pred_probs`` is not provided (you might only provide ``pred_probs_unlabeled`` to only get active learning scores for the unlabeled examples).
+
+        For multi-label classification (when ``multi_label=True``):
+        Can be a 3D numpy array of shape ``(N, M, K)`` with binary indicators (0, 1, or ``NaN``);
+        a 2D pandas DataFrame or array of shape ``(N, M)`` where each entry is a collection (list/tuple/set) of integer class indices (e.g. ``[0, 2]`` or ``[]``) or ``NaN`` (if annotator did not label example);
+        or a 2D binary indicator array of shape ``(N, K)`` / ``List[List[int]]`` (single annotator M=1 case).
     pred_probs : np.ndarray, optional
         An array of shape ``(N, K)`` of predicted class probabilities from a trained classifier model.
         Predicted probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
+        For multi-label classification, ``pred_probs[i, k]`` is the predicted probability that class k applies to example i.
         This argument is optional if you only want to get active learning scores for unlabeled examples (specify only ``pred_probs_unlabeled`` instead).
     pred_probs_unlabeled : np.ndarray, optional
         An array of shape ``(N, K)`` of predicted class probabilities from a trained classifier model for examples that have no annotator labels.
         Predicted probabilities in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
         This argument is optional if you only want to get active learning scores for already-labeled examples (specify only ``pred_probs`` instead).
+    multi_label : bool, default = False
+        Set to ``True`` for multi-label datasets. When enabled, multi-label active learning scores are computed by decomposing into binary one-vs-rest per class and averaging the ActiveLab scores across all K classes.
 
     Returns
     -------
@@ -613,6 +626,16 @@ def get_active_learning_scores(
         Examples with the lowest scores are those we should label next in order to maximally improve our classifier model
         (scores for unlabeled data are directly comparable with the `active_learning_scores` for labeled data).
     """
+
+    if multi_label or (
+        isinstance(labels_multiannotator, np.ndarray) and labels_multiannotator.ndim == 3
+    ):
+        return _get_active_learning_scores_multilabel(
+            labels_multiannotator=labels_multiannotator,
+            pred_probs=pred_probs,
+            pred_probs_unlabeled=pred_probs_unlabeled,
+            ensemble=False,
+        )
 
     assert_valid_pred_probs(pred_probs=pred_probs, pred_probs_unlabeled=pred_probs_unlabeled)
 
@@ -727,9 +750,11 @@ def get_active_learning_scores(
 
 
 def get_active_learning_scores_ensemble(
-    labels_multiannotator: Optional[Union[pd.DataFrame, np.ndarray]] = None,
+    labels_multiannotator: Optional[Union[pd.DataFrame, np.ndarray, list]] = None,
     pred_probs: Optional[np.ndarray] = None,
     pred_probs_unlabeled: Optional[np.ndarray] = None,
+    *,
+    multi_label: bool = False,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Returns an ActiveLab quality score for each example in the dataset, based on predictions from an ensemble of models.
 
@@ -738,7 +763,7 @@ def get_active_learning_scores_ensemble(
 
     Parameters
     ----------
-    labels_multiannotator : pd.DataFrame or np.ndarray
+    labels_multiannotator : pd.DataFrame, np.ndarray, or list
         Multiannotator labels in the same format expected by `~cleanlab.multiannotator.get_active_learning_scores`.
         This argument is optional if ``pred_probs`` is not provided (in cases where you only provide ``pred_probs_unlabeled`` to get active learning scores for unlabeled examples).
     pred_probs : np.ndarray
@@ -751,6 +776,8 @@ def get_active_learning_scores_ensemble(
         for examples that have no annotated labels so far (but which we may want to label in the future, and hence compute active learning quality scores for).
         Each set of predicted probabilities with shape ``(N, K)`` is in the same format expected by the :py:func:`get_label_quality_scores <cleanlab.rank.get_label_quality_scores>`.
         This argument is optional if you only want to get active learning scores for labeled examples (pass in ``pred_probs`` instead).
+    multi_label : bool, default = False
+        Set to ``True`` for multi-label datasets. When enabled, multi-label active learning scores are computed by decomposing into binary one-vs-rest per class and averaging the ActiveLab scores across all K classes.
 
     Returns
     -------
@@ -763,6 +790,16 @@ def get_active_learning_scores_ensemble(
     --------
     get_active_learning_scores
     """
+
+    if multi_label or (
+        isinstance(labels_multiannotator, np.ndarray) and labels_multiannotator.ndim == 3
+    ):
+        return _get_active_learning_scores_multilabel(
+            labels_multiannotator=labels_multiannotator,
+            pred_probs=pred_probs,
+            pred_probs_unlabeled=pred_probs_unlabeled,
+            ensemble=True,
+        )
 
     assert_valid_pred_probs(
         pred_probs=pred_probs, pred_probs_unlabeled=pred_probs_unlabeled, ensemble=True
@@ -888,6 +925,128 @@ def get_active_learning_scores_ensemble(
         active_learning_scores_unlabeled = get_label_quality_scores(
             consensus_label_unlabeled, modified_pred_probs_unlabeled
         )
+    else:
+        active_learning_scores_unlabeled = np.array([])
+
+    return active_learning_scores, active_learning_scores_unlabeled
+
+
+def _get_active_learning_scores_multilabel(
+    labels_multiannotator: Optional[Union[pd.DataFrame, np.ndarray, list]] = None,
+    pred_probs: Optional[np.ndarray] = None,
+    pred_probs_unlabeled: Optional[np.ndarray] = None,
+    ensemble: bool = False,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Compute active learning scores for multi-label classification by decomposing into binary one-vs-rest per class."""
+    assert_valid_pred_probs(
+        pred_probs=pred_probs, pred_probs_unlabeled=pred_probs_unlabeled, ensemble=ensemble
+    )
+
+    if pred_probs is not None:
+        num_classes = pred_probs.shape[2] if ensemble else pred_probs.shape[1]
+    elif pred_probs_unlabeled is not None:
+        num_classes = pred_probs_unlabeled.shape[2] if ensemble else pred_probs_unlabeled.shape[1]
+    elif (
+        labels_multiannotator is not None
+        and isinstance(labels_multiannotator, np.ndarray)
+        and labels_multiannotator.ndim == 3
+    ):
+        num_classes = labels_multiannotator.shape[2]
+    else:
+        raise ValueError(
+            "pred_probs and pred_probs_unlabeled cannot both be None, specify at least one of the two."
+        )
+
+    if pred_probs is not None:
+        if labels_multiannotator is None:
+            raise ValueError(
+                "labels_multiannotator cannot be None when passing in pred_probs. ",
+                "Either provide labels_multiannotator to obtain active learning scores for the labeled examples, "
+                "or just pass in pred_probs_unlabeled to get active learning scores for unlabeled examples.",
+            )
+        y_list, annotator_ids = _format_multilabel_multiannotator(
+            labels_multiannotator, num_classes=num_classes
+        )
+        N = pred_probs.shape[1] if ensemble else len(pred_probs)
+        if len(y_list[0]) != N:
+            raise ValueError("labels_multiannotator and pred_probs must have the same length.")
+
+        annotator_labeled_any = np.zeros(y_list[0].shape, dtype=bool)
+        for y_k in y_list:
+            annotator_labeled_any |= ~np.isnan(y_k)
+
+        nan_row_mask = ~annotator_labeled_any.any(axis=1)
+        if nan_row_mask.any():
+            nan_rows = list(np.where(nan_row_mask)[0])
+            raise ValueError(
+                "labels_multiannotator cannot have rows with all NaN, each example must have at least one label.\n"
+                f"Examples {nan_rows} do not have any labels."
+            )
+
+        nan_col_mask = ~annotator_labeled_any.any(axis=0)
+        if nan_col_mask.any():
+            if annotator_ids is not None:
+                nan_cols = list(annotator_ids[np.where(nan_col_mask)[0]])
+            else:
+                nan_cols = list(np.where(nan_col_mask)[0])
+            raise ValueError(
+                "labels_multiannotator cannot have columns with all NaN, each annotator must label at least one example.\n"
+                f"Annotators {nan_cols} did not label any examples."
+            )
+    else:
+        y_list = None
+
+    scores_labeled_per_class = []
+    scores_unlabeled_per_class = []
+
+    for k in range(num_classes):
+        if ensemble:
+            pred_probs_k = (
+                np.array([stack_complement(p[:, k]) for p in pred_probs])
+                if pred_probs is not None
+                else None
+            )
+            pred_probs_unlabeled_k = (
+                np.array([stack_complement(p[:, k]) for p in pred_probs_unlabeled])
+                if pred_probs_unlabeled is not None
+                else None
+            )
+            s_lab, s_unlab = get_active_learning_scores_ensemble(
+                labels_multiannotator=y_list[k] if y_list is not None else None,
+                pred_probs=pred_probs_k,
+                pred_probs_unlabeled=pred_probs_unlabeled_k,
+                multi_label=False,
+            )
+        else:
+            pred_probs_k = (
+                stack_complement(pred_probs[:, k])
+                if pred_probs is not None
+                else None
+            )
+            pred_probs_unlabeled_k = (
+                stack_complement(pred_probs_unlabeled[:, k])
+                if pred_probs_unlabeled is not None
+                else None
+            )
+            s_lab, s_unlab = get_active_learning_scores(
+                labels_multiannotator=y_list[k] if y_list is not None else None,
+                pred_probs=pred_probs_k,
+                pred_probs_unlabeled=pred_probs_unlabeled_k,
+                multi_label=False,
+            )
+
+        if pred_probs is not None:
+            scores_labeled_per_class.append(s_lab)
+        if pred_probs_unlabeled is not None:
+            scores_unlabeled_per_class.append(s_unlab)
+
+    if pred_probs is not None:
+        active_learning_scores = np.mean(scores_labeled_per_class, axis=0)
+    else:
+        active_learning_scores = np.array([])
+
+    if pred_probs_unlabeled is not None:
+        active_learning_scores_unlabeled = np.mean(scores_unlabeled_per_class, axis=0)
     else:
         active_learning_scores_unlabeled = np.array([])
 

--- a/cleanlab/multilabel_classification/rank.py
+++ b/cleanlab/multilabel_classification/rank.py
@@ -14,7 +14,6 @@ from cleanlab.internal.util import get_num_classes
 from cleanlab.internal.multilabel_utils import int2onehot
 from cleanlab.internal.multilabel_scorer import MultilabelScorer, ClassLabelScorer, Aggregator
 
-
 if TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
 

--- a/cleanlab/object_detection/rank.py
+++ b/cleanlab/object_detection/rank.py
@@ -26,7 +26,6 @@ from cleanlab.internal.object_detection_utils import (
     assert_valid_inputs,
 )
 
-
 if TYPE_CHECKING:  # pragma: no cover
     from typing import TypedDict
 
@@ -144,11 +143,9 @@ def issues_from_scores(label_quality_scores: np.ndarray, *, threshold: float = 0
     """
 
     if threshold > 1.0:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             Threshold is a cutoff of label_quality_scores and therefore should be <= 1.
-            """
-        )
+            """)
 
     issue_indices = np.argwhere(label_quality_scores <= threshold).flatten()
     issue_vals = label_quality_scores[issue_indices]

--- a/cleanlab/outlier.py
+++ b/cleanlab/outlier.py
@@ -569,12 +569,10 @@ def _get_ood_predictions_scores(
             1 - np.sum(probs_sorted**gamma * (1 - probs_sorted) ** (gamma), axis=1) / M
         )  # Use 1 + original gen score/M to make the scores lie in 0-1
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {method} is not a valid OOD scoring method!
             Please choose a valid scoring_method: {valid_methods}
-            """
-        )
+            """)
 
     return (
         ood_predictions_scores,

--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -137,12 +137,10 @@ def _compute_label_quality_scores(
     try:
         scoring_func = scoring_funcs[method]
     except KeyError:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {method} is not a valid scoring method for rank_by!
             Please choose a valid rank_by: self_confidence, normalized_margin, confidence_weighted_entropy
-            """
-        )
+            """)
     if adjust_pred_probs:
         if method == "confidence_weighted_entropy":
             raise ValueError(f"adjust_pred_probs is not currently supported for {method}.")
@@ -236,23 +234,19 @@ def get_label_quality_ensemble_scores(
     assert len(pred_probs_list) > 0, "pred_probs_list is empty."
 
     if len(pred_probs_list) == 1:
-        warnings.warn(
-            """
+        warnings.warn("""
             pred_probs_list only has one element.
             Consider using get_label_quality_scores() if you only have a single array of pred_probs.
-            """
-        )
+            """)
 
     for pred_probs in pred_probs_list:
         assert_valid_inputs(X=None, y=labels, pred_probs=pred_probs, multi_label=False)
 
     # Raise ValueError if user passed custom_weights array but did not choose weight_ensemble_members_by="custom"
     if custom_weights is not None and weight_ensemble_members_by != "custom":
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             custom_weights provided but weight_ensemble_members_by is not "custom"!
-            """
-        )
+            """)
 
     # This weighting scheme performs search of t in log_loss_search_T_values for "best" log loss
     if weight_ensemble_members_by == "log_loss_search":
@@ -356,12 +350,10 @@ def get_label_quality_ensemble_scores(
         label_quality_scores = (scores_ensemble * custom_weights).sum(axis=1)
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {weight_ensemble_members_by} is not a valid weighting method for weight_ensemble_members_by!
             Please choose a valid weight_ensemble_members_by: uniform, accuracy, custom
-            """
-        )
+            """)
 
     return label_quality_scores
 

--- a/cleanlab/regression/rank.py
+++ b/cleanlab/regression/rank.py
@@ -75,12 +75,10 @@ def get_label_quality_scores(
 
     scoring_func = scoring_funcs.get(method, None)
     if not scoring_func:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {method} is not a valid scoring method.
             Please choose a valid scoring technique: {scoring_funcs.keys()}.
-            """
-        )
+            """)
 
     # Calculate scores
     label_quality_scores = scoring_func(labels, predictions)

--- a/tests/datalab/datalab/test_datalab.py
+++ b/tests/datalab/datalab/test_datalab.py
@@ -23,7 +23,6 @@ from cleanlab.datalab.internal.issue_manager.knn_graph_helpers import num_neighb
 from cleanlab.datalab.internal.report import Reporter
 from cleanlab.datalab.internal.task import Task
 
-
 SEED = 42
 
 

--- a/tests/datalab/datalab/test_regression.py
+++ b/tests/datalab/datalab/test_regression.py
@@ -4,7 +4,6 @@ import pytest
 from sklearn.neighbors import NearestNeighbors
 from cleanlab.datalab.datalab import Datalab
 
-
 SEED = 42
 
 

--- a/tests/datalab/test_data.py
+++ b/tests/datalab/test_data.py
@@ -9,7 +9,6 @@ from hypothesis import given, assume, settings, HealthCheck
 
 from cleanlab.datalab.internal.task import Task
 
-
 NUM_COLS = 2
 
 

--- a/tests/test_multiannotator.py
+++ b/tests/test_multiannotator.py
@@ -1076,3 +1076,74 @@ def test_multilabel_active_learning_errors_and_edge_cases():
         labels_multiannotator=all_zeros_df, pred_probs=pred_probs, multi_label=True
     )
     assert len(scores_lab) == 2
+
+
+def test_format_multilabel_multiannotator_vectorized():
+    from cleanlab.internal.multiannotator_utils import _format_multilabel_multiannotator
+
+    df = pd.DataFrame(
+        {
+            "a1": [[0, 2], [1], [], np.nan],
+            "a2": [[0], np.nan, [1, 2], []],
+        }
+    )
+    y_list, annotator_ids = _format_multilabel_multiannotator(df, num_classes=3)
+    assert len(y_list) == 3
+    assert list(annotator_ids) == ["a1", "a2"]
+    for y_k in y_list:
+        assert y_k.dtype == np.float32
+
+    # Check values
+    np.testing.assert_array_equal(y_list[0][:, 0], [1.0, 0.0, 0.0, np.nan])
+    np.testing.assert_array_equal(y_list[0][:, 1], [1.0, np.nan, 0.0, 0.0])
+    np.testing.assert_array_equal(y_list[1][:, 0], [0.0, 1.0, 0.0, np.nan])
+    np.testing.assert_array_equal(y_list[1][:, 1], [0.0, np.nan, 1.0, 0.0])
+    np.testing.assert_array_equal(y_list[2][:, 0], [1.0, 0.0, 0.0, np.nan])
+    np.testing.assert_array_equal(y_list[2][:, 1], [0.0, np.nan, 1.0, 0.0])
+
+
+def test_multilabel_active_learning_zero_positive_classes():
+    df_labels = pd.DataFrame(
+        {
+            "a1": [[0], [1], [0], []],
+            "a2": [[0], [0], [1], [0]],
+        }
+    )
+    pred_probs = np.array(
+        [
+            [0.9, 0.1, 0.01],
+            [0.1, 0.9, 0.02],
+            [0.8, 0.2, 0.01],
+            [0.2, 0.1, 0.05],
+        ]
+    )
+    pred_probs_unlab = np.array(
+        [
+            [0.5, 0.5, 0.1],
+            [0.8, 0.1, 0.05],
+        ]
+    )
+    scores_lab, scores_unlab = get_active_learning_scores(
+        labels_multiannotator=df_labels,
+        pred_probs=pred_probs,
+        pred_probs_unlabeled=pred_probs_unlab,
+        multi_label=True,
+    )
+    assert len(scores_lab) == 4
+    assert len(scores_unlab) == 2
+    assert np.all((scores_lab >= 0.0) & (scores_lab <= 1.0))
+    assert np.all((scores_unlab >= 0.0) & (scores_unlab <= 1.0))
+
+    pred_probs_ens = np.array([pred_probs, pred_probs])
+    pred_probs_unlab_ens = np.array([pred_probs_unlab, pred_probs_unlab])
+    scores_lab_ens, scores_unlab_ens = get_active_learning_scores_ensemble(
+        labels_multiannotator=df_labels,
+        pred_probs=pred_probs_ens,
+        pred_probs_unlabeled=pred_probs_unlab_ens,
+        multi_label=True,
+    )
+    assert len(scores_lab_ens) == 4
+    assert len(scores_unlab_ens) == 2
+    assert np.all((scores_lab_ens >= 0.0) & (scores_lab_ens <= 1.0))
+    assert np.all((scores_unlab_ens >= 0.0) & (scores_unlab_ens <= 1.0))
+

--- a/tests/test_multiannotator.py
+++ b/tests/test_multiannotator.py
@@ -7,21 +7,15 @@ from sklearn.linear_model import LogisticRegression
 
 from cleanlab import count
 from cleanlab.benchmarking.noise_generation import (
-    generate_noise_matrix_from_trace,
-    generate_noisy_labels,
-)
+    generate_noise_matrix_from_trace, generate_noisy_labels)
 from cleanlab.internal.multiannotator_utils import (
-    assert_valid_inputs_multiannotator,
-    format_multiannotator_labels,
-)
-from cleanlab.multiannotator import (
-    convert_long_to_wide_dataset,
-    get_active_learning_scores,
-    get_active_learning_scores_ensemble,
-    get_label_quality_multiannotator,
-    get_label_quality_multiannotator_ensemble,
-    get_majority_vote_label,
-)
+    assert_valid_inputs_multiannotator, format_multiannotator_labels)
+from cleanlab.multiannotator import (convert_long_to_wide_dataset,
+                                     get_active_learning_scores,
+                                     get_active_learning_scores_ensemble,
+                                     get_label_quality_multiannotator,
+                                     get_label_quality_multiannotator_ensemble,
+                                     get_majority_vote_label)
 
 
 def make_data(
@@ -1079,7 +1073,8 @@ def test_multilabel_active_learning_errors_and_edge_cases():
 
 
 def test_format_multilabel_multiannotator_vectorized():
-    from cleanlab.internal.multiannotator_utils import _format_multilabel_multiannotator
+    from cleanlab.internal.multiannotator_utils import \
+        _format_multilabel_multiannotator
 
     df = pd.DataFrame(
         {
@@ -1146,4 +1141,3 @@ def test_multilabel_active_learning_zero_positive_classes():
     assert len(scores_unlab_ens) == 2
     assert np.all((scores_lab_ens >= 0.0) & (scores_lab_ens <= 1.0))
     assert np.all((scores_unlab_ens >= 0.0) & (scores_unlab_ens <= 1.0))
-

--- a/tests/test_multiannotator.py
+++ b/tests/test_multiannotator.py
@@ -820,3 +820,259 @@ def test_assert_valid_inputs_multiannotator_warnings(recwarn):
     assert_valid_inputs_multiannotator(agree_labels)
     # Assert no new warning were raised
     assert len(recwarn) == 0
+
+
+def test_get_active_learning_scores_multilabel():
+    df_labels = pd.DataFrame(
+        {
+            "annotator_0": [[0, 1], [1], [], np.nan, [0, 2]],
+            "annotator_1": [[0], np.nan, [0, 1], [], [2]],
+            "annotator_2": [np.nan, [0, 1], [1], [0], [1, 2]],
+        }
+    )
+    pred_probs = np.array(
+        [
+            [0.9, 0.8, 0.1],
+            [0.1, 0.95, 0.05],
+            [0.2, 0.7, 0.1],
+            [0.8, 0.1, 0.05],
+            [0.1, 0.8, 0.9],
+        ]
+    )
+    pred_probs_unlabeled = np.array(
+        [
+            [0.5, 0.5, 0.5],
+            [0.9, 0.1, 0.05],
+            [0.1, 0.2, 0.8],
+        ]
+    )
+
+    scores_lab, scores_unlab = get_active_learning_scores(
+        labels_multiannotator=df_labels,
+        pred_probs=pred_probs,
+        pred_probs_unlabeled=pred_probs_unlabeled,
+        multi_label=True,
+    )
+
+    assert isinstance(scores_lab, np.ndarray)
+    assert isinstance(scores_unlab, np.ndarray)
+    assert len(scores_lab) == len(df_labels)
+    assert len(scores_unlab) == len(pred_probs_unlabeled)
+    assert np.all((scores_lab >= 0.0) & (scores_lab <= 1.0))
+    assert np.all((scores_unlab >= 0.0) & (scores_unlab <= 1.0))
+
+    # Test labeled only
+    scores_lab_only, scores_unlab_empty = get_active_learning_scores(
+        labels_multiannotator=df_labels,
+        pred_probs=pred_probs,
+        multi_label=True,
+    )
+    assert len(scores_lab_only) == len(df_labels)
+    assert len(scores_unlab_empty) == 0
+    assert np.allclose(scores_lab, scores_lab_only)
+
+    # Test unlabeled only
+    scores_lab_empty, scores_unlab_only = get_active_learning_scores(
+        pred_probs_unlabeled=pred_probs_unlabeled,
+        multi_label=True,
+    )
+    assert len(scores_lab_empty) == 0
+    assert len(scores_unlab_only) == len(pred_probs_unlabeled)
+
+
+def test_get_active_learning_scores_multilabel_3d_array():
+    labels_3d = np.array(
+        [
+            [[1.0, 1.0, 0.0], [1.0, 0.0, 0.0], [np.nan, np.nan, np.nan]],
+            [[0.0, 1.0, 0.0], [np.nan, np.nan, np.nan], [1.0, 1.0, 0.0]],
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
+            [[np.nan, np.nan, np.nan], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+            [[1.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 1.0, 1.0]],
+        ]
+    )
+    pred_probs = np.array(
+        [
+            [0.9, 0.8, 0.1],
+            [0.1, 0.95, 0.05],
+            [0.2, 0.7, 0.1],
+            [0.8, 0.1, 0.05],
+            [0.1, 0.8, 0.9],
+        ]
+    )
+
+    # Test auto-detection with 3D array (multi_label=False default)
+    scores_lab_auto, _ = get_active_learning_scores(
+        labels_multiannotator=labels_3d,
+        pred_probs=pred_probs,
+    )
+    # Test explicit multi_label=True with 3D array
+    scores_lab_explicit, _ = get_active_learning_scores(
+        labels_multiannotator=labels_3d,
+        pred_probs=pred_probs,
+        multi_label=True,
+    )
+    assert np.allclose(scores_lab_auto, scores_lab_explicit)
+
+
+def test_get_active_learning_scores_multilabel_single_annotator():
+    single_labels_list = [[0, 1], [1], [], [0], [0, 2]]
+    single_labels_binary = np.array(
+        [
+            [1, 1, 0],
+            [0, 1, 0],
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 0, 1],
+        ]
+    )
+    pred_probs = np.array(
+        [
+            [0.9, 0.8, 0.1],
+            [0.1, 0.95, 0.05],
+            [0.2, 0.7, 0.1],
+            [0.8, 0.1, 0.05],
+            [0.1, 0.8, 0.9],
+        ]
+    )
+    scores_list, _ = get_active_learning_scores(
+        labels_multiannotator=single_labels_list,
+        pred_probs=pred_probs,
+        multi_label=True,
+    )
+    scores_binary, _ = get_active_learning_scores(
+        labels_multiannotator=single_labels_binary,
+        pred_probs=pred_probs,
+        multi_label=True,
+    )
+    assert len(scores_list) == len(single_labels_list)
+    assert np.allclose(scores_list, scores_binary)
+
+
+def test_get_active_learning_scores_ensemble_multilabel():
+    df_labels = pd.DataFrame(
+        {
+            "annotator_0": [[0, 1], [1], [], np.nan, [0, 2]],
+            "annotator_1": [[0], np.nan, [0, 1], [], [2]],
+            "annotator_2": [np.nan, [0, 1], [1], [0], [1, 2]],
+        }
+    )
+    pred_probs_m1 = np.array(
+        [
+            [0.9, 0.8, 0.1],
+            [0.1, 0.95, 0.05],
+            [0.2, 0.7, 0.1],
+            [0.8, 0.1, 0.05],
+            [0.1, 0.8, 0.9],
+        ]
+    )
+    pred_probs_m2 = np.array(
+        [
+            [0.85, 0.75, 0.15],
+            [0.15, 0.90, 0.1],
+            [0.25, 0.65, 0.15],
+            [0.75, 0.15, 0.1],
+            [0.15, 0.75, 0.85],
+        ]
+    )
+    pred_probs_ens = np.array([pred_probs_m1, pred_probs_m2])
+
+    pred_probs_unlab_m1 = np.array(
+        [
+            [0.5, 0.5, 0.5],
+            [0.9, 0.1, 0.05],
+        ]
+    )
+    pred_probs_unlab_m2 = np.array(
+        [
+            [0.55, 0.45, 0.5],
+            [0.85, 0.15, 0.1],
+        ]
+    )
+    pred_probs_unlab_ens = np.array([pred_probs_unlab_m1, pred_probs_unlab_m2])
+
+    scores_lab, scores_unlab = get_active_learning_scores_ensemble(
+        labels_multiannotator=df_labels,
+        pred_probs=pred_probs_ens,
+        pred_probs_unlabeled=pred_probs_unlab_ens,
+        multi_label=True,
+    )
+    assert len(scores_lab) == len(df_labels)
+    assert len(scores_unlab) == len(pred_probs_unlab_m1)
+    assert np.all((scores_lab >= 0.0) & (scores_lab <= 1.0))
+    assert np.all((scores_unlab >= 0.0) & (scores_unlab <= 1.0))
+
+    # Test unlabeled only ensemble
+    scores_lab_empty, scores_unlab_only = get_active_learning_scores_ensemble(
+        pred_probs_unlabeled=pred_probs_unlab_ens,
+        multi_label=True,
+    )
+    assert len(scores_lab_empty) == 0
+    assert len(scores_unlab_only) == len(pred_probs_unlab_m1)
+
+
+def test_multilabel_active_learning_errors_and_edge_cases():
+    # Missing both pred_probs and pred_probs_unlabeled
+    with pytest.raises(ValueError, match="cannot both be None"):
+        get_active_learning_scores(multi_label=True)
+
+    # Labeled pred_probs given without labels_multiannotator
+    pred_probs = np.array([[0.5, 0.5], [0.8, 0.2]])
+    with pytest.raises(ValueError, match="labels_multiannotator cannot be None"):
+        get_active_learning_scores(pred_probs=pred_probs, multi_label=True)
+
+    # Mismatched length between labels and pred_probs
+    df_labels = pd.DataFrame({"a": [[0], [1], [0]]})
+    with pytest.raises(ValueError, match="same length"):
+        get_active_learning_scores(
+            labels_multiannotator=df_labels, pred_probs=pred_probs, multi_label=True
+        )
+
+    # All-NaN row in labels_multiannotator
+    all_nan_row_df = pd.DataFrame(
+        {
+            "a1": [[0], np.nan],
+            "a2": [[1], np.nan],
+        }
+    )
+    with pytest.raises(ValueError, match="rows with all NaN"):
+        get_active_learning_scores(
+            labels_multiannotator=all_nan_row_df, pred_probs=pred_probs, multi_label=True
+        )
+
+    # All-NaN column in labels_multiannotator
+    all_nan_col_df = pd.DataFrame(
+        {
+            "a1": [[0], [1]],
+            "a2": [np.nan, np.nan],
+        }
+    )
+    with pytest.raises(ValueError, match="columns with all NaN"):
+        get_active_learning_scores(
+            labels_multiannotator=all_nan_col_df, pred_probs=pred_probs, multi_label=True
+        )
+
+    # Class index out of bounds
+    out_of_bounds_df = pd.DataFrame({"a1": [[0], [5]], "a2": [[1], [0]]})
+    with pytest.raises(ValueError, match="out of bounds"):
+        get_active_learning_scores(
+            labels_multiannotator=out_of_bounds_df, pred_probs=pred_probs, multi_label=True
+        )
+
+    # 3D array invalid values
+    bad_3d = np.array([[[2.0, 0.0], [1.0, 0.0]], [[0.0, 1.0], [0.0, 0.0]]])
+    with pytest.raises(ValueError, match="only 0, 1, or NaN"):
+        get_active_learning_scores(
+            labels_multiannotator=bad_3d, pred_probs=pred_probs, multi_label=True
+        )
+
+    # Class with all zeros across annotators
+    all_zeros_df = pd.DataFrame(
+        {
+            "a1": [[0], []],
+            "a2": [[0], [0]],
+        }
+    )
+    scores_lab, _ = get_active_learning_scores(
+        labels_multiannotator=all_zeros_df, pred_probs=pred_probs, multi_label=True
+    )
+    assert len(scores_lab) == 2

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -10,7 +10,6 @@ from cleanlab.internal.multilabel_utils import int2onehot, onehot2int
 from cleanlab.internal.util import num_unique_classes, format_labels, get_missing_classes
 from cleanlab.internal.validation import assert_valid_class_labels
 
-
 noise_matrix = np.array([[1.0, 0.0, 0.2], [0.0, 0.7, 0.2], [0.0, 0.3, 0.6]])
 
 noise_matrix_2 = np.array(


### PR DESCRIPTION
## Description & Motivation

Fixes #930

Extends ActiveLab active learning with multiple annotators (get_active_learning_scores and get_active_learning_scores_ensemble) to support **multi-label classification** datasets.

In multi-label classification, each example can belong to zero, one, or multiple classes simultaneously. Active learning scoring for multi-label datasets with multiple annotators is performed by:
1. Decomposing the dataset into $ binary one-vs-rest tasks (one per class  \in \{0, \dots, K-1\}$).
2. For each class $, constructing the binary multi-annotator label matrix  \in \{0, 1, \text{NaN}\}^{N \times M}$ and binary predicted class probabilities $[1 - p_k, p_k]$.
3. Computing binary ActiveLab quality scores using get_active_learning_scores (or get_active_learning_scores_ensemble).
4. Averaging the active learning quality scores across all $ classes for each example.

### Key Changes
- **cleanlab.multiannotator.get_active_learning_scores & get_active_learning_scores_ensemble**:
  - Added multi_label: bool = False argument.
  - Added multi-label input parsing and one-vs-rest decomposition for both labeled and unlabeled examples.
  - Supports multiple flexible multi-label input formats:
    - 3D binary NumPy arrays of shape (N, M, K) with values in {0, 1, NaN} (auto-detected).
    - 2D pandas DataFrames or object NumPy arrays of shape (N, M) where cells are collections (e.g. [0, 2], []) or NaN/None.
    - Single-annotator 2D binary indicator arrays (N, K) or List[List[int]] (length $).
- **cleanlab.internal.multiannotator_utils._format_multilabel_multiannotator**:
  - Validates and formats multi-label multi-annotator inputs into $ binary matrices of shape (N, M).
- **	ests/test_multiannotator.py**:
  - Added comprehensive unit tests covering:
    - Multi-label active learning with pandas DataFrame input (labeled, unlabeled, and both).
    - Multi-label active learning with 3D array input and auto-detection.
    - Single-annotator multi-label active learning.
    - Multi-label active learning with model ensembles (get_active_learning_scores_ensemble).
    - Error handling, edge cases, class-out-of-bounds, all-zero classes, and NaN validations.

### Test Verification
All 18 unit tests in 	ests/test_multiannotator.py pass cleanly.
