### PR TITLE
fix: pass confident_joint to _get_num_examples in rank_classes_by_label_quality and health_summary

### DIFF
--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -83,7 +83,7 @@ def rank_classes_by_label_quality(
             confident_joint=confident_joint,
         )
     if num_examples is None:
-        num_examples = _get_num_examples(labels=labels)
+        num_examples = _get_num_examples(labels=labels, confident_joint=confident_joint)
     given_label_noise = joint.sum(axis=1) - joint.diagonal()  # p(s=k) - p(s=k,y=k) = p(y!=k, s=k)
     true_label_noise = joint.sum(axis=0) - joint.diagonal()  # p(y=k) - p(s=k,y=k) = p(s!=k,y=k)
     given_conditional_noise = given_label_noise / np.clip(
@@ -421,7 +421,7 @@ def health_summary(
             confident_joint=confident_joint,
         )
     if num_examples is None:
-        num_examples = _get_num_examples(labels=labels)
+        num_examples = _get_num_examples(labels=labels, confident_joint=confident_joint)
 
     if verbose:
         longest_line = (

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -562,3 +562,17 @@ def test_find_overlapping_classes_with_confident_joint(confident_joint):
     # Joint probabilities sorted in descending order
     if K > 2:
         assert (overlapping_classes["Joint Probability"].diff()[1:] <= 0).all()
+
+
+def test_rank_classes_and_health_summary_with_confident_joint():
+    cj = np.array([[10, 2], [1, 15]])
+    # rank_classes_by_label_quality with confident_joint and no labels
+    df_classes = rank_classes_by_label_quality(confident_joint=cj)
+    assert len(df_classes) == 2
+    assert "Label Issues" in df_classes.columns
+    assert "Label Quality Score" in df_classes.columns
+
+    # health_summary with confident_joint and no labels
+    summary = health_summary(confident_joint=cj, verbose=False)
+    assert "overall_label_health_score" in summary
+    assert "classes_by_label_quality" in summary


### PR DESCRIPTION
### Summary

Fixes #1329

When calling `rank_classes_by_label_quality(confident_joint=...)` or `health_summary(confident_joint=...)` without passing `labels`, a `ValueError` was raised because `_get_num_examples` was called with only `labels=labels` and `confident_joint` remained unset (`None`).

### Changes
- Forward `confident_joint=confident_joint` to `_get_num_examples` in both `rank_classes_by_label_quality` and `health_summary` within `cleanlab/dataset.py`.
- Added unit regression tests in `tests/test_dataset.py` verifying that both functions execute without errors when passing `confident_joint` without `labels`.
