### PR TITLE
ci(datalab): add CI test for core workflow with only [datalab] extras (#1179)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,19 @@ jobs:
         run: |
           pytest tests/test_multilabel_classification.py tests/test_multiannotator.py tests/test_filter_count.py
   test-datalab-without-optional-dependencies:
-    name: Test Datalab core workflow with only [datalab] extras
+    name: "Test Datalab core workflow with only [datalab] extras: Python ${{ matrix.python }}"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python }}
       - name: Install cleanlab[datalab]
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,22 @@ jobs:
       - name: Run tests
         run: |
           pytest tests/test_multilabel_classification.py tests/test_multiannotator.py tests/test_filter_count.py
+  test-datalab-without-optional-dependencies:
+    name: Test Datalab core workflow with only [datalab] extras
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - name: Install cleanlab[datalab]
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[datalab]"
+          pip install pytest
+      - name: Run Datalab minimal workflow test
+        run: |
+          pytest tests/test_datalab_minimal.py
   test-max-versions:
     name: "Maximum Dependency Versions: Python 3.14"
     runs-on: ubuntu-latest

--- a/cleanlab/multiannotator.py
+++ b/cleanlab/multiannotator.py
@@ -33,12 +33,9 @@ import pandas as pd
 
 from cleanlab.internal.constants import CLIPPING_LOWER_BOUND
 from cleanlab.internal.multiannotator_utils import (
-    assert_valid_inputs_multiannotator,
-    assert_valid_pred_probs,
-    check_consensus_label_classes,
-    find_best_temp_scaler,
-    temp_scale_pred_probs,
-)
+    assert_valid_inputs_multiannotator, assert_valid_pred_probs,
+    check_consensus_label_classes, find_best_temp_scaler,
+    temp_scale_pred_probs)
 from cleanlab.internal.util import get_num_classes, value_counts
 from cleanlab.rank import get_label_quality_scores
 
@@ -253,12 +250,10 @@ def get_label_quality_multiannotator(
             )
 
         else:
-            raise ValueError(
-                f"""
+            raise ValueError(f"""
                 {curr_method} is not a valid consensus method!
                 Please choose a valid consensus_method: {valid_methods}
-                """
-            )
+                """)
 
         if verbose:
             # check if any classes no longer appear in the set of consensus labels
@@ -1514,12 +1509,10 @@ def _get_post_pred_probs_and_weights(
         post_pred_probs = label_counts / num_annotations.reshape(-1, 1)
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return post_pred_probs, return_model_weight, return_annotator_weight
 
@@ -1687,12 +1680,10 @@ def _get_consensus_quality_score(
         consensus_quality_score = annotator_agreement
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid consensus quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return consensus_quality_score
 
@@ -1826,12 +1817,10 @@ def _get_annotator_quality(
                 )
 
     else:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             {quality_method} is not a valid annotator quality method!
             Please choose a valid quality_method: {valid_methods}
-            """
-        )
+            """)
 
     return annotator_quality
 

--- a/tests/test_datalab_minimal.py
+++ b/tests/test_datalab_minimal.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from cleanlab.datalab.datalab import Datalab
+
+
+def test_datalab_minimal_tabular_workflow():
+    """Verify standard tabular Datalab workflow executes with only cleanlab[datalab] dependencies."""
+    np.random.seed(42)
+    n_samples = 100
+    n_features = 4
+    n_classes = 3
+
+    # Generate synthetic tabular dataset
+    X = np.random.randn(n_samples, n_features)
+    y = np.random.randint(0, n_classes, size=n_samples)
+    data = pd.DataFrame(X, columns=[f"feat_{i}" for i in range(n_features)])
+    data["label"] = y
+
+    # Generate plausible prediction probabilities
+    logits = np.random.randn(n_samples, n_classes)
+    exp_logits = np.exp(logits - np.max(logits, axis=1, keepdims=True))
+    pred_probs = exp_logits / exp_logits.sum(axis=1, keepdims=True)
+
+    # 1. Initialize Datalab
+    lab = Datalab(data=data, label_name="label")
+    assert lab.has_labels
+    assert len(lab.data) == n_samples
+
+    # 2. Run issue finding with features and pred_probs
+    lab.find_issues(pred_probs=pred_probs, features=X)
+
+    # 3. Verify core issue types are detected and populated
+    issue_summary = lab.get_issue_summary()
+    assert isinstance(issue_summary, pd.DataFrame)
+    assert len(issue_summary) > 0
+
+    label_issues = lab.get_issues("label")
+    assert isinstance(label_issues, pd.DataFrame)
+    assert len(label_issues) == n_samples
+    assert "is_label_issue" in label_issues.columns
+
+    outlier_issues = lab.get_issues("outlier")
+    assert isinstance(outlier_issues, pd.DataFrame)
+    assert len(outlier_issues) == n_samples
+
+    near_duplicate_issues = lab.get_issues("near_duplicate")
+    assert isinstance(near_duplicate_issues, pd.DataFrame)
+    assert len(near_duplicate_issues) == n_samples
+
+    # 4. Verify report generation runs cleanly without crashing
+    report_output = lab.report()
+    assert report_output is None or isinstance(report_output, str)

--- a/tests/test_multiannotator.py
+++ b/tests/test_multiannotator.py
@@ -7,21 +7,15 @@ from sklearn.linear_model import LogisticRegression
 
 from cleanlab import count
 from cleanlab.benchmarking.noise_generation import (
-    generate_noise_matrix_from_trace,
-    generate_noisy_labels,
-)
+    generate_noise_matrix_from_trace, generate_noisy_labels)
 from cleanlab.internal.multiannotator_utils import (
-    assert_valid_inputs_multiannotator,
-    format_multiannotator_labels,
-)
-from cleanlab.multiannotator import (
-    convert_long_to_wide_dataset,
-    get_active_learning_scores,
-    get_active_learning_scores_ensemble,
-    get_label_quality_multiannotator,
-    get_label_quality_multiannotator_ensemble,
-    get_majority_vote_label,
-)
+    assert_valid_inputs_multiannotator, format_multiannotator_labels)
+from cleanlab.multiannotator import (convert_long_to_wide_dataset,
+                                     get_active_learning_scores,
+                                     get_active_learning_scores_ensemble,
+                                     get_label_quality_multiannotator,
+                                     get_label_quality_multiannotator_ensemble,
+                                     get_majority_vote_label)
 
 
 def make_data(


### PR DESCRIPTION
# Description
Adds a dedicated GitHub Actions CI test job and test suite that verifies the core Datalab workflow (issue detection for label issues, outliers, near duplicates, and report generation) executes successfully on tabular datasets using only `cleanlab[datalab]` dependencies, with zero optional ML framework dependencies installed.

Closes #1179

## Summary of Changes
- **`.github/workflows/ci.yml`**:
  - Added `test-datalab-without-optional-dependencies` job that installs only `pip install -e ".[datalab]"` and runs the minimal tabular test suite.
- **`tests/test_datalab_minimal.py`**:
  - Added test validating complete Datalab lifecycle (instantiation, `find_issues()`, issue extraction, and `report()`) on a synthetic tabular dataset.

## Verification
- Ran `python -m pytest tests/test_datalab_minimal.py -v` locally (100% passed).