### PR TITLE
fix(dataset): support standalone confident_joint in rank_classes_by_label_quality and health_summary (#1329)

### DIFF
--- a/cleanlab/dataset.py
+++ b/cleanlab/dataset.py
@@ -6,6 +6,7 @@ and which classes to merge (see `~cleanlab.dataset.find_overlapping_classes`).
 """
 
 from typing import Optional, cast
+
 import numpy as np
 import pandas as pd
 
@@ -83,7 +84,7 @@ def rank_classes_by_label_quality(
             confident_joint=confident_joint,
         )
     if num_examples is None:
-        num_examples = _get_num_examples(labels=labels)
+        num_examples = _get_num_examples(labels=labels, confident_joint=confident_joint)
     given_label_noise = joint.sum(axis=1) - joint.diagonal()  # p(s=k) - p(s=k,y=k) = p(y!=k, s=k)
     true_label_noise = joint.sum(axis=0) - joint.diagonal()  # p(y=k) - p(s=k,y=k) = p(s!=k,y=k)
     given_conditional_noise = given_label_noise / np.clip(
@@ -421,7 +422,7 @@ def health_summary(
             confident_joint=confident_joint,
         )
     if num_examples is None:
-        num_examples = _get_num_examples(labels=labels)
+        num_examples = _get_num_examples(labels=labels, confident_joint=confident_joint)
 
     if verbose:
         longest_line = (

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,17 +1,19 @@
-import requests
-import pytest
+import io
+
 import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
-import io
 import numpy as np
+import pytest
+import requests
 from hypothesis import given, settings
+
+from cleanlab.count import compute_confident_joint, estimate_joint, num_label_issues
 from cleanlab.dataset import (
-    health_summary,
     find_overlapping_classes,
-    rank_classes_by_label_quality,
+    health_summary,
     overall_label_health_score,
+    rank_classes_by_label_quality,
 )
-from cleanlab.count import estimate_joint, num_label_issues, compute_confident_joint
 
 cifar100 = [
     "apple",
@@ -562,3 +564,23 @@ def test_find_overlapping_classes_with_confident_joint(confident_joint):
     # Joint probabilities sorted in descending order
     if K > 2:
         assert (overlapping_classes["Joint Probability"].diff()[1:] <= 0).all()
+
+
+def test_rank_classes_by_label_quality_with_confident_joint():
+    """Regression test for issue #1329: rank_classes_by_label_quality should work with standalone confident_joint."""
+    confident_joint = np.array([[80, 5], [10, 105]])
+    df = rank_classes_by_label_quality(confident_joint=confident_joint)
+    assert df is not None
+    assert len(df) == 2
+    assert "Label Quality Score" in df.columns
+    assert "Label Issues" in df.columns
+
+
+def test_health_summary_with_confident_joint():
+    """Regression test for issue #1329: health_summary should work with standalone confident_joint."""
+    confident_joint = np.array([[80, 5], [10, 105]])
+    summary = health_summary(confident_joint=confident_joint, verbose=False)
+    assert summary is not None
+    assert "overall_label_health_score" in summary
+    assert "joint" in summary
+    assert "classes_by_label_quality" in summary


### PR DESCRIPTION
## Description
Fixes #1329

When calling `rank_classes_by_label_quality(confident_joint=cj)` or `health_summary(confident_joint=cj)` without passing `labels`, `_get_num_examples` was previously called with only `labels=labels` (leaving `confident_joint=None`). Because `labels` was `None`, `_get_num_examples` raised a `ValueError` even though a valid `confident_joint` was provided.

### Changes:
1. Updated `rank_classes_by_label_quality` and `health_summary` in `cleanlab/dataset.py` to forward `confident_joint=confident_joint` to `_get_num_examples` (matching the pattern in `find_overlapping_classes` and `overall_label_health_score`).
2. Added regression unit tests in `tests/test_dataset.py` to verify that `rank_classes_by_label_quality` and `health_summary` execute successfully with standalone `confident_joint`.

## Testing
- Ran regression tests in `tests/test_dataset.py` (passed).
- Formatted with `black` and `isort`.
